### PR TITLE
Fix "Join the Community" link from Homepage.

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -43,7 +43,7 @@
     <div class="icon"></div>
     <h2><%= t('.icons.community.title') %></h2>
     <p><%= t('.icons.community.text') %></p>
-    <a href="https://groups.google.com/forum/?fromgroups#!forum/gfw2" class="btn green darker_glow community" target="_blank"><span><%= t('.icons.community.link') %></span></a>
+    <a href="https://groups.google.com/d/forum/globalforestwatch" class="btn green darker_glow community" target="_blank"><span><%= t('.icons.community.link') %></span></a>
     </li>
 
     <li class="analysis_tool">


### PR DESCRIPTION
Addresses "[BUG] Fix google group broken link" in Basecamp by updating link to:
https://groups.google.com/forum/#!forum/globalforestwatch
