### PR TITLE
Quick change to the "Join Community" text on homepage.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,7 +47,7 @@ en:
       icons:
         community:
           title: 'Join the community'
-          text: "Subscribe to the Global Forest Watch discussion group to stay up to date with the latest news on forest clearing."
+          text: "Subscribe to the Global Forest Watch discussion group."
           link: 'Join the Group'
         analysis:
           title: 'Analysis & alerts'


### PR DESCRIPTION
Changed:
"Subscribe to the Global Forest Watch discussion group to stay up to date with the latest news on forest clearing."

To:
"Subscribe to the Global Forest Watch discussion group."
