### PR TITLE
remove "global" from name of protected areas

### DIFF
--- a/app/views/common/_sources.html.erb
+++ b/app/views/common/_sources.html.erb
@@ -494,7 +494,7 @@
       <ul class="sources">
         <li id="conservation" data-slug="conservation" class="first">
           <div class="source_header">
-            <strong>Global Protected Areas</strong>
+            <strong>Protected Areas</strong>
             <i class="expand_arrow"></i>
           </div>
 


### PR DESCRIPTION
Changed "Global Protected Areas" to "Protected Areas" since that's what it's called on the map
