### PR TITLE
change download buttons for conservation layers

### DIFF
--- a/app/views/common/_sources.html.erb
+++ b/app/views/common/_sources.html.erb
@@ -500,7 +500,7 @@
 
           <div class="source_body">
             <div class="source_download">
-              <a href="http://www.protectedplanet.net" target="_blank" title="Download at project website">Download<i class="arrow_down"></i></a>
+              <a href="http://www.protectedplanet.net" target="_blank" title="Download at project website">Download at project website<i class="arrow_down"></i></a>
             </div>
 
             <div class="source_table">
@@ -571,10 +571,10 @@
             <strong>Biodiversity hotspots</strong>
             <i class="expand_arrow"></i>
           </div>
-
-          <div class="source_body">
+            
+            <div class="source_body">
             <div class="source_download">
-              <a href="#" class="disabled">Download<i class="arrow_down"></i></a>
+              <a href="http://www.conservation.org/where/priority_areas/hotspots/Pages/hotspots_main.aspx" target="_blank" title="Download at project website">Download at project website<i class="arrow_down"></i></a>
             </div>
             
             <div class="source_table">


### PR DESCRIPTION
Users download data from project websites, so download buttons should say "download from project website."  Will green buttons automatically expand to fit text?
