### PR TITLE
"join the discussion" should open in new tab

### DIFF
--- a/app/views/static/sources.html.erb
+++ b/app/views/static/sources.html.erb
@@ -15,7 +15,7 @@
       </li>
 
       <li>
-        <a href="https://groups.google.com/forum/#!forum/globalforestwatch">Join the discussion<i></i></a>
+        <a href="https://groups.google.com/forum/#!forum/globalforestwatch" target="_blank">Join the discussion<i></i></a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Changed "Join the discussion" link so it opens in a new tab
