### PR TITLE
broken link, typos

### DIFF
--- a/app/views/common/_sources.html.erb
+++ b/app/views/common/_sources.html.erb
@@ -206,7 +206,7 @@
           </div>
 
           <div class="source_coverage_header">
-            <strong>Geographic coverage of forma alerts</strong>
+            <strong>Geographic coverage of FORMA alerts</strong>
           </div>
 
           <div class="source_coverage">
@@ -268,7 +268,7 @@
               </dl>
               <dl class="sources_row even">
                 <dt>Source data</dt>
-                <dd><a href="http://modis.gsfc.nasa.gov/about/">MODIS</a>, validated with <a href="http://landsat.usgs.gov/" target="_blank">Landsat</a> and <a href="http://www.cbers.inpe.br/ingles/" target="_blank">CBERS</a></dd>
+                <dd><a href="http://modis.gsfc.nasa.gov/about/" target="_blank">MODIS</a>, validated with <a href="http://landsat.usgs.gov/" target="_blank">Landsat</a> and <a href="http://www.cbers.inpe.br/ingles/" target="_blank">CBERS</a></dd>
               </dl>
               <dl class="sources_row">
                 <dt>Frequency of updates</dt>
@@ -327,7 +327,7 @@
               </dl>
               <dl class="sources_row">
                 <dt>Geographical coverage</dt>
-                <dd>Global, except for areas <37 degrees north</dd>
+                <dd>Global, except for areas >37 degrees north</dd>
               </dl>
               <dl class="sources_row even">
                 <dt>Source data</dt>
@@ -367,7 +367,7 @@
           </div>
 
           <div class="source_coverage">
-            <p>The geographic coverage of QUICC alerts is global, except for areas <37 degrees north.</p>
+            <p>The geographic coverage of QUICC alerts is global, except for areas >37 degrees north.</p>
           </div>
         </li>
 


### PR DESCRIPTION
Fixed link so opens in new tab, capitalized FORMA, fixed typo (QUICC excludes areas >37 degrees north, not <37 degrees north), etc.
