### PR TITLE
fixed forest use citations

### DIFF
--- a/app/views/common/_sources.html.erb
+++ b/app/views/common/_sources.html.erb
@@ -643,7 +643,7 @@
 
               <p>If you are aware of concession data for additional countries, please e-mail us <a href="mailto:gfw@wri.org">here</a>.</p>
 
-              <p class="credits"><strong>Suggested citation for data as displayed on GFW:</strong><br />Saatchi, S.S., N.L. Harris, S. Brown, M. Lefsky, E. Mitchard, W. Salas, B. Zutta, W. Buermann, S. Lewis, S. Hagen, S. Petrova, L. White, M. Silman and A. Morel. 2011. “Benchmark map of forest carbon stocks in tropical regions across three continents.” Proceedings of the National Academy of Sciences vol 108, no. 24, pp 9899-9904. DOI: 10.1073/pnas.1019576108.<br />See the <%= link_to "Data page", sources_path %> for details on specific data sets.</p>
+              <p class="credits"><strong>Suggested citation for data as displayed on GFW:</strong><br />“Logging.” World Resources Institute. Accessed through Global Forest Watch on [date]. <a href="http://www.globalforestwatch.org/" target="_blank">www.globalforestwatch.org</a>.</p>
 
               <p class="read_more hidden"><em><%= link_to "Learn more or download data", sources_path %></em></p>
             </div>
@@ -759,7 +759,7 @@
 
               <p>If you are aware of concession data for additional countries, please e-mail us <a href="mailto:gfw@wri.org">here</a>.</p>
 
-              <p class="credits"><strong>Suggested citation for data as displayed on GFW:</strong><br />“Mining.” World Resources Institute. Accessed through Global Forest Watch on [date]. Please refer to the <%= link_to "Data page", sources_path %> for information on how to cite individual country concession data sets.</p>
+              <p class="credits"><strong>Suggested citation for data as displayed on GFW:</strong><br />“Mining.” World Resources Institute. Accessed through Global Forest Watch on [date]. <a href="http://www.globalforestwatch.org/" target="_blank">www.globalforestwatch.org</a>.</p>
 
               <p class="read_more hidden"><em><%= link_to "Learn more or download data", sources_path %></em></p>
             </div>
@@ -845,7 +845,7 @@
 
               <p>If you are aware of concession data for additional countries, please e-mail us <a href="mailto:gfw@wri.org">here</a>.</p>
 
-              <p class="credits"><strong>Suggested citation for data as displayed on GFW:</strong><br />“Oil Palm.” World Resources Institute. Accessed through Global Forest Watch on [date]. Please refer to the <%= link_to "Data page", sources_path %> for information on how to cite individual country concession data sets.</p>
+              <p class="credits"><strong>Suggested citation for data as displayed on GFW:</strong><br />“Oil Palm.” World Resources Institute. Accessed through Global Forest Watch on [date]. <a href="http://www.globalforestwatch.org/" target="_blank">www.globalforestwatch.org</a>.</p>
 
               <p class="read_more hidden"><em><%= link_to "Learn more or download data", sources_path %></em></p>
             </div>
@@ -931,7 +931,7 @@
 
               <p>If you are aware of concession data for additional countries, please e-mail us <a href="mailto:gfw@wri.org">here</a>.</p>
 
-              <p class="credits"><strong>Suggested citation for data as displayed on GFW:</strong><br />“Wood Fiber.” World Resources Institute. Accessed through Global Forest Watch on [date]. Please refer to the <%= link_to "Data page", sources_path %> for information on how to cite individual country concession data sets.</p>
+              <p class="credits"><strong>Suggested citation for data as displayed on GFW:</strong><br />“Wood Fiber.” World Resources Institute. Accessed through Global Forest Watch on [date]. <a href="http://www.globalforestwatch.org/" target="_blank">www.globalforestwatch.org</a>.</p>
 
               <p class="read_more hidden"><em><%= link_to "Learn more or download data", sources_path %></em></p>
             </div>


### PR DESCRIPTION
Removed extra line from citations and added www.globalforestwatch.org
