### PR TITLE
Embedding new GFW animated video

### DIFF
--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -6,7 +6,7 @@
       <p>GFW is supported by a diverse partnership of organizations that contribute data, technical capabilities, funding, and expertise. The partnership is convened by the World Resources Institute. See a full list of partners below.</p>
       <p class="header_block-description">Watch our video here:</p>
 
-      <iframe width="860" height="484" src="//www.youtube.com/embed/5HH1qaBAQRA" frameborder="0" allowfullscreen></iframe>
+      <iframe width="860" height="484" src="//player.vimeo.com/video/84808953" frameborder="0" allowfullscreen></iframe>
     </div>
   </div>
 </div>


### PR DESCRIPTION
We will be eventually putting this on YouTube (we are keeping this video private before the launch), but in the meantime- here's a unlisted version from Vimeo.

Here's the full embed code, in case I didn't do it right:

<iframe src="//player.vimeo.com/video/84808953" width="860" height="483" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe> <p><a href="http://vimeo.com/84808953">Global Forest Watch</a> from <a href="http://vimeo.com/worldresources">World Resources Institute</a> on <a href="https://vimeo.com">Vimeo</a>.</p>

And link:

https://vimeo.com/84808953 (password is GFW)
