### PR TITLE
Removed Indonesia from mining

### DIFF
--- a/app/views/shared/_sources.html.erb
+++ b/app/views/shared/_sources.html.erb
@@ -762,7 +762,7 @@
           </dl>
           <dl class='sources_row'>
             <dt>Geographical coverage</dt>
-            <dd>Currently available for Cameroon, Democratic Republic of the Congo (DRC), Gabon, Republic of the Congo, and Indonesia</dd>
+            <dd>Currently available for Cameroon, Democratic Republic of the Congo (DRC), Gabon, and Republic of the Congo</dd>
           </dl>
           <dl class='sources_row even'>
             <dt>Source data</dt>


### PR DESCRIPTION
Indonesia was never included as part of the mining layer
