### PR TITLE
changed name of discussion forum

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,7 +69,7 @@ en:
       actions:
         community:
           title: Join the community
-          text: Subscribe to the “Global Forest Watchers” discussion group to learn more about data and interact with fellow users and researchers.
+          text: Subscribe to the Global Forest Watch discussion forum to learn more about data and interact with fellow users and researchers.
           link: Join the group
         analysis:
           title: 'Analysis & alerts'


### PR DESCRIPTION
Changed to "Global Forest Watch discussion forum" per Susan's request
