### PR TITLE
changed splash screen language

### DIFF
--- a/app/views/static/accept_terms.html.erb
+++ b/app/views/static/accept_terms.html.erb
@@ -15,7 +15,7 @@
 
 <p>Global Forest Watch (GFW) is a dynamic online forest monitoring and alert system that empowers people everywhere to better manage forests.</p>
 
-<p><strong>We recommend visiting GFW using the latest version of Google Chrome, Mozilla Firefox, or Apple Safari. Internet Explorer may cause errors when viewing the site.</strong></p>
+<p><strong>We recommend visiting GFW using the latest version of <a href='https://www.google.com/intl/en/chrome/browser/#brand=CHMB&utm_campaign=…' target='_blank'>Google Chrome</a>, <a href='http://www.mozilla.org/en-US/firefox/new/' target='_blank'>Mozilla Firefox</a>, <a href='http://support.apple.com/downloads/#safari' target='_blank'>Apple Safari</a>, or <a href='http://windows.microsoft.com/en-us/internet-explorer/download-ie' target='_blank'>Internet Explorer</a>.  We also recommend installing <a href='http://get.adobe.com/flashplayer' target='_blank'>Adobe Flash Player</a>.</strong></p>
 
 <div contenteditable='false' class='terms_field'>
   <%= render 'shared/terms' %>


### PR DESCRIPTION
We recommend visiting GFW using the latest version of Google Chrome [link to https://www.google.com/intl/en/chrome/browser/#brand=CHMB&utm_campaign=…], Mozilla Firefox [link to http://www.mozilla.org/en-US/firefox/new/], Apple Safari [link to http://support.apple.com/downloads/#safari], or Internet Explorer [link to http://windows.microsoft.com/en-us/internet-explorer/download-ie].  We also recommend installing Adobe Flash Player [link to http://get.adobe.com/flashplayer].
