### PR TITLE
Ignore unenabled countries for gain/loss graph - avoid NaNs e.g. for Sint Maarten

### DIFF
--- a/app/assets/javascripts/countries.js
+++ b/app/assets/javascripts/countries.js
@@ -1068,7 +1068,7 @@ gfw.ui.view.CountriesOverview = cdb.core.View.extend({
                                                          FROM loss\
                                                          WHERE loss.iso = gain.iso) as sum_loss ';
       sql += 'FROM gain, gfw2_countries c\
-              WHERE gain.iso = c.iso\
+              WHERE gain.iso = c.iso AND c.enabled is true\
               ORDER BY sum_loss DESC ';
 
       if(e) {


### PR DESCRIPTION
![2014-02-18_16-57-37](https://f.cloud.github.com/assets/428784/2200851/b83a1c5e-98e7-11e3-8f7b-6e7300768968.png)
