### PR TITLE
map: smooth handler moves on UMD

### DIFF
--- a/lib/assets/javascripts/gfw/ui/timeline/timeline_loss.js
+++ b/lib/assets/javascripts/gfw/ui/timeline/timeline_loss.js
@@ -288,8 +288,6 @@ gfw.ui.view.TimelineLoss = gfw.ui.view.Widget.extend({
     this._updateRangeYears(x, (this.current_drag_side === 'left'));
     this._updateDate(x);
 
-    this.updateMap();
-
     if ( this.current_drag_side === 'left' && current_handle_pos + this.grid_x > this.$right_handle.position().left) {
       this.fixPosition = 'left';
       return;
@@ -340,7 +338,6 @@ gfw.ui.view.TimelineLoss = gfw.ui.view.Widget.extend({
     });
 
     this._adjustHandlePosition();
-
     setTimeout(function() { that.$current_drag.find('.tipsy').fadeOut(150); }, 2000);
   },
 


### PR DESCRIPTION
_onStopDragging calls to the updateMap method already so it's not necessary to call it while dragging
