### PR TITLE
Fix failing tests and add test for formatUrl

### DIFF
--- a/app/assets/javascripts/map/services/PlaceService.js
+++ b/app/assets/javascripts/map/services/PlaceService.js
@@ -55,7 +55,7 @@ define([
 
   var PlaceService = Class.extend({
 
-    _uriTemplate: 'map{/zoom}{/lat}{/lng}{/iso}{/maptype}{/baselayers}{/sublayers}{?begin,end}',
+    _uriTemplate: '{name}{/zoom}{/lat}{/lng}{/iso}{/maptype}{/baselayers}{/sublayers}{?begin,end}',
 
     /**
      * Create new PlaceService with supplied MapLayerService and
@@ -117,26 +117,38 @@ define([
           }, this));
       }
 
-      route = this._getRoute(newPlace.params);
+      route = this._getRoute(name, newPlace.params);
       this.router.navigate(route, {silent: true});
     },
 
     /**
-     * Return formated url representation of supplied params object
-     * to keep a precise lat/lng in the application but not in url.
+     * Return formated URL representation of supplied params object based on 
+     * a route name.
      *
-     * @param  {Object} params The params to standardize
-     * @return {Object} The standardized params.
+     * @param {string} name The route name
+     * @param  {Object} params Params to standardize
+     * @return {Object} Params ready for URL
      */
-    _formatUrl: function(params) {
-      return _.extend({}, params, {
-        lat: params.lat.toFixed(2),
-        lng: params.lng.toFixed(2)
-      });
+    _formatUrl: function(name, params) {
+      if (name === 'map') {
+        return _.extend({}, params, {
+          lat: String(_.toNumber(params.lat).toFixed(2)),
+          lng: String(_.toNumber(params.lng).toFixed(2))
+        });
+      } else {
+        return params;
+      }
     },
 
-    _getRoute: function(params) {
-      params = this._formatUrl(params);
+    /**
+     * Return route URL for supplied route name and route params.
+     * 
+     * @param  {string} name The route name (e.g. map)
+     * @param  {Object} params The route params
+     * @return {string} The route URL
+     */
+    _getRoute: function(name, params) {
+      params = _.extend(this._formatUrl(name, params), {name: name});
       return new UriTemplate(this._uriTemplate).fillFromObject(params);
     },
 

--- a/app/assets/javascripts/map/views/layersNavView.js
+++ b/app/assets/javascripts/map/views/layersNavView.js
@@ -6,7 +6,7 @@
 define([
   'backbone',
   'underscore',
-  'text!map/templates/layersNav.html'
+  'text!templates/layersNav.html'
 ], function(Backbone, _, layersNavTpl) {
 
   'use strict';

--- a/jstest/spec-runner.js
+++ b/jstest/spec-runner.js
@@ -101,7 +101,8 @@ require([
   'spec/MapLayerService_spec',
   'spec/MapPresenter_spec',
   'spec/UMDLossLayerPresenter_spec',
-  'spec/PlaceService_spec'
+  'spec/PlaceService_spec',
+  'spec/utils_spec'
 ], function (mock_ajax, main, nsa_spec){
   console.log('Setting up specs...');
 });

--- a/jstest/spec/PlaceService_spec.js
+++ b/jstest/spec/PlaceService_spec.js
@@ -75,8 +75,8 @@ define([
       });
 
       it('correctly returns route', function() {        
-        var r = 'map/8/1.1/2/idn/terrain/loss/1%2C2%2C3?begin=2014&end=3014';
-        expect(service._getRoute(params)).toEqual(r);
+        var r = 'map/8/1.10/2.00/idn/terrain/loss/1%2C2%2C3?begin=2014&end=3014';
+        expect(service._getRoute('map', params)).toEqual(r);
       });
     });
 
@@ -123,36 +123,43 @@ define([
       });
 
       it('correctly calls router.navigate when go is false', function() {
-        var r = 'map/8/1.1/2/idn/terrain/loss/1%2C2%2C3?begin=2014&end=3014';
+        var r = 'map/8/1.10/2.00/idn/terrain/loss/1%2C2%2C3?begin=2014&end=3014';
 
         service._handleNewPlace('map', params, false);
         expect(mockRouter.navigate).toHaveBeenCalledWith(r, {silent: true});
       });
     });
 
-    /**
-     * Spec for testing _toNumber().
+
+     /**
+     * Spec for testing _formatUrl().
      */
-    describe('_toNumber()', function() {
+    describe('_formatUrl()', function() {
 
       beforeEach(function() {
         service = new PlaceService({}, {});
       });
 
-      it('correctly returns numbers for numbers', function() {        
-        expect(service._toNumber('1')).toEqual(1);
-        expect(service._toNumber(1)).toEqual(1);
-        expect(service._toNumber('1.1')).toEqual(1.1);
+      it('correctly handles lat/lng strings', function() {        
+        expect(service._formatUrl('map', {lat: '1.234567', lng: '2.34567'})).
+          toEqual({lat: '1.23', lng: '2.35'});
       });
+      
+      it('correctly handles lat/lng decimals', function() {        
+        expect(service._formatUrl('map', {lat: 1.23456789, lng: 2.3456789})).
+          toEqual({lat: '1.23', lng: '2.35'});
+      });      
 
-      it('correctly returns undefined for non-numbers', function() {        
-        expect(service._toNumber('a')).toEqual(undefined);
-        expect(service._toNumber('')).toEqual(undefined);
-        expect(service._toNumber(undefined)).toEqual(undefined);
-        expect(service._toNumber(null)).toEqual(undefined);
-      });
+      it('correctly handles lat/lng integers', function() {        
+        expect(service._formatUrl('map', {lat: 1, lng: 2})).
+          toEqual({lat: '1.00', lng: '2.00'});
+      });      
+
+      it('correctly handles lat/lng with non-map route name', function() {
+        expect(service._formatUrl('foo', {lat: 1, lng: 2})).
+          toEqual({lat: 1, lng: 2});
+      });      
     });
-
 
    /**
      * Spec for testing _getBaselayerFilters().

--- a/jstest/spec/UMDLossLayerPresenter_spec.js
+++ b/jstest/spec/UMDLossLayerPresenter_spec.js
@@ -31,7 +31,7 @@ define([
     });    
 
     it("Check Timeline/change event handling", function() {
-      mps.publish('Timeline/change', ['loss', [2001, 2002]]);        
+      mps.publish('Timeline/date-change', ['loss', [2001, 2002]]);        
       
       expect(viewSpy.setTimelineDate).toHaveBeenCalled();
       expect(viewSpy.setTimelineDate).toHaveBeenCalledWith([2001, 2002]);        

--- a/jstest/spec/utils_spec.js
+++ b/jstest/spec/utils_spec.js
@@ -1,0 +1,33 @@
+/**
+ * Unit test coverage for the utils module.
+ */
+define([
+  'utils',
+  'underscore'
+], function(utils, _) {
+
+  'use strict';
+
+  describe('utils module suite', function() {
+
+
+    /**
+     * Spec for testing _toNumber().
+     */
+    describe('_toNumber()', function() {
+
+      it('correctly returns numbers for numbers', function() {        
+        expect(_.toNumber('1')).toEqual(1);
+        expect(_.toNumber(1)).toEqual(1);
+        expect(_.toNumber('1.1')).toEqual(1.1);
+      });
+
+      it('correctly returns undefined for non-numbers', function() {        
+        expect(_.toNumber('a')).toEqual(undefined);
+        expect(_.toNumber('')).toEqual(undefined);
+        expect(_.toNumber(undefined)).toEqual(undefined);
+        expect(_.toNumber(null)).toEqual(undefined);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Yo dudes, hh, a bunch of tests were failing, fixed here! :D 

So before sending a PR, super easy, we just have to:

``` bash
$ cd jstests
$ testem
```

That'll run all tests in jstests/spec via terminal and browser and let you know if anything is broken BOOM haha. @pdgago is there another way to run these tests with your new grunt stuff?

What do you guys think? Also maybe if we send PRs instead of direct commits then we'll all get notified when new code is inbound... It just makes it easier to review and spot stuff before/after it gets merged in. Just thoughts!

Other stuff in this PR:
- fixed injection of layersNav.html in layersNavView
- added tests for PlaceService._formatUrl, added route name param
- added utils_spec with test for _.toNumber
