### PR TITLE
Add FORMA concession+wdpa support to AnalysisService

### DIFF
--- a/app/assets/javascripts/map/nsa.js
+++ b/app/assets/javascripts/map/nsa.js
@@ -3,17 +3,24 @@
  *
  */
 define([
-  'jquery',
+  'Class',
   'mps',
   'store'
-], function ($, mps, store) {
+], function (Class, mps, store) {
 
   'use strict';
 
-  return {
+  var NSA = Class.extend({
 
     // Added for Jasmine testing to bypass cache and use 'json' dataType
     test: false,
+
+    init: function() {
+      mps.subscribe('LocalStorage/clear', function() {
+        store.clear();
+        console.log('LocalStorage cleared');
+      });
+    },
 
     /**
      * Async HTTP request to supplied URL and optional data.
@@ -29,11 +36,14 @@ define([
       var val = null;
       var dataType = url.contains('cartodb.com') ? 'jsonp' : 'json';
 
+      cache = cache === undefined ? true : cache;
+
       if (!this.test && cache && store.enabled) {
         // TODO: Key should be made from url+data
         val = store.get(url);
         if (val) {
           successCb(val);
+          return;
         }
       }
 
@@ -59,5 +69,9 @@ define([
       });
       return jqxhr;
     }
-  };
+  });
+
+  var nsa = new NSA();
+
+  return nsa;
 });

--- a/jstest/spec/AnalysisService_spec.js
+++ b/jstest/spec/AnalysisService_spec.js
@@ -104,15 +104,23 @@ define([
       });
 
       it('correctly returns URI template for national API', function() {
-        var config = {iso: 'bra', thresh: 10};
-        var uriTemplate = 'http://{host}/forest-change/{dataset}/admin{/iso}{?period,download,bust,dev,thresh}';
+        var config = {iso: 'bra', thresh: 10, dataset: 'umd-loss-gain'};
+        var uriTemplate = 'http://beta.gfw-apis.appspot.com/forest-change/umd-loss-gain/admin/{iso}{?bust,dev,thresh}';
 
         expect(service._getUriTemplate(config)).toEqual(uriTemplate);
       });
 
       it('correctly returns URI template for subnational API', function() {
-        var config = {iso: 'bra', id1: 1, thresh: 10};
-        var uriTemplate = 'http://{host}/forest-change/{dataset}/admin{/iso}{/id1}{?period,download,bust,dev,thresh}';
+        var config = {iso: 'bra', id1: 1, thresh: 10,
+          dataset: 'umd-loss-gain'};
+        var uriTemplate = 'http://beta.gfw-apis.appspot.com/forest-change/umd-loss-gain/admin/{iso}/{id1}{?bust,dev,thresh}';
+
+        expect(service._getUriTemplate(config)).toEqual(uriTemplate);
+      });   
+
+      it('correctly returns null template for invalid config', function() {
+        var config = {};
+        var uriTemplate = null;
 
         expect(service._getUriTemplate(config)).toEqual(uriTemplate);
       });      
@@ -140,7 +148,46 @@ define([
         var url = 'http://beta.gfw-apis.appspot.com/forest-change/umd-loss-gain/admin/bra/1?thresh=10';
 
         expect(service._getUrl(config)).toEqual(url);
-      });           
+      });       
+
+      it('correctly returns URL for FORMA national API', function() {
+        var config = {
+          dataset: 'forma-alerts', iso: 'bra'};
+        var url = 'http://beta.gfw-apis.appspot.com/forest-change/forma-alerts/admin/bra';
+
+        expect(service._getUrl(config)).toEqual(url);
+      });        
+  
+      it('correctly returns URL for FORMA subnational API', function() {
+        var config = {
+          dataset: 'forma-alerts', iso: 'bra', id1: 1};
+        var url = 'http://beta.gfw-apis.appspot.com/forest-change/forma-alerts/admin/bra/1';
+
+        expect(service._getUrl(config)).toEqual(url);
+      });     
+
+      it('correctly returns URL for FORMA wdpa API', function() {
+        var config = {
+          dataset: 'forma-alerts', wdpaid: 1,};
+        var url = 'http://beta.gfw-apis.appspot.com/forest-change/forma-alerts/wdpa/1';
+
+        expect(service._getUrl(config)).toEqual(url);
+      });            
+
+      it('correctly returns URL for FORMA use API', function() {
+        var config = {
+          dataset: 'forma-alerts', use: 'logging', useid: 1,};
+        var url = 'http://beta.gfw-apis.appspot.com/forest-change/forma-alerts/use/logging/1';
+
+        expect(service._getUrl(config)).toEqual(url);
+      });            
+
+      it('correctly returns null URL for invalid config', function() {
+        var config = {};
+        var uriTemplate = null;
+
+        expect(service._getUrl(config)).toEqual(uriTemplate);
+      });        
     });    
 
 


### PR DESCRIPTION
If we inject AnalysisService as `service` we now have concessions and WDPA support for FORMA. Boom!

``` javascript
// WDPA example
var config = {dataset: 'forma-alerts', wdpaid: 180};
var callback = function(data) {console.log(data)};
service.execute(config, callback);

// Concession example (supported: logging, mining, oilpalm, fiber)
var config = {dataset: 'forma-alerts', use: 'logging', useid: 1};
var callback = function(data) {console.log(data)};
service.execute(config, callback);
```

This PR also wires up local storage by default. So all analysis results are now cached. You can clear the cache at the console by publishing the `LocalStorage/clear` event:

``` javascript
mps.publish('LocalStorage/clear');
```
