### PR TITLE
change test task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 .grunt
 node_modules
 vendor/assets/bower_components
+jstest/SpecRunner.html
 
 # Ingore Sublime project files:
 *.sublime-*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,8 +15,11 @@ module.exports = function(grunt) {
     },
 
     connect: {
-      test : {
-        port : 8000
+      server: {
+        options: {
+          livereload: true,
+          port : 8000
+        }
       }
     },
 
@@ -37,6 +40,8 @@ module.exports = function(grunt) {
           specs: '<%= root.test %>/spec/*_spec.js',
           host: 'http://127.0.0.1:8000/',
           helpers: '<%= root.test %>/helpers/*.js',
+          outfile: '<%= root.test %>/SpecRunner.html',
+          keepRunner: true,
           template: require('grunt-template-jasmine-requirejs'),
           templateOptions: {
             requireConfigFile: '<%= root.test %>/config.js'
@@ -50,24 +55,27 @@ module.exports = function(grunt) {
 
     watch: {
       options: {
-        nospawn: true
+        spawn: false
       },
       scripts: {
         files: '<%= jshint.all %>',
-        tasks: ['jshint', 'test']
+        tasks: ['jshint', 'jasmine']
       }
     }
 
   });
 
   grunt.registerTask('test', [
-    'connect:test',
-    'jasmine'
+    'connect:server',
+    'jasmine',
+    'watch:scripts'
   ]);
 
   grunt.registerTask('default', [
+    'connect:server',
     'jshint',
-    'test'
+    'jasmine',
+    'watch'
   ]);
 
 };


### PR DESCRIPTION
I have change the command `grunt test`, now it create a server on http://localhost:8000, validate by jshint, run jasmine and watch scripts changes. Furthermore it create a output test file in jstest folder called SpecRunner.html. 

So if you open in browser http://localhost:8000/jstest/SpecRunner.html you can see the jasmine browser version while command is running. Probably now don`t works because test fail and grunt task is interrupted, for avoid this you can use the command`grunt test --force`.
