### PR TITLE
Add global query support via geojson param for forma, quicc, fires

### DIFF
--- a/app/assets/javascripts/map/services/AnalysisService.js
+++ b/app/assets/javascripts/map/services/AnalysisService.js
@@ -23,6 +23,7 @@ define([
     apis: {
       'forma-alerts': {
         'apis': {
+          'world': 'http://beta.gfw-apis.appspot.com/forest-change/forma-alerts{?geojson,period,bust,dev}',
           'national': 'http://beta.gfw-apis.appspot.com/forest-change/forma-alerts/admin/{iso}{?period,bust,dev}',
           'subnational': 'http://beta.gfw-apis.appspot.com/forest-change/forma-alerts/admin/{iso}/{id1}{?period,bust,dev}',
           'use': 'http://beta.gfw-apis.appspot.com/forest-change/forma-alerts/use/{use}/{useid}{?period,bust,dev}',
@@ -31,6 +32,7 @@ define([
       },
       'nasa-active-fires': {
         'apis': {
+          'world': 'http://beta.gfw-apis.appspot.com/forest-change/nasa-active-fires{?geojson,period,bust,dev}',          
           'national': 'http://beta.gfw-apis.appspot.com/forest-change/nasa-active-fires/admin/{iso}{?period,bust,dev}',
           'subnational': 'http://beta.gfw-apis.appspot.com/forest-change/nasa-active-fires/admin/{iso}/{id1}{?period,bust,dev}',
           'use': 'http://beta.gfw-apis.appspot.com/forest-change/nasa-active-fires/use/{use}/{useid}{?period,bust,dev}',
@@ -39,6 +41,7 @@ define([
       },
       'quicc-alerts': {
         'apis': {
+          'world': 'http://beta.gfw-apis.appspot.com/forest-change/quicc-alerts{?geojson,period,bust,dev}',
           'national': 'http://beta.gfw-apis.appspot.com/forest-change/quicc-alerts/admin/{iso}{?period,bust,dev}',
           'subnational': 'http://beta.gfw-apis.appspot.com/forest-change/quicc-alerts/admin/{iso}/{id1}{?period,bust,dev}',
           'use': 'http://beta.gfw-apis.appspot.com/forest-change/quicc-alerts/use/{use}/{useid}{?period,bust,dev}',
@@ -78,7 +81,9 @@ define([
         return this.apis[dataset].apis.use;
       } else if (_.has(config, 'wdpaid')) {
         return this.apis[dataset].apis.wdpa;
-      } 
+      } else if (_.has(config, 'geojson')) {
+        return this.apis[dataset].apis.world;
+      }
 
       return null;
     },

--- a/jstest/spec/AnalysisService_spec.js
+++ b/jstest/spec/AnalysisService_spec.js
@@ -109,6 +109,11 @@ define([
         var config = null;
         var uriTemplate = null;
 
+        // World
+        config = {geojson: 'foo', dataset: 'quicc-alerts'};
+        uriTemplate = 'http://beta.gfw-apis.appspot.com/forest-change/quicc-alerts{?geojson,period,bust,dev}';
+        expect(service._getUriTemplate(config)).toEqual(uriTemplate);
+
         // National
         config = {iso: 'bra', dataset: 'quicc-alerts'};
         uriTemplate = 'http://beta.gfw-apis.appspot.com/forest-change/quicc-alerts/admin/{iso}{?period,bust,dev}';
@@ -135,6 +140,11 @@ define([
       it('correctly returns URI template for nasa-active-fires', function() {
         var config = null;
         var uriTemplate = null;
+        
+        // World
+        config = {geojson: 'foo', dataset: 'nasa-active-fires'};
+        uriTemplate = 'http://beta.gfw-apis.appspot.com/forest-change/nasa-active-fires{?geojson,period,bust,dev}';
+        expect(service._getUriTemplate(config)).toEqual(uriTemplate);
 
         // National
         config = {iso: 'bra', dataset: 'nasa-active-fires'};
@@ -161,6 +171,11 @@ define([
       it('correctly returns URI template for forma-alerts', function() {
         var config = null;
         var uriTemplate = null;
+
+        // World
+        config = {geojson: 'foo', dataset: 'forma-alerts'};
+        uriTemplate = 'http://beta.gfw-apis.appspot.com/forest-change/forma-alerts{?geojson,period,bust,dev}';
+        expect(service._getUriTemplate(config)).toEqual(uriTemplate);
 
         // National
         config = {iso: 'bra', dataset: 'forma-alerts'};
@@ -240,6 +255,11 @@ define([
         var config = null;
         var url = null;
 
+        // World
+        config = {dataset: 'forma-alerts', geojson: 'foo'};
+        url = 'http://beta.gfw-apis.appspot.com/forest-change/forma-alerts?geojson=foo';
+        expect(service._getUrl(config)).toEqual(url);
+
         // National
         config = {dataset: 'forma-alerts', iso: 'bra'};
         url = 'http://beta.gfw-apis.appspot.com/forest-change/forma-alerts/admin/bra';
@@ -268,6 +288,11 @@ define([
         var config = null;
         var url = null;
 
+        // World
+        config = {dataset: 'quicc-alerts', geojson: 'foo'};
+        url = 'http://beta.gfw-apis.appspot.com/forest-change/quicc-alerts?geojson=foo';
+        expect(service._getUrl(config)).toEqual(url);
+
         // National
         config = {dataset: 'quicc-alerts', iso: 'bra'};
         url = 'http://beta.gfw-apis.appspot.com/forest-change/quicc-alerts/admin/bra';
@@ -295,6 +320,11 @@ define([
       it('correctly returns URL for nasa-active-fires', function() {
         var config = null;
         var url = null;
+
+        // World
+        config = {dataset: 'nasa-active-fires', geojson: 'foo'};
+        url = 'http://beta.gfw-apis.appspot.com/forest-change/nasa-active-fires?geojson=foo';
+        expect(service._getUrl(config)).toEqual(url);
 
         // National
         config = {dataset: 'nasa-active-fires', iso: 'bra'};


### PR DESCRIPTION
Support for forma-alerts, quicc-alerts, nasa-active-fires. Example:

``` javascript
// FORMA global query with GeoJSON
var config = {dataset: 'forma-alerts', geojson: JSON.stringify({"type":"Polygon","coordinates":[[[-62.13867187499999,-1.845383988573187],[-64.6875,-7.972197714386866],[-61.083984375,-10.487811882056695],[-52.03125,-5.703447982149503],[-56.77734375,-0.26367094433665017],[-62.13867187499999,-1.845383988573187]]]})};
var callback = function(data) {console.log(data)};
service.execute(config, callback);
// Hits: http://beta.gfw-apis.appspot.com/forest-change/forma-alerts?geojson={"type":"Polygon","coordinates":[[[-62.13867187499999,-1.845383988573187],[-64.6875,-7.972197714386866],[-61.083984375,-10.487811882056695],[-52.03125,-5.703447982149503],[-56.77734375,-0.26367094433665017],[-62.13867187499999,-1.845383988573187]]]}
```
