### PR TITLE
Solution for #653 that clears local cache based on url parameter

### DIFF
--- a/app/assets/javascripts/map/router.js
+++ b/app/assets/javascripts/map/router.js
@@ -11,6 +11,7 @@ define([
   'backbone',
   'mps',
   'gmap',
+  'amplify',
   'services/PlaceService',
   'views/LayersNavView',
   'views/MapView',
@@ -19,8 +20,7 @@ define([
   'views/MaptypeView',
   'views/TimelineView',
   'services/MapLayerService'
-], function($, _, Backbone, mps, gmap, PlaceService, LayersNavView, MapView,
-  LegendView, SearchboxView, MaptypeView, TimelineView, mapLayerService) {
+], function($, _, Backbone, mps, gmap, amplify, PlaceService, LayersNavView, MapView, LegendView, SearchboxView, MaptypeView, TimelineView, mapLayerService) {
 
   'use strict';
 
@@ -36,6 +36,7 @@ define([
           this.navigate('map/' + this.route, {silent: true});
         }
       }, this));
+      this.bind( 'all', this._checkForCacheBust());
       this.setWrapper();
       this.placeService = new PlaceService(mapLayerService, this);
       this.layersNavView = new LayersNavView();
@@ -43,6 +44,21 @@ define([
       this.maptypeView = new MaptypeView();
       this.searchboxView = new SearchboxView();
       this.timelineView = new TimelineView();
+    },
+
+    /**
+     * If the URL contains the cache parameter (e.g., cache=bust), clear all 
+     * cached values in the browser (e.g., from memory, local storage, 
+     * session).
+     */
+    _checkForCacheBust: function() {
+      var params = _.parseUrl();
+
+      if (_.has(params, 'cache')) {
+        _.each(amplify.store(), function(value, key) {
+          amplify.store(key, null);
+        });
+      }
     },
 
     map: function(zoom, lat, lng, iso, maptype, baselayers, sublayers) {

--- a/app/assets/javascripts/map/services/AnalysisService.js
+++ b/app/assets/javascripts/map/services/AnalysisService.js
@@ -73,6 +73,11 @@ define([
     },
 
     /**
+     * The configuration for client side caching of results.
+     */
+    _cacheConfig: {type: 'persist', duration: 1, unit: 'days'},
+
+    /**
      * Defines all API requests used by AnalysisService.
      */
     _defineRequests: function() {
@@ -85,9 +90,10 @@ define([
       // national)
       _.each(datasets, function(dataset) {
         _.each(this._urls(dataset), function(url, id) {
-          var cache = {duration: 1, unit: 'days'};
+          var cache = this._cacheConfig;
           var config = {
-            cache: cache, url: url, type: 'POST', dataType: 'json'};
+            cache: cache, url: url, type: 'POST',
+            dataType: 'json'};
           ds.define(id, config);
         }, this);
       }, this);

--- a/app/assets/javascripts/map/services/CountryService.js
+++ b/app/assets/javascripts/map/services/CountryService.js
@@ -23,10 +23,15 @@ define([
     },
 
     /**
+     * The configuration for client side caching of results.
+     */
+    _cacheConfig: {type: 'persist', duration: 1, unit: 'days'},
+
+    /**
      * Defines requests used by CountryService.
      */
     _defineRequests: function() {
-      var cache = {duration: 1, unit: 'days'};
+      var cache = this._cacheConfig;
       var config = {cache: cache, url: this._uriTemplate};
       ds.define(this.requestId, config);
     },

--- a/app/assets/javascripts/map/services/DataService.js
+++ b/app/assets/javascripts/map/services/DataService.js
@@ -46,10 +46,10 @@ define([
     define: function(id, config) {
       var cache = config.cache;
       var duration = cache && cache.duration ? cache.duration : 1;
-      var unit = cache && cache.unit ? cache.unit : 'weeks  ';
+      var unit = cache && cache.unit ? cache.unit : 'weeks';
       var expires = this._getDuration(duration, unit);
 
-      if (cache) {
+      if (cache) {        
         cache.expires = expires;
       }
 

--- a/app/assets/javascripts/map/services/MapLayerService.js
+++ b/app/assets/javascripts/map/services/MapLayerService.js
@@ -31,7 +31,7 @@ define([
      * Defines CartoDB requests used by MapLayerService.
      */
     _defineRequests: function() {
-      var cache = {duration: 1, unit: 'days'};
+      var cache = {type: 'persist', duration: 1, unit: 'days'};
       var url = this._getUrl();
       var config = {cache: cache, url: url, type: 'POST', dataType: 'jsonp'};
       ds.define(this.requestId, config);

--- a/jstest/spec/AnalysisService_spec.js
+++ b/jstest/spec/AnalysisService_spec.js
@@ -125,6 +125,10 @@ define([
 
       beforeEach(function(done) {
         jasmine.Ajax.install();
+        
+        // Disable caching and redefine requests
+        service._cacheConfig = null;
+        service._defineRequests();
 
         callback = {
           success: function(results) {

--- a/jstest/spec/CountryService_spec.js
+++ b/jstest/spec/CountryService_spec.js
@@ -21,6 +21,10 @@ define([
       var response = null;
       var callback = null;
 
+      // Disable caching and redefine requests
+      service._cacheConfig = null;
+      service._defineRequests();
+
       beforeEach(function(done) {
         jasmine.Ajax.install();
 


### PR DESCRIPTION
Handy little feature here. For debugging, if you want to clear the entire client side cache, just add `cache=bust` parameter to the URL and reload:

http://localhost:5000/map/3/15.00/27.00/ALL/terrain/umd-loss-gain?cache=bust

cc: @d4weed 
