### PR TITLE
Change CGIAR logo's link

### DIFF
--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -79,7 +79,7 @@
           <li><a target='_blank' href='http://www.scanex.ru/en/' class='scanex'></a></li>
           <li class="last"><a target='_blank' href='http://www.transparentworld.ru/ru' class='twrus'></a></li>
           <li><a target='_blank' href='http://www.janegoodall.org/' class='goodall'></a></li>
-          <li><a target='_blank' href='http://www.cgiar.org/our-research/cgiar-research-programs/cgiar-research-program-on-forests-trees-and-agroforestry/' class='cgiar'></a></li>
+          <li><a target='_blank' href='http://foreststreesagroforestry.org/' class='cgiar'></a></li>
           <li class='last'><a target='_blank' href='http://www.cartodb.com' class='carto'></a></li>
           <li><a target='_blank' href='http://www.vizzuality.com' class='vizz'></a></li>
           <li><a target='_blank' href='http://www.blueraster.com' class='blue'></a></li>


### PR DESCRIPTION
CGIAR logo should link to http://foreststreesagroforestry.org/
