### PR TITLE
Fix sharing snippets

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
 
-  helper_method :watch_cookie?
+  helper_method :terms_cookie
 
   protect_from_forgery with: :exception
 
@@ -31,7 +31,7 @@ class ApplicationController < ActionController::Base
     def show_terms?
       !(is_ip_whitelisted_from_terms? ||
         is_embed_request? ||
-        is_terms_cookie_set? ||
+        terms_cookie ||
         is_exempt_from_terms?)
     end
 
@@ -53,7 +53,7 @@ class ApplicationController < ActionController::Base
       request.original_url.include?('embed') ? true : false
     end
 
-    def is_terms_cookie_set?
+    def terms_cookie
       cookies.permanent[ENV['TERMS_COOKIE'].to_sym]
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,19 +17,8 @@ class ApplicationController < ActionController::Base
 
   private
 
-    Browser = Struct.new(:browser, :version)
-
-    SupportedBrowsers = [
-      Browser.new('Safari', '5.0.5'),
-      Browser.new('Firefox', '12.0'),
-      Browser.new('Internet Explorer', '10.0'),
-      Browser.new('Chrome', '19.0.1036.7'),
-      Browser.new('Opera', '11.00')
-    ]
-
     def check_browser
-      user_agent = UserAgent.parse(request.user_agent)
-      redirect_to "/notsupportedbrowser" unless SupportedBrowsers.detect { |browser| user_agent >= browser } || user_agent.bot?
+      redirect_to "/notsupportedbrowser" unless UserAgentValidator.user_agent_supported? request.user_agent
     end
 
     def check_terms

--- a/app/views/shared/_js_footer.html.erb
+++ b/app/views/shared/_js_footer.html.erb
@@ -1,6 +1,6 @@
 <script>
   // Coockie
-  window.terms_cookie = <%= watch_cookie? ? true : false %>;
+  window.terms_cookie = <%= terms_cookie ? true : false %>;
 
   //Analytics
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/lib/user_agent_validator.rb
+++ b/lib/user_agent_validator.rb
@@ -1,0 +1,43 @@
+class UserAgentValidator
+  Browser = Struct.new(:browser, :version)
+
+  SupportedBrowsers = [
+    Browser.new('Safari', '5.0.5'),
+    Browser.new('Firefox', '12.0'),
+    Browser.new('Internet Explorer', '10.0'),
+    Browser.new('Chrome', '19.0.1036.7'),
+    Browser.new('Opera', '11.00')
+  ]
+
+  SupportedSnippetCollectors = [
+    Regexp.new("facebookexternalhit"),
+    Regexp.new("https://developers.google.com/\\+/web/snippet/")
+  ]
+
+  def self.user_agent_supported? user_agent
+    instance = self.new user_agent
+    instance.user_agent_supported?
+  end
+
+  def initialize user_agent
+    @user_agent = user_agent
+  end
+
+  def user_agent_supported?
+    is_supported_browser || user_agent.bot? || is_snippet_collector
+  end
+
+  private
+
+  def is_snippet_collector
+    @user_agent.match(Regexp.union(SupportedSnippetCollectors))
+  end
+
+  def is_supported_browser
+    SupportedBrowsers.detect { |browser| user_agent >= browser }
+  end
+
+  def user_agent
+    UserAgent.parse(@user_agent)
+  end
+end

--- a/lib/user_agent_validator.rb
+++ b/lib/user_agent_validator.rb
@@ -27,11 +27,15 @@ class UserAgentValidator
     is_supported_browser || user_agent.bot? || is_snippet_collector
   end
 
-  private
-
   def is_snippet_collector
     @user_agent.match(Regexp.union(SupportedSnippetCollectors))
   end
+
+  def method_missing method
+     user_agent.send(method) rescue super(method)
+  end
+
+  private
 
   def is_supported_browser
     SupportedBrowsers.detect { |browser| user_agent >= browser }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe ApplicationController do
+  controller do
+    def index
+      render text: ''
+    end
+  end
+
+  describe 'GET :index' do
+    let(:user_agent) { nil }
+
+    subject { get :index }
+
+    before :each do
+      @request.user_agent = user_agent
+    end
+
+    context "with a Google Snippet bot" do
+      let(:user_agent) {
+        "Mozilla/5.0 (Windows NT 6.1; rv:6.0) Gecko/20110814 Firefox/6.0 Google (+https://developers.google.com/+/web/snippet/)"
+      }
+
+      it "does not redirect to /notsupportedbrowser" do
+        is_expected.to_not redirect_to("/notsupportedbrowser")
+      end
+    end
+
+    context "with a Facebook Snippet bot" do
+      let(:user_agent) {
+        "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)"
+      }
+
+      it "does not redirect to /notsupportedbrowser" do
+        is_expected.to_not redirect_to("/notsupportedbrowser")
+      end
+    end
+
+    context "with a bot" do
+      let(:user_agent) { "bot" }
+
+      it "does not redirect to /notsupportedbrowser" do
+        is_expected.to_not redirect_to("/notsupportedbrowser")
+      end
+    end
+
+    context "with a supported browser" do
+      let(:user_agent) {
+        "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
+      }
+
+      it "does not redirect to /notsupportedbrowser" do
+        is_expected.to_not redirect_to("/notsupportedbrowser")
+      end
+    end
+
+    context "with a unsupported browser" do
+      let(:user_agent) { "Mozilla/4.0 WebTV/2.6 (compatible; MSIE 4.0)" }
+
+      it "redirects to /notsupportedbrowser" do
+        is_expected.to redirect_to("/notsupportedbrowser")
+      end
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -2,18 +2,28 @@ require 'spec_helper'
 
 describe ApplicationController do
   controller do
+    before_action :check_terms
+
     def index
       render text: ''
     end
   end
 
+  before do
+    ENV['TERMS_COOKIE'] = "terms_cookie"
+  end
+
   describe 'GET :index' do
-    let(:user_agent) { nil }
+    let(:user_agent) {
+      "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
+    }
+    let(:ip) { "127.0.0.1" }
 
     subject { get :index }
 
     before :each do
       @request.user_agent = user_agent
+      ActionDispatch::Request.any_instance.stub(:remote_ip).and_return(ip)
     end
 
     context "with a Google Snippet bot" do
@@ -23,6 +33,10 @@ describe ApplicationController do
 
       it "does not redirect to /notsupportedbrowser" do
         is_expected.to_not redirect_to("/notsupportedbrowser")
+      end
+
+      it "does not redirect to accept_terms_path" do
+        is_expected.to_not redirect_to(accept_terms_path)
       end
     end
 
@@ -34,6 +48,26 @@ describe ApplicationController do
       it "does not redirect to /notsupportedbrowser" do
         is_expected.to_not redirect_to("/notsupportedbrowser")
       end
+
+      it "does not redirect to accept_terms_path" do
+        is_expected.to_not redirect_to(accept_terms_path)
+      end
+    end
+
+    context "with a whitelisted IP" do
+      let(:ip) { "80.74.134.135" }
+
+      it "does not redirect to accept_terms_path" do
+        is_expected.to_not redirect_to(accept_terms_path)
+      end
+    end
+
+    context "with a non whitelisted IP" do
+      let(:ip) { "1.3.3.7" }
+
+      it "redirects to accept_terms_path" do
+        is_expected.to redirect_to(accept_terms_path)
+      end
     end
 
     context "with a bot" do
@@ -41,6 +75,10 @@ describe ApplicationController do
 
       it "does not redirect to /notsupportedbrowser" do
         is_expected.to_not redirect_to("/notsupportedbrowser")
+      end
+
+      it "does not redirect to accept_terms_path" do
+        is_expected.to_not redirect_to(accept_terms_path)
       end
     end
 
@@ -51,6 +89,10 @@ describe ApplicationController do
 
       it "does not redirect to /notsupportedbrowser" do
         is_expected.to_not redirect_to("/notsupportedbrowser")
+      end
+
+      it "redirects to accept_terms_path" do
+        is_expected.to redirect_to(accept_terms_path)
       end
     end
 


### PR DESCRIPTION
The sharing snippets for FB and G+ were not getting passed the supported browser check (the bot check in the user agent gem is just a regex match for "bot" :dizzy_face:) and the terms check, so I extracted that out and added some special cases for Facebook and g+. It's easy to add in more exemptions if we need to, for whatever reason. 

This seems like a big change, but I've just moved the user agent validation out in to a separate class as it's a separate responsibility from the app controller, and to make it testable.