### PR TITLE
Adds a download link mailer on mobile

### DIFF
--- a/app/assets/javascripts/countries/views/CountryShowView.js
+++ b/app/assets/javascripts/countries/views/CountryShowView.js
@@ -9,12 +9,13 @@ define([
   'mps',
   'scrollit',
   'views/SourceWindowView',
+  'views/DownloadView',
   'countries/views/CountryHeaderView',
   'countries/views/CountryShareView',
   'countries/models/CountryShowModel',
   'countries/helpers/CountryHelper',
 
-], function($, Backbone, _, d3, mps, scrollit, SourceWindowView, CountryHeaderView, CountryShareView, CountryShowModel, CountryHelper ) {
+], function($, Backbone, _, d3, mps, scrollit, SourceWindowView, DownloadView, CountryHeaderView, CountryShareView, CountryShowModel, CountryHelper ) {
 
   'use strict';
 
@@ -46,6 +47,7 @@ define([
       this.headerView = new CountryHeaderView({country: this.country});
       this._stickynav();
       this._initSource();
+      this._initDownload();
       this._drawTenure();
       this._drawForestsType();
       this._drawFormaAlerts();
@@ -62,6 +64,10 @@ define([
 
     _initSource: function() {
       this.sourceWindow  = new SourceWindowView();
+    },
+
+    _initDownload: function() {
+      new DownloadView();
     },
 
     _initFormaDropdown: function() {

--- a/app/assets/javascripts/templates/download.handlebars
+++ b/app/assets/javascripts/templates/download.handlebars
@@ -1,0 +1,21 @@
+<div class="download_dialog">
+  <h1 class="title">Send yourself a download link</h1>
+
+  <form id="download_email_form">
+    <p>
+      <span>
+        Enter your email to get a download link sent to your inbox
+      </span>
+    </p>
+
+    <div class="input-field huge">
+      <input class="field" type="text" name="email_address" placeholder="your@email.com">
+      <ul class="mode_menu">
+        <li class="selected first last"><a class="submit">submit</a></li>
+      </ul>
+    </div>
+
+    <p class="error">
+    </p>
+  </form>
+</div>

--- a/app/assets/javascripts/templates/download_error.handlebars
+++ b/app/assets/javascripts/templates/download_error.handlebars
@@ -1,0 +1,3 @@
+Sorry, we couldn't send you an email because an error occurred.
+Try again in a moment, but <a href="{{ downloadLink }}">here's a direct
+link to the download you requested</a>

--- a/app/assets/javascripts/views/DownloadView.js
+++ b/app/assets/javascripts/views/DownloadView.js
@@ -1,0 +1,93 @@
+define([
+  'jquery',
+  'backbone',
+  'underscore',
+  'mps',
+  'handlebars',
+  'text!templates/download.handlebars',
+  'text!templates/download_error.handlebars',
+], function($,Backbone, _,mps,Handlebars,raw_template,raw_error_template) {
+
+  'use strict';
+
+  var DownloadModel = Backbone.Model.extend({
+    sync: function(method, model, options) {
+      options || (options = {});
+      options.url = model.get('url');
+
+      Backbone.sync(method, model, options);
+    }
+  });
+
+  var DownloadView = Backbone.View.extend({
+    template: Handlebars.compile(raw_template),
+    errorTemplate: Handlebars.compile(raw_error_template),
+
+    el: 'body',
+
+    events: {
+      'click .download' : 'download',
+      'click .close': 'hide',
+      'click #download_email_form .submit': '_requestDownload'
+    },
+
+    initialize: function() {
+      this.model = new DownloadModel();
+
+      this.$wrapper = $('#window');
+      this.$content = $('#window .content');
+
+      this.mobile = ($(window).width() > 850) ? false : true;
+    },
+
+    show: function() {
+      this.render();
+      this.$wrapper.addClass('active');
+    },
+
+    hide: function() {
+      this.$wrapper.removeClass('active');
+    },
+
+    download: function(event) {
+      if (this.mobile) {
+        event && event.preventDefault() && event.stopPropagation();
+        this.show();
+
+        var href = $(event.target).attr('href');
+        this.model.set('url', href);
+      }
+    },
+
+    render: function() {
+      if (this.mobile) {
+        this.$content.html(this.template());
+      }
+    },
+
+    _downloadRequestSuccess: function() {
+      this.hide();
+    },
+
+    _downloadRequestFailure: function() {
+      var errorTemplate = this.errorTemplate({
+        downloadLink: this.model.get('url')
+      });
+      this.$content.find('.error').html(errorTemplate);
+    },
+
+    _requestDownload: function(event) {
+      event && event.preventDefault() && event.stopPropagation();
+
+      var email = $('#download_email_form [name="email_address"]').val()
+      this.model.set('email', email);
+
+      this.model.save({}, {
+        success: _.bind(this._downloadRequestSuccess, this),
+        error: _.bind(this._downloadRequestFailure, this)
+      });
+    }
+  });
+
+  return DownloadView;
+});

--- a/app/assets/stylesheets/modules/countries/_overview.scss
+++ b/app/assets/stylesheets/modules/countries/_overview.scss
@@ -733,12 +733,16 @@
 
 
 .share_dialog {
+  display: none;
+  z-index: 2000;
+}
+
+.download_dialog,
+.share_dialog {
   $width: 500px;
   $height: 170px;
 
-  display: none;
   position: fixed;
-  z-index: 2000;
   top: 50%; left: 50%;
   margin-top: -$height/2;
   margin-left: -$width/2;
@@ -909,6 +913,8 @@
     }
   }
 }
+
+.download_dialog,
 .share_dialog {
   height: 270px;
 
@@ -938,6 +944,26 @@
     }
   }
 }
+
+.source_window .content-wrapper
+.content .download_dialog .input-field a {
+  color: #FFFFFF;
+}
+
+.download_dialog {
+  .mode_menu {
+    width: 55px;
+  }
+
+  p {
+    margin: 15px 10px;
+  }
+
+  .error {
+    font-weight: bold;
+  }
+}
+
 .overview_button_group {
   position: relative;
   background: #EEEEEE;
@@ -1210,6 +1236,7 @@
     }
   }
 
+  .download_dialog,
   .share_dialog {
     top: 0;
     margin: 0;

--- a/app/controllers/concerns/countries_concern.rb
+++ b/app/controllers/concerns/countries_concern.rb
@@ -1,0 +1,7 @@
+module CountriesConcern
+  extend ActiveSupport::Concern
+
+  def download_link iso
+    "https://wri-01.cartodb.com/api/v2/sql?q=SELECT iso as country_code,id1 as region_code, country,region, year, thresh as min_percent_canopy_density, loss as loss_ha, loss_perc as loss_percent, extent as extent_ha, extent_perc as extent_percent, gain as gain_ha, gain_perc as gain_percent from umd_subnat where iso='#{iso}'&format=csv&filename='#{iso}'"
+  end
+end

--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -1,7 +1,12 @@
 class CountriesController < ApplicationController
   before_filter :check_terms
   before_action :check_country_iso, only: :show
+
+  skip_before_filter :verify_authenticity_token, only: [:create_download]
+
   include ActionView::Helpers::NumberHelper
+  include CountriesConcern
+
   layout 'countries'
 
   def index
@@ -37,6 +42,23 @@ class CountriesController < ApplicationController
 
   def overview
     @title =  I18n.translate 'countries.overview.title'
+  end
+
+  def create_download
+    if (params[:email].present?)
+      MobileDownload.download_email(
+        params[:email],
+        download_link(params[:id])
+      ).deliver
+
+      return render json: true
+    end
+
+    return render json: false, status: :unprocessable_entity
+  end
+
+  def download
+    redirect_to download_link(params[:id])
   end
 
   private

--- a/app/mailers/mobile_download.rb
+++ b/app/mailers/mobile_download.rb
@@ -1,0 +1,9 @@
+class MobileDownload < ActionMailer::Base
+  default from: "gfw@wri.org"
+
+  # Set subject in I18n: en.mobile_download.download_email.subject
+  def download_email email_address, download_link
+    @download_link = download_link
+    mail to: email_address
+  end
+end

--- a/app/views/countries/_header.html.erb
+++ b/app/views/countries/_header.html.erb
@@ -88,7 +88,7 @@
               </a>
             </li>
             <li>
-              <a href="https://wri-01.cartodb.com/api/v2/sql?q=SELECT iso as country_code,id1 as region_code, country,region, year, thresh as min_percent_canopy_density, loss as loss_ha, loss_perc as loss_percent, extent as extent_ha, extent_perc as extent_percent, gain as gain_ha, gain_perc as gain_percent from umd_subnat where iso='<%=@country['iso']%>'&format=csv&filename='<%=@country['iso']%>'">
+              <a href="<%= country_download_path(id: @country['iso']) %>" class="download">
                 Download country stats
                 <!-- <span class="sidenav-icon country-icons-download_grey"></span> -->
                 <span class="sidenav-icon">

--- a/app/views/mobile_download/download_email.text.erb
+++ b/app/views/mobile_download/download_email.text.erb
@@ -1,0 +1,5 @@
+Hi,
+
+Here's that dataset download you requested:
+
+<%= @download_link %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,3 +109,6 @@ en:
     share: Share Global Forest Watch.
     partnership: A partnership of
     strategic: A strategic initiative of
+  mobile_download:
+    download_email:
+      subject: Your Global Forest Watch download

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,10 @@ Gfw::Application.routes.draw do
   # countries
   get '/countries' => 'countries#index'
   get '/country/:id' => 'countries#show', :as => 'country'
+
+  post '/country/:id/download' => 'countries#create_download'
+  get '/country/:id/download' => 'countries#download', :as => 'country_download'
+
   get '/country_info/:id/:box',to: redirect('/country/%{id}#%{box}')
   # todo => validate id
   get '/country/:id/:area_id' => 'countries#show', :as => 'country_area'

--- a/spec/concerns/countries_concern_spec.rb
+++ b/spec/concerns/countries_concern_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe CountriesConcern do
+  class CountriesConcernDouble
+    include ::CountriesConcern
+  end
+
+  context "given a country ISO" do
+    let(:iso) { "AWM" }
+    let(:url) {
+      "https://wri-01.cartodb.com/api/v2/sql?q=SELECT iso as country_code,id1 as region_code, country,region, year, thresh as min_percent_canopy_density, loss as loss_ha, loss_perc as loss_percent, extent as extent_ha, extent_perc as extent_percent, gain as gain_ha, gain_perc as gain_percent from umd_subnat where iso='#{iso}'&format=csv&filename='#{iso}'"
+    }
+
+    subject {
+      CountriesConcernDouble.new.download_link iso
+    }
+
+    it "returns a download link for that country" do
+      is_expected.to eq(url)
+    end
+  end
+end

--- a/spec/controllers/countries_controller_spec.rb
+++ b/spec/controllers/countries_controller_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe CountriesController do
+  before do
+    ENV['TERMS_COOKIE'] = "terms_cookie"
+  end
+
+  let(:url_params) { {} }
+  let(:iso) { "AWM" }
+  let(:download_link) { "http://download.com/country" }
+
+  before(:each) do
+    @request.user_agent = "bot" # get past browser checks
+
+    expect_any_instance_of(CountriesController).to(
+      receive(:download_link).
+      with(iso).
+      and_return(download_link)
+    )
+  end
+
+  describe "POST download" do
+    context "given an email address" do
+      let(:email) { "my@email.com" }
+      let(:mailer_double) { double("mailer") }
+
+      subject {
+        post :create_download, {id: iso, email: email}
+      }
+
+      it "sends an email with the download link" do
+        expect(MobileDownload).to(
+          receive(:download_email).
+          with(email, download_link).
+          and_return(mailer_double)
+        )
+
+        expect(mailer_double).to receive(:deliver).and_return(true)
+
+        subject
+      end
+
+      it "returns a success response code" do
+        expect(response.code).to eq("200")
+        subject
+      end
+    end
+  end
+
+  describe "GET download" do
+    context "given an ISO" do
+      subject {
+        get :download, {id: iso}
+      }
+
+      it "redirects to the download link for that country" do
+        is_expected.to redirect_to(download_link)
+      end
+    end
+  end
+end

--- a/spec/mailers/mobile_download_spec.rb
+++ b/spec/mailers/mobile_download_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe MobileDownload do
+  let(:email) { "mobileuser@internet.com" }
+  let(:link) { "http://download.com/gfw" }
+
+  before(:each) do
+    MobileDownload.download_email(email, link).deliver
+  end
+
+  after(:each) do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  context "counting email" do
+    subject { ActionMailer::Base.deliveries.count }
+
+    it "should send an email" do
+      is_expected.to eq(1)
+    end
+  end
+
+  context "sent email" do
+    subject { ActionMailer::Base.deliveries.first }
+
+    it "sets the correct subject" do
+      expect(subject.subject).to eq("Your Global Forest Watch download")
+    end
+
+    it "sets the correct receiver email" do
+      expect(subject.to).to eq([email])
+    end
+
+    it "sets the correct from email" do
+      expect(subject.from).to eq(["gfw@wri.org"])
+    end
+
+    it "includes the download link in the email body" do
+      expect(subject.body.encoded).to match(Regexp.new(link))
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces a download link mailer: when on a mobile device,
instead of linking directly to a Country download, we'll offer them the
ability to email themselves a link to the download.

The DownloadView on the client has been designed to be generic (it takes
any URL for a "download"), and so it can be used for mail notifications
for any type of download. The same goes for the mailer on the server.

![screenshot 2015-03-24 15 38 52](https://cloud.githubusercontent.com/assets/182921/6805882/655ea8de-d23d-11e4-92c8-f941962a189c.png)
![screenshot 2015-03-24 15 31 30](https://cloud.githubusercontent.com/assets/182921/6805881/6542f058-d23d-11e4-97d1-0236964b4d71.png)