### PR TITLE
hotfixed: change url quicc to data portal link

### DIFF
--- a/app/views/shared/_sources_map.html.erb
+++ b/app/views/shared/_sources_map.html.erb
@@ -556,7 +556,7 @@
 
           <p class='credits'><strong>Suggested citation for data as displayed on GFW:</strong> “QUICC Alerts.” NASA Ames Research Center and California State University. Accessed through Global Forest Watch on [date].<a href='http://www.globalforestwatch.org' target='_blank'>www.globalforestwatch.org</a>.</p>
 
-          <p class='read_more hidden'><em><%= link_to 'Learn more or download data', "#{sources_path}/forest_change?t=modis" %></em></p>
+          <p class='read_more hidden'><em><%= link_to 'Learn more or download data', "http://data.globalforestwatch.org/datasets/e7bfe60d90ea4e5aa808eba4723ad3f8_0" %></em></p>
         </div>
       </div>
 


### PR DESCRIPTION
there is only one link left miguel, the one on the image (quicc one)