### PR TITLE
Fit iframe to content of share previews

### DIFF
--- a/app/assets/javascripts/views/SharePreviewView.js
+++ b/app/assets/javascripts/views/SharePreviewView.js
@@ -32,8 +32,18 @@ define([
     render: function(){
       var renderedTemplate = this.template({src: this.src});
       this.$el.html(renderedTemplate);
+      this.$('iframe').load(_.bind(this.fitToContent, this));
 
       return this;
+    },
+
+    fitToContent: function() {
+      var $iframe = this.$('iframe');
+      var iframe = $iframe[0];
+      var iframeContent = iframe.contentWindow.document.body;
+
+      $iframe.width(iframeContent.clientWidth);
+      $iframe.height(iframeContent.scrollHeight);
     }
   });
 

--- a/app/assets/stylesheets/modules/countries/_overview.scss
+++ b/app/assets/stylesheets/modules/countries/_overview.scss
@@ -1,3 +1,7 @@
+.embed.countries_overview {
+  width: 960px;
+}
+
 .section-title {
 
   @media only screen and (max-width: 480px) {


### PR DESCRIPTION
On slower connections there can be a bit of a delay as we can't figure out the width until the iframe has loaded. Wasn't sure if it was worth adding some sort of loading indicator, thoughts? Here's how it looks: http://recordit.co/e3x3IqvTmY