### PR TITLE
Fix/damn hotspots

### DIFF
--- a/app/assets/javascripts/map/cartocss/dam_hotspots.cartocss
+++ b/app/assets/javascripts/map/cartocss/dam_hotspots.cartocss
@@ -1,16 +1,24 @@
 #dam_hotspots {
    marker-fill-opacity: 0.9;
    marker-line-color: #FFF;
-   marker-line-width: 1;
+   marker-line-width: 0.5;
    marker-line-opacity: 1;
    marker-placement: point;
    marker-type: ellipse;
-   marker-width: 10;
+   marker-width: 4;
    marker-allow-overlap: true;
+  
+  [zoom > 5 ][zoom < 9]{
+   marker-width: 10;
+  }
+  [zoom > 8 ]{
+   marker-width: 20;
+  }
+  
 }
 
 #dam_hotspots[status="Operational"] {
-   marker-fill: #A6CEE3;
+   marker-fill: #A53ED5;
 }
 #dam_hotspots[status="Under Construction"] {
    marker-fill: #FB9A99;

--- a/app/assets/javascripts/map/templates/infowindow.handlebars
+++ b/app/assets/javascripts/map/templates/infowindow.handlebars
@@ -6,6 +6,7 @@
         {{#if content.data.name}}
           <h2>{{content.data.name}}</h2>
         {{/if}}
+        
         {{!-- <div class="thumb-mask" style="background-image: url({{content.data.image}})"> --}}
           <div class="thumb-mask"><img src="{{content.data.image}}" onerror="this.style.display='none';"></div>
       {{/if}}
@@ -22,7 +23,6 @@
             <h2>{{content.data.name}}</h2>
           {{/if}}
         {{/unless}}
-
         {{#if content.data.local_name}}
           <h4>Local name:</h4>
           <p>{{content.data.local_name}}</p>
@@ -53,6 +53,14 @@
           <h4>Type:</h4>
           <p>{{content.data.type}}</p>
         {{/if}}
+        {{#if content.data.status}}
+          <h4>Status:</h4>
+          <p>{{content.data.status}}</p>
+        {{/if}}
+        {{#if content.data.capacity}}
+          <h4>Capacity:</h4>
+          <p>{{content.data.capacity}}</p>
+        {{/if}}
         {{#if content.data.basin_name}}
           <h4>Basin:</h4>
           <p>{{content.data.basin_name}}</p>
@@ -60,18 +68,6 @@
         {{#if content.data.rivers}}
           <h4>River:</h4>
           <p>{{content.data.rivers}}</p>
-        {{/if}}
-        {{#if content.data.project_na}}
-          <h4>Project Name</h4>
-          <p><a href="{{content.data.project_ur}}" target="_blank">{{content.data.project_na}}</a></p>
-        {{/if}}
-        {{#if content.data.capacity}}
-          <h4>Capacity:</h4>
-          <p>{{content.data.capacity}}</p>
-        {{/if}}
-        {{#if content.data.status}}
-          <h4>Status:</h4>
-          <p>{{content.data.status}}</p>
         {{/if}}
         {{#if content.data.company}}
           <h4>Company:</h4>

--- a/app/assets/javascripts/map/templates/infowindow.handlebars
+++ b/app/assets/javascripts/map/templates/infowindow.handlebars
@@ -59,7 +59,7 @@
         {{/if}}
         {{#if content.data.capacity}}
           <h4>Capacity:</h4>
-          <p>{{content.data.capacity}}</p>
+          <p>{{content.data.capacity}} MW</p>
         {{/if}}
         {{#if content.data.basin_name}}
           <h4>Basin:</h4>

--- a/app/assets/javascripts/map/templates/layersNav.handlebars
+++ b/app/assets/javascripts/map/templates/layersNav.handlebars
@@ -127,10 +127,10 @@
             <span class="onoffswitch"><span></span></span>
             <span class="layer-title">Wood fiber plantations<a href='#' data-source='wood_fiber_plantations' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
           </li>
-          {{!-- <li class="layer" data-layer="dam_hotspots">
+          <li class="layer" data-layer="dam_hotspots">
             <span class="onoffswitch"><span></span></span>
             <span class="layer-title">Dam Hotspots<a href='#' data-source='dam_hotspots' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
-          </li> --}}
+          </li>
         </ul>
       </div>
     </li>
@@ -152,10 +152,10 @@
             <span class="onoffswitch"><span></span></span>
             <span class="layer-title">Biodiversity hotspots<a href='#' data-source='biodiversity_hotspots' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
           </li>
-          {{!--<li class="layer" data-layer="wwf">
+          <li class="layer" data-layer="wwf">
             <span class="onoffswitch"><span></span></span>
             <span class="layer-title">WWF Terrestrial Ecoregions of the World<a href='#' data-source='wwf' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
-          </li> --}}
+          </li> 
           <li class="layer" data-layer="birdlife">
             <span class="onoffswitch"><span></span></span>
             <span class="layer-title">BirdLife Endemic Bird Areas<a href='#' data-source='birdlife' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
@@ -168,10 +168,10 @@
             <span class="onoffswitch"><span></span></span>
             <span class="layer-title">Tiger Conservation Landscapes<a href='#' data-source='tigers' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
           </li>
-          {{!-- <li class="layer" data-layer="verified_carbon">
+          <li class="layer" data-layer="verified_carbon">
             <span class="onoffswitch"><span></span></span>
             <span class="layer-title">Verified Carbon Standard project boundaries<a href='#' data-source='verified_carbon' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
-          </li> --}}
+          </li>
         </ul>
       </div>
     </li>

--- a/app/assets/javascripts/map/templates/legend/dam_hotspots.handlebars
+++ b/app/assets/javascripts/map/templates/legend/dam_hotspots.handlebars
@@ -1,6 +1,6 @@
 <div class="layer-details layer-details-dam_hotspots">
   <ul class="layer-colors">
-    <li><i class="circle" style='color:#A6CEE3;'></i>Operational</li>
+    <li><i class="circle" style='color:#A53ED5;'></i>Operational</li>
     <li><i class="circle" style='color:#FB9A99;'></i>Under construcction</li>
     <li><i class="circle" style='color:#1F78B4;'></i>Planned</li>
     <li><i class="circle" style='color:#B2DF8A;'></i>Inventoried</li>

--- a/app/assets/javascripts/map/views/layers/DamHotspotsLayer.js
+++ b/app/assets/javascripts/map/views/layers/DamHotspotsLayer.js
@@ -13,9 +13,9 @@ define([
   var DamHotspotsLayer = CartoDBLayerClass.extend({
 
     options: {
-      sql: 'SELECT the_geom_webmercator, basin_name, project as project_na, capacity, rivers, status, campaign as project_ur,  {analysis} AS analysis, \'{tableName}\' AS layer FROM {tableName}',
+      sql: 'SELECT the_geom_webmercator, basin_name, project as name, capacity, rivers, status, campaign as project_ur,  {analysis} AS analysis, \'{tableName}\' AS layer FROM {tableName}',
       infowindow: true,
-      interactivity: ' basin_name, project_na, capacity, rivers, status, project_ur',
+      interactivity: ' basin_name, name, capacity, rivers, status, project_ur',
       analysis: false,
       cartocss: dam_hotspots
     }


### PR DESCRIPTION
added the changes requested:
When zoomed in, the "Operational" and "Unknown" dam point colors are difficult to see against the default basemap. Could we alter the color to enhance the contrast?
Can we make the "project name" attribute the title for each pop-up window when a point is selected? Similar to how we display the Protected Area name as a title when a protected area polygon is selected. 
Can we move the "status" attribute to the first location in the attribute list under the title?
The "project name" attributes are hyperlinked, and while some of them link to an International Rivers blog, most of them take you nowhere (or back to GFW). Can we remove the hyperlinks all together, or keep only those that link to an external website?
Can we add "MW" for megawatt next to each "Capacity" attribute value. 