### PR TITLE
Fix/legend damn

### DIFF
--- a/app/assets/javascripts/map/templates/infowindow.handlebars
+++ b/app/assets/javascripts/map/templates/infowindow.handlebars
@@ -6,9 +6,15 @@
         {{#if content.data.name}}
           <h2>{{content.data.name}}</h2>
         {{/if}}
-        
+      
         {{!-- <div class="thumb-mask" style="background-image: url({{content.data.image}})"> --}}
           <div class="thumb-mask"><img src="{{content.data.image}}" onerror="this.style.display='none';"></div>
+
+      {{/if}}
+      {{#if content.data.project_ur}}
+        <h2><a href="{{content.data.project_ur}}" target="_blank">{{content.data.project_name}}</a></h2>
+      {{else}}
+        <h2>{{content.data.project_name}}</h2>
       {{/if}}
     </div>
     <div class="cartodb-popup-fixed">

--- a/app/assets/javascripts/map/templates/infowindow.handlebars
+++ b/app/assets/javascripts/map/templates/infowindow.handlebars
@@ -11,11 +11,6 @@
           <div class="thumb-mask"><img src="{{content.data.image}}" onerror="this.style.display='none';"></div>
 
       {{/if}}
-      {{#if content.data.project_ur}}
-        <h2><a href="{{content.data.project_ur}}" target="_blank">{{content.data.project_name}}</a></h2>
-      {{else}}
-        <h2>{{content.data.project_name}}</h2>
-      {{/if}}
     </div>
     <div class="cartodb-popup-fixed">
       {{#if content.data.analysis}}
@@ -24,6 +19,11 @@
     </div>
     <div class="cartodb-popup-content">
       <div class="cartodb-popup-content-inside">
+        {{#if content.data.project_ur}}
+        <h2><a href="{{content.data.project_ur}}" target="_blank">{{content.data.project_name}}</a></h2>
+        {{else}}
+        <h2>{{content.data.project_name}}</h2>
+        {{/if}}
         {{#unless content.data.image}}
           {{#if content.data.name}}
             <h2>{{content.data.name}}</h2>

--- a/app/assets/javascripts/map/views/layers/DamHotspotsLayer.js
+++ b/app/assets/javascripts/map/views/layers/DamHotspotsLayer.js
@@ -13,9 +13,9 @@ define([
   var DamHotspotsLayer = CartoDBLayerClass.extend({
 
     options: {
-      sql: 'SELECT the_geom_webmercator, basin_name, project as name, capacity, rivers, status, campaign as project_ur,  {analysis} AS analysis, \'{tableName}\' AS layer FROM {tableName}',
+      sql: 'SELECT the_geom_webmercator, basin_name, project as project_name, capacity, rivers, status, campaign as project_ur,  {analysis} AS analysis, \'{tableName}\' AS layer FROM {tableName}',
       infowindow: true,
-      interactivity: ' basin_name, name, capacity, rivers, status, project_ur',
+      interactivity: ' basin_name, project_name, capacity, rivers, status, project_ur',
       analysis: false,
       cartocss: dam_hotspots
     }


### PR DESCRIPTION
The "project name" attributes are hyperlinked, and while some of them link to an International Rivers blog, most of them take you nowhere (or back to GFW). Can we remove the hyperlinks all together, or keep only those that link to an external website?

now only those with url will lead to the url