### PR TITLE
removed Peru from list of managed forests

### DIFF
--- a/app/views/shared/_sources_map.html.erb
+++ b/app/views/shared/_sources_map.html.erb
@@ -1219,7 +1219,7 @@
           </dl>
           <dl class='sources_row'>
             <dt>Geographic coverage</dt>
-            <dd>Currently available for Cameroon, Canada, Central African Republic, Democratic Republic of the Congo (DRC), Equatorial Guinea, Gabon, Indonesia, Liberia, Peru, and Republic of the Congo.</dd>
+            <dd>Currently available for Cameroon, Canada, Central African Republic, Democratic Republic of the Congo (DRC), Equatorial Guinea, Gabon, Indonesia, Liberia, and Republic of the Congo.</dd>
           </dl>
           <dl class='sources_row even'>
             <dt>Source data</dt>


### PR DESCRIPTION
the Peru layer is not part of the global managed forests layer