### PR TITLE
Changed link for Data Playbook to Amazon S3.

### DIFF
--- a/app/views/static/howto.html.erb
+++ b/app/views/static/howto.html.erb
@@ -627,7 +627,7 @@
 
                     <p>See our <a class="mobile-friendly" href="http://data.globalforestwatch.org/">Open Data Portal</a> for more detail. To contribute or suggest data, please <a href='mailto:gfw@wri.com'>email</a> us.</p>
 
-                    <p>For more information about how Global Forest Watch acquires and incorporates new data to the GFW system, see our <a href="/GFW-Data-Playbook.pdf" target="_blank">Data Playbook</a>.</p>
+                    <p>For more information about how Global Forest Watch acquires and incorporates new data to the GFW system, see our <a href="http://gfw.blog.s3.amazonaws.com/Data%20Playbook/GFW%20Data%20Playbook%20v2.pdf" target="_blank">Data Playbook</a>.</p>
 
                   </div>
                 </div>


### PR DESCRIPTION
On FAQ "What Kinds of Data Are Available on GFW?" page.