### PR TITLE
Update prodes endpoints for API

### DIFF
--- a/app/assets/javascripts/map/presenters/analysis/AnalysisResultsPresenter.js
+++ b/app/assets/javascripts/map/presenters/analysis/AnalysisResultsPresenter.js
@@ -41,7 +41,7 @@ define([
       'fires': 'nasa-active-fires',
       'modis': 'quicc-alerts',
       'terrailoss': 'terrai-alerts',
-      'prodes': 'prodes-alerts'
+      'prodes': 'prodes-loss'
     },
 
     init: function(view) {

--- a/app/assets/javascripts/map/presenters/tabs/AnalysisPresenter.js
+++ b/app/assets/javascripts/map/presenters/tabs/AnalysisPresenter.js
@@ -48,7 +48,7 @@ define([
       'fires': 'nasa-active-fires',
       'modis': 'quicc-alerts',
       'terrailoss': 'terrai-alerts',
-      'prodes' : 'prodes-alerts'
+      'prodes' : 'prodes-loss'
     },
 
     init: function(view) {

--- a/app/assets/javascripts/map/presenters/tabs/SubscriptionPresenter.js
+++ b/app/assets/javascripts/map/presenters/tabs/SubscriptionPresenter.js
@@ -48,7 +48,7 @@ define([
       'fires': 'nasa-active-fires',
       'modis': 'quicc-alerts',
       'terrailoss': 'terrai-alerts',
-      'prodes': 'prodes-alerts'
+      'prodes': 'prodes-loss'
     },
 
     init: function(view) {

--- a/app/assets/javascripts/map/services/AnalysisService.js
+++ b/app/assets/javascripts/map/services/AnalysisService.js
@@ -97,7 +97,7 @@ define([
     _defineRequests: function() {
       var datasets = [
         'forma-alerts', 'umd-loss-gain', 'imazon-alerts', 'nasa-active-fires',
-        'quicc-alerts', 'terrai-alerts', 'prodes-alerts'
+        'quicc-alerts', 'terrai-alerts', 'prodes-loss'
       ];
 
       // Defines requests for each dataset (e.g., forma-alerts) and type (e.g.


### PR DESCRIPTION
This PR updates `prodes-alerts` endpoints to hit `prodes-loss`.

API changes are deployed to staging:

http://staging.gfw-apis.appspot.com/forest-change/prodes-loss