### PR TITLE
Update link in loss info window

### DIFF
--- a/app/views/shared/_sources.html.erb
+++ b/app/views/shared/_sources.html.erb
@@ -101,7 +101,7 @@
 
           <p class='credits'><strong>Suggested citations for data as displayed on GFW:</strong>Hansen, M. C., P. V. Potapov, R. Moore, M. Hancher, S. A. Turubanova, A. Tyukavina, D. Thau, S. V. Stehman, S. J. Goetz, T. R. Loveland, A. Kommareddy, A. Egorov, L. Chini, C. O. Justice, and J. R. G. Townshend. 2013. “Hansen/UMD/Google/USGS/NASA Tree Cover Loss and Gain Area.” University of Maryland, Google, USGS, and NASA. Accessed through Global Forest Watch on [date]. <a href='http://www.globalforestwatch.org' target='_blank'>www.globalforestwatch.org</a>.</p>
 
-          <p class='read_more hidden'><em><%= link_to 'Learn more or download data', "http://data.globalforestwatch.org/datasets/93ecbfa0542c42fdaa8454fa42a6cc27" %></em></p>
+          <p class='read_more hidden'><em><%= link_to 'Learn more or download data', "http://earthenginepartners.appspot.com/science-2013-global-forest/download_v1.2.html" %></em></p>
         </div>
       </div>
     </li>


### PR DESCRIPTION
Link is broken since this data is not currently on the ODP (because the 2014 data download is not ready). Linking instead to the Google Earth Engine