### PR TITLE
Removed Fires and Commodities from How To

### DIFF
--- a/app/views/static/howto.html.erb
+++ b/app/views/static/howto.html.erb
@@ -337,7 +337,7 @@
                     <p><strong>8.</strong> You can then download the raw data on the <a class="mobile-friendly" href="http://data.globalforestwatch.org/" target='_blank'>Open Data Portal</a>, discard your analysis or subscribe to alerts.</p>
                     <p><%= image_tag('howto-screenshots/new_content/image28.png') %></p>
 
-                    <a class="btn green medium" href='/map' target='_blank'>GFW Interactive Map</a><a href='http://commodities.globalforestwatch.org/' class="btn green medium uppercase">GFW Commodities</a><a href='http://fires.globalforestwatch.org/' class="btn green medium uppercase">GFW Fires</a>
+                    <a class="btn green medium" href='/map' target='_blank'>GFW Interactive Map</a>
                   </div>
                 </div>
               </li>
@@ -361,7 +361,7 @@
                     <p><%= image_tag('howto-screenshots/new_content/image28.png') %></p>
                     <p>NOTE: You can also analyze forest change within a country from the <a href="/countries">Country Profiles</a>. Once you arrive at the Country Profiles, select a country and, if desired, select a subnational jurisdiction (e.g., state, county, province) using the dropdown menu under the country name. Click “analyze on map” You will then be directed to the map and results will appear for an analysis of tree cover loss and gain.</p>
 
-                    <a class="btn green medium" href='/map' target='_blank'>GFW Interactive Map</a><a href='http://commodities.globalforestwatch.org/' class="btn green medium uppercase">GFW Commodities</a><a href='http://fires.globalforestwatch.org/' class="btn green medium uppercase">GFW Fires</a>
+                    <a class="btn green medium" href='/map' target='_blank'>GFW Interactive Map</a>
                   </div>
                 </div>
               </li>


### PR DESCRIPTION
Removed Fires and Commodities buttons from "ANALYZE A USER-DEFINED AREA" and "ANALYZE A COUNTRY OR SUBNATIONAL JURISDICTION".