### PR TITLE
Adds FORMA 250 torque layer

### DIFF
--- a/app/assets/javascripts/map/cartocss/Forma250Layer.cartocss
+++ b/app/assets/javascripts/map/cartocss/Forma250Layer.cartocss
@@ -1,0 +1,11 @@
+#layer {
+  comp-op: lighter;
+  marker-fill-opacity: 1;
+  marker-type: ellipse;
+  marker-width: 0.5;
+  marker-fill: #FF6699;
+
+  [zoom=15] {
+    marker-width: 1;
+  }
+}

--- a/app/assets/javascripts/map/cartocss/Forma250Layer.cartocss
+++ b/app/assets/javascripts/map/cartocss/Forma250Layer.cartocss
@@ -8,33 +8,38 @@
   marker-height: 0.25;
   marker-fill: #F69;
 
-	[zoom>7] {
-		marker-width: 1;
-		marker-height: 1;
-	}
+  [zoom>=10] {
+    marker-width: 0.75;
+    marker-height: 0.75;
+  }
 
-	[zoom=14]{
-		marker-width: 2;
-		marker-height: 2;
-	}
+  [zoom>13] {
+    marker-width: 1.5;
+    marker-height: 1.5;
+  }
 
-	[zoom=15]{
-		marker-width: 3;
-		marker-height: 3;
-	}
+  [zoom=14]{
+    marker-width: 3;
+    marker-height: 3;
+  }
 
-	[zoom=16]{
-		marker-width: 6;
-		marker-height: 6;
-	}
+  [zoom=15]{
+    marker-width: 6;
+    marker-height: 6;
+  }
 
-	[zoom=17]{
-		marker-width: 12;
-		marker-height: 12;
-	}
+  [zoom=16]{
+    marker-width: 12;
+    marker-height: 12;
+  }
 
-	[zoom>=18]{
-		marker-width: 24;
-		marker-height: 24;
-	}
+  [zoom=17]{
+    marker-width: 24;
+    marker-height: 24;
+  }
+
+  [zoom>=18]{
+    marker-width: 48;
+    marker-height: 48;
+  }
 }

--- a/app/assets/javascripts/map/cartocss/Forma250Layer.cartocss
+++ b/app/assets/javascripts/map/cartocss/Forma250Layer.cartocss
@@ -1,11 +1,40 @@
 #layer {
-  comp-op: lighter;
+  comp-op: src;
   marker-fill-opacity: 1;
-  marker-type: ellipse;
-  marker-width: 0.5;
-  marker-fill: #FF6699;
+  marker-line-width: 0;
+  marker-placement: point;
+  marker-type: rectangle;
+  marker-width: 0.25;
+  marker-height: 0.25;
+  marker-fill: #F69;
 
-  [zoom=15] {
-    marker-width: 1;
-  }
+	[zoom>7] {
+		marker-width: 1;
+		marker-height: 1;
+	}
+
+	[zoom=14]{
+		marker-width: 2;
+		marker-height: 2;
+	}
+
+	[zoom=15]{
+		marker-width: 3;
+		marker-height: 3;
+	}
+
+	[zoom=16]{
+		marker-width: 6;
+		marker-height: 6;
+	}
+
+	[zoom=17]{
+		marker-width: 12;
+		marker-height: 12;
+	}
+
+	[zoom>=18]{
+		marker-width: 24;
+		marker-height: 24;
+	}
 }

--- a/app/assets/javascripts/map/helpers/layersHelper.js
+++ b/app/assets/javascripts/map/helpers/layersHelper.js
@@ -6,6 +6,7 @@ define([
   'map/views/layers/LossLayer',
   'map/views/layers/ForestGainLayer',
   'map/views/layers/FormaLayer',
+  'map/views/layers/Forma250Layer',
   'map/views/layers/FormaCoverLayer',
   'map/views/layers/ImazonLayer',
   'map/views/layers/ImazonCoverLayer',
@@ -114,6 +115,7 @@ define([
   // Layers timelines
   'map/views/timeline/LossTimeline',
   'map/views/timeline/FormaTimeline',
+  'map/views/timeline/Forma250Timeline',
   'map/views/timeline/ImazonTimeline',
   'map/views/timeline/LandsatAlertsTimeline',
   'map/views/timeline/ModisTimeline',
@@ -127,6 +129,7 @@ define([
   LossLayer,
   ForestGainLayer,
   FormaLayer,
+  Forma250Layer,
   FormaCoverLayer,
   ImazonLayer,
   ImazonCoverLayer,
@@ -234,6 +237,7 @@ define([
   // Layer timelines
   LossTimeline,
   FormaTimeline,
+  Forma250Timeline,
   ImazonTimeline,
   LandsatAlertsTimeline,
   ModisTimeline,
@@ -257,6 +261,10 @@ define([
     forma: {
       view: FormaLayer,
       timelineView: FormaTimeline
+    },
+    forma_250: {
+      view: Forma250Layer,
+      timelineView: Forma250Timeline
     },
     forma_cover: {
       view: FormaCoverLayer

--- a/app/assets/javascripts/map/models/LayerSpecModel.js
+++ b/app/assets/javascripts/map/models/LayerSpecModel.js
@@ -123,6 +123,7 @@ define([
       "modis",
       "imazon",
       "forma",
+      "forma_250",
       "prodes",
       "loss",
       "forestgain",

--- a/app/assets/javascripts/map/presenters/MapPresenter.js
+++ b/app/assets/javascripts/map/presenters/MapPresenter.js
@@ -152,6 +152,8 @@ define([
           // Always fit to the most recent layer
           layerToFit = layersToFit[layersToFit.length - 1];
 
+      if (layerToFit === undefined) { return; }
+
       var southWest = new google.maps.LatLng(layerToFit.ymin, layerToFit.xmin),
           northEast = new google.maps.LatLng(layerToFit.ymax, layerToFit.xmax),
           bounds = new google.maps.LatLngBounds(southWest, northEast);

--- a/app/assets/javascripts/map/services/MapLayerService.js
+++ b/app/assets/javascripts/map/services/MapLayerService.js
@@ -98,6 +98,7 @@ define([
                 ST_XMIN(the_geom) AS xmin, \
                 ST_YMAX(the_geom) AS ymax, \
                 ST_YMIN(the_geom) AS ymin, \
+                fit_to_geom, \
                 tileurl, \
                 does_wrapper, \
                 true AS visible \

--- a/app/assets/javascripts/map/templates/layersNav.handlebars
+++ b/app/assets/javascripts/map/templates/layersNav.handlebars
@@ -50,6 +50,11 @@
               <span class="layer-title">FORMA<a href='#' data-source='forma' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
               <span class="layer-info">(monthly, 500m, humid tropics, WRI/CGD)</span>
             </li>
+            <li class="layer" data-layer="forma_250">
+              <span class="onoffradio"><span></span></span>
+              <span class="layer-title">FORMA 250<a href='#' data-source='forma' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
+              <span class="layer-info">(daily, 250m, humid tropics, WRI/CGD)</span>
+            </li>
             <li class="layer" data-layer="terrailoss">
               <span class="onoffradio"><span></span></span>
               <span class="layer-title">Terra-i<a href='#' data-source='terrailoss' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>

--- a/app/assets/javascripts/map/views/layers/Forma250Layer.js
+++ b/app/assets/javascripts/map/views/layers/Forma250Layer.js
@@ -1,0 +1,27 @@
+/**
+ * The FORMA 250 layer module.
+ *
+ * @return Forma250Layer class (extends TorqueLayerClass)
+ */
+
+define([
+  'abstract/layer/TorqueLayerClass',
+  'text!map/cartocss/Forma250Layer.cartocss'
+], function(TorqueLayerClass, CartoCSS) {
+
+  'use strict';
+
+  var Forma250Layer = TorqueLayerClass.extend({
+
+    options: {
+      table: 'peru_250_daily',
+      column: 'date',
+      data_aggregation: 'cumulative',
+      cartocss: CartoCSS
+    }
+
+  });
+
+  return Forma250Layer;
+
+});

--- a/app/assets/javascripts/map/views/timeline/Forma250Timeline.js
+++ b/app/assets/javascripts/map/views/timeline/Forma250Timeline.js
@@ -1,0 +1,28 @@
+/**
+ * The FORMA 250 Alerts timeline.
+ *
+ * @return Forma250Timeline class (extends * TorqueTimelineClass)
+ */
+define([
+  'moment',
+  'abstract/timeline/TorqueTimelineClass'
+], function(moment, TorqueTimelineClass) {
+
+  'use strict';
+
+  var Forma250Timeline = TorqueTimelineClass.extend({
+
+    initialize: function(layer, currentDate) {
+      this.options = {
+        dateRange: [moment(layer.mindate), moment(layer.maxdate)],
+        player: false
+      };
+
+      Forma250Timeline.__super__.initialize.apply(this, [layer, currentDate]);
+    }
+
+  });
+
+  return Forma250Timeline;
+
+});


### PR DESCRIPTION
Adds a layer to test out the forma 250 data (for Peru). Mostly a standard layer addition, but also introduces a method to fit the map to the geometry bounds in the layerspec when selecting the layer from the menu.

@apercas This adds a new column to the layerspec: `fit_to_geom` that the MapPresenter uses to decide whether or not to try and fit to the geometry bounds. Does the staging server use `layerspec_nuclear_hazard`?

Test it out: http://localhost:5000/map/10/-5.75/-77.20/ALL/grayscale/forma_250?begin=2015-03-22&end=2015-11-16