### PR TITLE
Change year in FAQ from 2015 to 2016

### DIFF
--- a/app/views/static/getinvolved.html.erb
+++ b/app/views/static/getinvolved.html.erb
@@ -199,7 +199,7 @@
                     </li>
                   </ul>
 
-                  <p><strong>Our larger project won’t be completed by December 31, 2015. Can I still apply?</strong></p>
+                  <p><strong>Our larger project won’t be completed by December 31, 2016. Can I still apply?</strong></p>
                   <ul class='bullets'>
                     <li>
                       Yes. However, in your application, you must


### PR DESCRIPTION
The date was wrong in an FAQ - should be December 31, 2016