### PR TITLE
Updated text for non-standard coordinates

### DIFF
--- a/app/views/shared/_notifications.html.erb
+++ b/app/views/shared/_notifications.html.erb
@@ -48,7 +48,7 @@
     <p>This browser does not support clipboard access, please update</p>
   </div>
   <div id="coordinates-not-standard" data-type="info">
-    <p>The provided coordinated has not the 0°0'0"NSEW standard. Using the Address searchbox instead.</p>
+    <p>The provided coordinates do not follow the 0°0'0"NSEW standard. Use the Address searchbox instead.</p>
   </div>
   <div id="open-forest-change-layer" data-type="info">
     <p>Please turn on a Forest Change layer to analyze before using the analysis tool.</p>


### PR DESCRIPTION
Fixed typo in error message text when user enters non-standard coordinates.