### PR TITLE
Fixed typo in spelling of WRI

### DIFF
--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -106,7 +106,7 @@
                     <li><a target='_blank' href='https://www.gov.uk/government/organisations/department-for-international-development' class='ukaid'></a></li>
                     <li><a target='_blank' href='http://www.usaid.gov/' class='usaid'></a></li>
                     <li><a target='_blank' title="Vizzuality" href='http://www.vizzuality.com' class='vizzuality'></a></li>
-                    <li><a target='_blank' title="World Resorces Institute" href='http://www.wri.org' class='wri'></a></li>
+                    <li><a target='_blank' title="World Resources Institute" href='http://www.wri.org' class='wri'></a></li>
                   </ul>
                 </li>
             <div class="content">


### PR DESCRIPTION
Changed "World Resorces Institute" to correct spelling.