### PR TITLE
Cache until the end of the day, rather than 24 hours later

### DIFF
--- a/app/assets/javascripts/map/services/CartoDbLayerDateService.js
+++ b/app/assets/javascripts/map/services/CartoDbLayerDateService.js
@@ -1,7 +1,7 @@
 define([
-  'Class', 'uri', 'bluebird',
+  'Class', 'uri', 'bluebird', 'moment',
   'map/services/DataService'
-], function (Class, UriTemplate, Promise, ds) {
+], function (Class, UriTemplate, Promise, moment, ds) {
 
   'use strict';
 
@@ -21,8 +21,11 @@ define([
       var sql = 'SELECT MIN('+this.dateAttribute+') AS min_date, MAX('+this.dateAttribute+') AS max_date FROM '+this.table,
           url = new UriTemplate(URL).fillFromObject({q: sql});
 
+      var endOfDay = moment().endOf('day'),
+          secondsToEndOfDay = endOfDay.diff(moment()) / 1000;
+
       ds.define(REQUEST_ID, {
-        cache: {type: 'persist', duration: 1, unit: 'days'},
+        cache: {type: 'persist', duration: secondsToEndOfDay, unit: 'seconds'},
         url: url,
         type: 'GET'
       });

--- a/app/assets/javascripts/map/services/TorqueDateService.js
+++ b/app/assets/javascripts/map/services/TorqueDateService.js
@@ -15,8 +15,11 @@ define([
     },
 
     _defineRequests: function() {
+      var endOfDay = moment().endOf('day'),
+          secondsToEndOfDay = endOfDay.diff(moment()) / 1000;
+
       var config = {
-        cache: {type: 'persist', duration: 1, unit: 'days'},
+        cache: {type: 'persist', duration: secondsToEndOfDay, unit: 'seconds'},
         url: this._getUrl(),
         type: 'POST',
         dataType: 'jsonp'


### PR DESCRIPTION
It seems that some of the issues related to GLAD dates were due to the cache. In particular, the dates would be cached for 24 hours, which meant that you might not necessarily see new data, depending on when you last viewed the layer.