### PR TITLE
Map: fixing mousewheel behaviour in custom infowindows

### DIFF
--- a/app/assets/javascripts/map/views/layers/CustomInfowindow.js
+++ b/app/assets/javascripts/map/views/layers/CustomInfowindow.js
@@ -102,6 +102,7 @@ define([
       this.div_.parentNode.removeChild(this.div_);
       this.div_ = null;
     }
+    if(this.map) this.map.setOptions({ scrollwheel: true });
     this.setMap(null);
     mps.publish('Infowindow/close');
   };


### PR DESCRIPTION
If you close the infowindow by clicking the "X" icon, mousewheel map option will be enabled again