### PR TITLE
Subscription migration support

### DIFF
--- a/app/assets/javascripts/connect/views/SubscriptionListView.js
+++ b/app/assets/javascripts/connect/views/SubscriptionListView.js
@@ -54,11 +54,22 @@ define([
       if (urlParams.subscription_confirmed === 'true') {
         mps.publish('Notification/open', ['my-gfw-subscription-confirmed']);
       }
+
       if (urlParams.subscription_confirmation_sent === 'true') {
         mps.publish('Notification/open', ['my-gfw-subscription-confirmation-sent']);
       }
+
       if (urlParams.unsubscribed === 'true') {
         mps.publish('Notification/open', ['my-gfw-subscription-deleted']);
+      }
+
+      if (urlParams.migration_successful === 'true') {
+        mps.publish('Notification/open', ['my-gfw-subscription-migrated']);
+      }
+
+      if (urlParams.migration_id !== undefined) {
+        window.location = window.gfw.config.GFW_API_HOST + '/v2/migrations/' +
+          urlParams.migration_id + '/migrate';
       }
     },
 

--- a/app/views/shared/_notifications.html.erb
+++ b/app/views/shared/_notifications.html.erb
@@ -90,6 +90,10 @@
     <p>Your subscription has been removed and you will no longer receive emails for it.</p>
   </div>
 
+  <div id="my-gfw-subscription-migrated" data-type="info">
+    <p>Your previous subscriptions have been migrated to this account, and you will continue to receive forest change alerts as normal.</p>
+  </div>
+
   <div id="my-gfw-profile-errors" data-type="info">
     <p>Please enter your email to sign up as an official tester.</p>
   </div>


### PR DESCRIPTION
A little bit of code to redirect back to the API from subscription migrations. This allows us to use the existing log-in UI for users who have not visited before (which is likely for migrations).