### PR TITLE
Country: policy links enabled

### DIFF
--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -56,6 +56,7 @@ class CountriesController < ApplicationController
 
     def find_by_iso(iso)
       unless iso.blank?
+        # &cache=bust if you want to flush the cache
         iso = iso.downcase
         response = Typhoeus.get(
             "#{ENV['GFW_API_HOST']}/countries/#{iso}?thresh=30",

--- a/app/views/countries/show.html.erb
+++ b/app/views/countries/show.html.erb
@@ -532,11 +532,19 @@
                 </div>
               </div>
               <div class="section-content">
-                <% if @country['national_policy_link'].present? %>
-                  <div class="national-policy-links">
-                    <%= link_to @country['national_policy_title'].present? ? @country['national_policy_title'] : 'National Forest Policy', @country['national_policy_link'] %>
-                  </div>
-                <% end %>
+                <ul>
+                  <% if @country['national_policy_link'].present? %>
+                    <li class="national-policy-links">
+                      <%= link_to @country['national_policy_title'].present? ? @country['national_policy_title'] : 'National Forest Policy', @country['national_policy_link'] %>
+                    </li>
+                  <% end %>
+                  <% if @country['policy_links'].present? %>
+                    <% JSON.parse(@country['policy_links']).each do |link| %>
+                      <li><%= link_to link['title'], link['url'], :target => '_blank' %></li>
+                    <% end %>
+                  <% end %>
+                </ul>
+
                 <%= link_to 'Are we missing a link?', 'mailto:gfw@wri.org', class: 'btn-rdn btn-rdn-primary' %>
               </div>
             </section>


### PR DESCRIPTION
We need to add the column in the sql in the GFW API and deploy the API to pro. The name of the column is 'policy_links'. Hey Adam, could you do it?
 
https://github.com/Vizzuality/gfw-api/blob/master/gfw/countries/countries.py#L50
