### PR TITLE
Save subscription email to user's profile

### DIFF
--- a/app/assets/javascripts/map/models/UserModel.js
+++ b/app/assets/javascripts/map/models/UserModel.js
@@ -7,6 +7,12 @@ define([
   var User = Backbone.Model.extend({
     url: window.gfw.config.GFW_API_HOST + '/user',
 
+    setEmailIfEmpty: function(email) {
+      if (_.isEmpty(this.get('email'))) {
+        this.set('email', email);
+      }
+    },
+
     isLoggedIn: function() {
       return !_.isEmpty(this.attributes);
     },

--- a/app/assets/javascripts/map/views/tabs/SubscribeView.js
+++ b/app/assets/javascripts/map/views/tabs/SubscribeView.js
@@ -166,6 +166,10 @@ define([
       this.subscription.set('name',
         this.$el.find('#subscriptionName').val());
 
+      this.stopListening(this.user);
+      this.user.setEmailIfEmpty(this.subscription.get('email'));
+      this.user.save();
+
       this.subscription.save().
         then(this.onSave.bind(this)).
         fail(this.close.bind(this));

--- a/jstest/spec/SubscribeView_spec.js
+++ b/jstest/spec/SubscribeView_spec.js
@@ -1,0 +1,53 @@
+define([
+  'backbone', 'jquery',
+  'map/views/tabs/SubscribeView',
+  'map/models/UserModel',
+], function(Backbone, $, SubscribeView, User) {
+
+  'use strict';
+
+  describe('SubscribeView', function() {
+
+    describe('.subscribe', function() {
+
+      var user,
+          context,
+          email = 'new@email.com';
+
+      beforeEach(function() {
+        user = new User();
+        spyOn(user, 'save');
+
+        window.ga = function() {};
+        var subscription = new (Backbone.Model.extend({
+          url: '/', defaults: {email: email}}))();
+
+        context = {
+          user: user,
+          subscription: subscription,
+          onSave: function() {},
+          close: function() {},
+          showSpinner: function() {},
+          stopListening: function() {},
+          '$el': $('<div>')
+        };
+      });
+
+      it('updates the user email if they do not have one', function() {
+        SubscribeView.prototype.subscribe.call(context);
+        expect(user.get('email')).toEqual(email);
+        expect(user.save).toHaveBeenCalled();
+      });
+
+      it('does not update the user email if they have one', function() {
+        user.set('email', 'old@email.com');
+        SubscribeView.prototype.subscribe.call(context);
+        expect(user.get('email')).toEqual('old@email.com');
+        expect(user.save).toHaveBeenCalled();
+      });
+
+    });
+
+  });
+
+});

--- a/jstest/spec/UserModel_spec.js
+++ b/jstest/spec/UserModel_spec.js
@@ -1,0 +1,32 @@
+define([
+  'map/models/UserModel',
+], function(User) {
+
+  'use strict';
+
+  describe('UserModel', function() {
+
+    describe('.setEmailIfEmpty', function() {
+
+      var user;
+
+      beforeEach(function() {
+        user = new User();
+      });
+
+      it('updates the email if the user has no email', function() {
+        user.setEmailIfEmpty('new@email.com');
+        expect(user.get('email')).toEqual('new@email.com');
+      });
+
+      it('does not update the email if the user already has an email', function() {
+        user.set('email', 'old@email.com');
+        user.setEmailIfEmpty('new@email.com');
+        expect(user.get('email')).toEqual('old@email.com');
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
If a user does not already have an email on their profile, use the email input in to a subscription instead.