### PR TITLE
Move away from Mandrill

### DIFF
--- a/app/mailers/mobile_download.rb
+++ b/app/mailers/mobile_download.rb
@@ -23,6 +23,6 @@ class MobileDownload < ActionMailer::Base
 
     mail :subject => subject,
          :to      => email_address,
-         :from    => 'gfw@wri.org'
+         :from    => 'no-reply@globalforestwatch.org'
   end
 end

--- a/app/mailers/your_mailer.rb
+++ b/app/mailers/your_mailer.rb
@@ -9,7 +9,7 @@ class YourMailer < ActionMailer::Base
 
     mail :subject => "GFW Feedback",
          :to      => emails,
-         :from    => 'feedback@wri.com',
+         :from    => 'feedback@globalforestwatch.org',
          :template_path => 'your_mailer',
          :template_name => 'feedback'
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,14 +49,15 @@ module Gfw
       ]
     end)
 
+    config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {
-      :address   => "smtp.mandrillapp.com",
-      :port      => 25, # ports 587 and 2525 are also supported with STARTTLS
-      :enable_starttls_auto => true, # detects and uses STARTTLS
-      :user_name => ENV["MANDRILL_USERNAME"],
-      :password  => ENV["MANDRILL_APIKEY"], # SMTP password is any valid API key
-      :authentication => 'login', # Mandrill supports 'plain' or 'login'
-      :domain => 'globalforestwatch.org', # your domain to identify your server when connecting
+      :address   => "smtp.sparkpostmail.com",
+      :port      => 587, # ports 587 and 2525 are also supported with STARTTLS
+      :enable_starttls_auto => true,
+      :user_name => ENV["SMTP_USERNAME"],
+      :password  => ENV["SMTP_PASSWORD"],
+      :authentication => 'login',
+      :domain => 'globalforestwatch.org',
     }
 
   end


### PR DESCRIPTION
Mandrill is merging in to the MailChimp plan, which makes things a little more complicated regarding payment, so we're switching to SparkPost.