### PR TITLE
Map: country layers do not select automatically any layer

### DIFF
--- a/app/assets/javascripts/map/views/tabs/CountriesView.js
+++ b/app/assets/javascripts/map/views/tabs/CountriesView.js
@@ -145,19 +145,10 @@ define([
     renderIsoLayer: function(layersToRender){
       this.$layers.html(this.templateIso({ layers: layersToRender }));
       this._renderHtml();
-      this._selectSubIsoLayer();
     },
 
     _renderHtml: function(){
       this.$layers.find('.layers-list').html($('#country-layers .layers-list').html())
-    },
-
-    _selectSubIsoLayer: function() {
-      var parentSelected = this.$layers.find('.layer:first').hasClass('selected');
-      var subLayersSelected = this.$layers.find('.wrapped.selected').length > 0;
-      if (!subLayersSelected && parentSelected) {
-        this.$layers.find('.wrapped:first').click();
-      }
     },
 
     toggleLayer: function(event) {


### PR DESCRIPTION
Sharing link didn't save activated data layers correctly.

The "share" link for the map when GLAD Alerts and Indonesia forest moratorium data was turned on opened tree plantations and forgot the dates selected for GLAD Alerts. Now, it doesn't do that