### PR TITLE
Map: country layers do not select automatically any layer

### DIFF
--- a/app/assets/javascripts/map/views/tabs/CountriesView.js
+++ b/app/assets/javascripts/map/views/tabs/CountriesView.js
@@ -145,19 +145,10 @@ define([
     renderIsoLayer: function(layersToRender){
       this.$layers.html(this.templateIso({ layers: layersToRender }));
       this._renderHtml();
-      this._selectSubIsoLayer();
     },
 
     _renderHtml: function(){
       this.$layers.find('.layers-list').html($('#country-layers .layers-list').html())
-    },
-
-    _selectSubIsoLayer: function() {
-      var parentSelected = this.$layers.find('.layer:first').hasClass('selected');
-      var subLayersSelected = this.$layers.find('.wrapped.selected').length > 0;
-      if (!subLayersSelected && parentSelected) {
-        this.$layers.find('.wrapped:first').click();
-      }
     },
 
     toggleLayer: function(event) {


### PR DESCRIPTION
Prevent issues when you share a country with the first layer activated. 