### PR TITLE
A couple of fixes for subscription alerts

### DIFF
--- a/app/assets/javascripts/map/presenters/tabs/AnalysisPresenter.js
+++ b/app/assets/javascripts/map/presenters/tabs/AnalysisPresenter.js
@@ -264,6 +264,11 @@ define([
         }
       }.bind(this);
 
+      if (params.fit_to_geom !== undefined) {
+        this.status.set('fit_to_geom', params.fit_to_geom)
+      }
+
+      var fit_to_geom = this.status.get('fit_to_geom') === 'true';
       if (params.analyze && params.name === 'map') {
         this.view.onClickAnalysis();
       } else if (params.wdpaid) {
@@ -274,13 +279,13 @@ define([
         if (params.geojson) {
           Promise.all([
             this._analyzeIso(params.iso),
-            this._analyzeGeojson(params.geojson)
+            this._analyzeGeojson(params.geojson, {draw: true, fit_to_geom: fit_to_geom})
           ]).then(subscribe);
         } else {
           this._analyzeIso(params.iso).then(subscribe);
         }
       } else if (params.geojson) {
-        this._analyzeGeojson(params.geojson).then(subscribe);
+        this._analyzeGeojson(params.geojson, {draw: true, fit_to_geom: fit_to_geom}).then(subscribe);
       } else if (params.geostore) {
         this.status.set('geostore', params.geostore);
         subscribe();
@@ -315,10 +320,18 @@ define([
       mps.publish('Spinner/start');
       resource = this._buildResource(resource);
 
+      var paths = geojsonUtilsHelper.geojsonToPath(geojson);
       // Draw geojson if needed.
       if (options.draw) {
-        this.view.drawPaths(
-          geojsonUtilsHelper.geojsonToPath(geojson));
+        this.view.drawPaths(paths);
+      }
+
+      if (options.fit_to_geom) {
+        var bounds = new google.maps.LatLngBounds();
+        paths.forEach(function(point) {
+          bounds.extend(point);
+        });
+        this.view.map.fitBounds(bounds);
       }
 
       // Publish analysis
@@ -815,6 +828,10 @@ define([
       } else if (resource.use && resource.useid) {
         p.use = resource.use;
         p.useid = resource.useid;
+      }
+
+      if (this.status.get('fit_to_geom')) {
+        p.fit_to_geom = 'true';
       }
 
       if (this.status.get('tab')) {

--- a/app/assets/javascripts/map/services/PlaceService.js
+++ b/app/assets/javascripts/map/services/PlaceService.js
@@ -66,7 +66,7 @@ define([
 
   var PlaceService = PresenterClass.extend({
 
-    _uriTemplate: '{name}{/zoom}{/lat}{/lng}{/iso}{/maptype}{/baselayers}{/sublayers}{?tab,geojson,geostore,wdpaid,begin,end,threshold,dont_analyze,hresolution,tour,subscribe,use,useid}',
+    _uriTemplate: '{name}{/zoom}{/lat}{/lng}{/iso}{/maptype}{/baselayers}{/sublayers}{?tab,fit_to_geom,geojson,geostore,wdpaid,begin,end,threshold,dont_analyze,hresolution,tour,subscribe,use,useid}',
 
     /**
      * Create new PlaceService with supplied Backbone.Router.

--- a/app/assets/javascripts/map/views/tabs/SubscribeView.js
+++ b/app/assets/javascripts/map/views/tabs/SubscribeView.js
@@ -147,7 +147,9 @@ define([
           }
         }
         this.subscription.set('geom', geom);
-      } else if (geostoreId) {
+      }
+
+      if (geostoreId) {
         this.subscription.set('geostore_id', geostoreId);
       }
     },


### PR DESCRIPTION
* always store geostore IDs, if they are available, so they can be processed by the API
* adds a fit_to_geom URL parameter, so links in emails will always fit the map bounds to the alert geometry