### PR TITLE
Fix VIIRS layer for subscriptions

### DIFF
--- a/app/assets/javascripts/abstract/timeline/TimelineBtnClass.js
+++ b/app/assets/javascripts/abstract/timeline/TimelineBtnClass.js
@@ -55,7 +55,6 @@ define([
       this.svg = {};
       this.xscale = {};
 
-
       enquire.register("screen and (min-width:"+window.gfw.config.GFW_MOBILE+"px)", {
         match: _.bind(function(){
           this.render(_.bind(function() {
@@ -66,13 +65,12 @@ define([
           }, this));
         },this)
       });
+
       enquire.register("screen and (max-width:"+window.gfw.config.GFW_MOBILE+"px)", {
         match: _.bind(function(){
           this.renderMobile();
         },this)
       });
-
-
     },
 
     renderMobile: function(){

--- a/app/assets/javascripts/map/helpers/FiresDatesHelper.js
+++ b/app/assets/javascripts/map/helpers/FiresDatesHelper.js
@@ -1,0 +1,40 @@
+define([
+  'moment',
+], function(moment) {
+
+  'use strict';
+
+  var AVAILABLE_DATE_RANGES = [{
+    start: moment().subtract(7, 'days').utc(),
+    end: moment().utc(),
+    label: 'past week',
+    duration: 24 * 7
+  }, {
+    start: moment().subtract(3, 'days').utc(),
+    end: moment().utc(),
+    label: 'past 72 hours',
+    duration: 72
+  }, {
+    start: moment().subtract(2, 'days').utc(),
+    end: moment().utc(),
+    label: 'past 48 hours',
+    duration: 48
+  }, {
+    start: moment().subtract(1, 'days').utc(),
+    end: moment().utc(),
+    label: 'past 24 hours',
+    duration: 24
+  }];
+
+  return {
+    getRangeForDates: function(dates) {
+      var duration = moment(dates[1]).diff(dates[0], 'hours'),
+          dateRange = _.findWhere(AVAILABLE_DATE_RANGES, {duration: duration});
+
+      return [dateRange.start, dateRange.end];
+    },
+
+    dateRanges: AVAILABLE_DATE_RANGES
+  };
+
+});

--- a/app/assets/javascripts/map/helpers/FiresDatesHelper.js
+++ b/app/assets/javascripts/map/helpers/FiresDatesHelper.js
@@ -28,7 +28,7 @@ define([
 
   return {
     getRangeForDates: function(dates) {
-      var duration = moment(dates[1]).diff(dates[0], 'hours'),
+      var duration = moment(dates[1]).diff(moment(dates[0]), 'hours'),
           dateRange = _.findWhere(AVAILABLE_DATE_RANGES, {duration: duration});
 
       return [dateRange.start, dateRange.end];

--- a/app/assets/javascripts/map/views/layers/FiresLayer.js
+++ b/app/assets/javascripts/map/views/layers/FiresLayer.js
@@ -9,8 +9,9 @@ define([
   'uri',
   'abstract/layer/CartoDBLayerClass',
   'map/presenters/layers/FiresLayerPresenter',
+  'map/helpers/FiresDatesHelper',
   'text!map/cartocss/global_7d.cartocss'
-], function(_, moment, UriTemplate, CartoDBLayerClass, Presenter, global7dCartoCSS) {
+], function(_, moment, UriTemplate, CartoDBLayerClass, Presenter, DatesHelper, global7dCartoCSS) {
 
   'use strict';
 
@@ -26,9 +27,10 @@ define([
       _.bindAll(this, 'setCurrentDate');
       this.presenter = new Presenter(this);
 
-      // Default to 48 hours
-      this.setCurrentDate(options.currentDate ||
-        [moment().subtract(24, 'hours'), moment()]);
+      // Default to 24 hours
+      var currentDate = options.currentDate ||
+        [moment().subtract(24, 'hours'), moment()];
+      this.setCurrentDate(DatesHelper.getRangeForDates(currentDate));
 
       this._super(layer, options, map);
     },

--- a/app/assets/javascripts/map/views/layers/ViirsLayer.js
+++ b/app/assets/javascripts/map/views/layers/ViirsLayer.js
@@ -10,7 +10,8 @@ define([
   'abstract/layer/CartoDBLayerClass',
   'text!map/cartocss/viirs.cartocss',
   'map/presenters/layers/FiresLayerPresenter',
-], function(_, moment, UriTemplate, CartoDBLayerClass,ViirsCarto, Presenter) {
+  'map/helpers/FiresDatesHelper'
+], function(_, moment, UriTemplate, CartoDBLayerClass, ViirsCarto, Presenter, DatesHelper) {
 
   'use strict';
 
@@ -26,9 +27,10 @@ define([
       _.bindAll(this, 'setCurrentDate');
       this.presenter = new Presenter(this);
 
-      // Default to 48 hours
-      this.setCurrentDate(options.currentDate ||
-        [moment().subtract(24, 'hours'), moment()]);
+      // Default to 24 hours
+      var currentDate = options.currentDate ||
+        [moment().subtract(24, 'hours'), moment()];
+      this.setCurrentDate(DatesHelper.getRangeForDates(currentDate));
 
       this._super(layer, options, map);
     },

--- a/app/assets/javascripts/map/views/timeline/FiresTimeline.js
+++ b/app/assets/javascripts/map/views/timeline/FiresTimeline.js
@@ -4,35 +4,13 @@
  * @return FiresTimeline class (extends TimelineBtnClass)
  */
 define([
-  'underscore',
-  'moment',
+  'underscore', 'moment',
   'abstract/timeline/TimelineBtnClass',
-  'map/presenters/TimelineClassPresenter'
-], function(_, moment, TimelineBtnClass, Presenter) {
+  'map/presenters/TimelineClassPresenter',
+  'map/helpers/FiresDatesHelper'
+], function(_, moment, TimelineBtnClass, Presenter, DatesHelper) {
 
   'use strict';
-
-  var data = [{
-    start: moment().subtract(7, 'days').utc(),
-    end: moment().utc(),
-    label: 'Past week',
-    hoursDiff: 24 * 7
-  },{
-    start: moment().subtract(3, 'days').utc(),
-    end: moment().utc(),
-    label: 'Past 72 hours',
-    hoursDiff: 72
-  },{
-    start: moment().subtract(2, 'days').utc(),
-    end: moment().utc(),
-    label: 'Past 48 hours',
-    hoursDiff: 48
-  },{
-    start: moment().subtract(1, 'days').utc(),
-    end: moment().utc(),
-    label: 'Past 24 hours',
-    hoursDiff: 24
-  }];
 
   var FiresTimeline = TimelineBtnClass.extend({
 
@@ -46,26 +24,13 @@ define([
         tipsy: false
       };
 
-      if (currentDate) {
-        currentDate = this.setCurrentDate(currentDate);
+      if (!(currentDate && currentDate[0] && currentDate[1])) {
+        currentDate = [moment().subtract(24, 'hours'), moment()];
       }
+      currentDate = DatesHelper.getRangeForDates(currentDate);
+
 
       FiresTimeline.__super__.initialize.apply(this, [layer, currentDate]);
-    },
-
-    /**
-     * To make fires layer bookmarkable we need to
-     * convert the url date to current valid dates.
-     * eg. last month day 29 to 30 should be last 24 hours.
-     *
-     *
-     * @param {Array} currentDate [moment, moment]
-     */
-    setCurrentDate: function(currentDate) {
-      var hoursDiff = moment(currentDate[1]).diff(currentDate[0], 'hours');
-      var dataItem = _.findWhere(data, {hoursDiff: hoursDiff});
-      currentDate = [dataItem.start, dataItem.end];
-      return currentDate;
     },
 
     /**
@@ -74,7 +39,7 @@ define([
      * @return {array} Array of quarterly.
      */
     _getData: function() {
-      return data;
+      return DatesHelper.dateRanges;
     }
   });
 

--- a/jstest/spec/AnalysisPresenter_spec.js
+++ b/jstest/spec/AnalysisPresenter_spec.js
@@ -1,7 +1,7 @@
 define([
-  'underscore', 'backbone',
+  'underscore', 'backbone', 'moment',
   'map/presenters/tabs/AnalysisPresenter',
-], function(_, Backbone, AnalysisPresenter) {
+], function(_, Backbone, moment, AnalysisPresenter) {
 
   describe('AnalysisPresenter', function() {
 
@@ -17,7 +17,8 @@ define([
             'loss': 'umd-loss-gain',
             'forestgain': 'umd-loss-gain',
             'forest2000': 'umd-loss-gain',
-            'viirs_fires_alerts': 'viirs-active-fires'
+            'viirs_fires_alerts': 'viirs-active-fires',
+            'afakelayer': 'fl'
           }
         };
 
@@ -37,7 +38,7 @@ define([
       describe('when a baselayer is selected', function() {
         beforeEach(function() {
           this.status.set('baselayer', {
-            slug: 'viirs_fires_alerts'
+            slug: 'afakelayer'
           });
         });
 
@@ -68,7 +69,7 @@ define([
         });
 
         it('stores the dataset on the resource', function() {
-          expect(this.method({}).dataset).toEqual('viirs-active-fires');
+          expect(this.method({}).dataset).toEqual('fl');
         });
       });
 
@@ -160,10 +161,32 @@ define([
         });
       });
 
-      describe('when a baselayer that is not loss, forestgain or forest2000 is selected', function() {
+      describe('when the viirs baselayer is selected', function() {
         beforeEach(function() {
           this.status.set('baselayer', {
             slug: 'viirs_fires_alerts'
+          });
+        });
+
+        describe('with a date far in the past', function() {
+          beforeEach(function() {
+            this.status.set('date', ['2014-03-03', '2014-03-04']);
+          });
+
+          it('transforms the dates to the most recent valid range', function() {
+            var expectedPeriod = [
+              moment().subtract(1, 'days').utc().format('YYYY-MM-DD'),
+              moment().utc().format('YYYY-MM-DD')].join(',');
+
+            expect(this.method({}).period).toEqual(expectedPeriod);
+          });
+        });
+      });
+
+      describe('when a baselayer that is not loss, forestgain or forest2000 is selected', function() {
+        beforeEach(function() {
+          this.status.set('baselayer', {
+            slug: 'afakelayer'
           });
         });
 

--- a/jstest/spec/AnalysisPresenter_spec.js
+++ b/jstest/spec/AnalysisPresenter_spec.js
@@ -1,0 +1,179 @@
+define([
+  'underscore', 'backbone',
+  'map/presenters/tabs/AnalysisPresenter',
+], function(_, Backbone, AnalysisPresenter) {
+
+  describe('AnalysisPresenter', function() {
+
+    describe('_buildResource', function() {
+
+      beforeEach(function() {
+        this.status = new (Backbone.Model.extend({
+          defaults: {date: []}}))();
+
+        var context = {
+          status: this.status,
+          datasets: {
+            'loss': 'umd-loss-gain',
+            'forestgain': 'umd-loss-gain',
+            'forest2000': 'umd-loss-gain',
+            'viirs_fires_alerts': 'viirs-active-fires'
+          }
+        };
+
+        this.method = AnalysisPresenter.prototype._buildResource.bind(context);
+      });
+
+      describe('when there is no baselayer selected', function() {
+        beforeEach(function() {
+          this.status.unset('baselayer');
+        });
+
+        it('returns the resource unchanged', function() {
+          expect(this.method({})).toEqual({});
+        });
+      });
+
+      describe('when a baselayer is selected', function() {
+        beforeEach(function() {
+          this.status.set('baselayer', {
+            slug: 'viirs_fires_alerts'
+          });
+        });
+
+        describe('given a geostore ID', function() {
+          beforeEach(function() {
+            this.status.set('geostore', '1234');
+          });
+
+          it('stores the geostore ID on the resource', function() {
+            expect(this.method({}).geostore).toEqual('1234');
+          });
+        });
+
+        describe('given a date', function() {
+          beforeEach(function() {
+            this.status.set('date', ['2002-02-02', '2003-03-03']);
+          });
+
+          it('formats the period as YYYY-MM-DD,YYYY-MM-DD', function() {
+            expect(this.method({}).period).toEqual('2002-02-02,2003-03-03');
+          });
+        });
+
+        describe('given no date', function() {
+          it('formats the default period as YYYY-MM-DD,YYYY-MM-DD', function() {
+            expect(this.method({}).period).toEqual('2001-01-01,2014-12-31');
+          });
+        });
+
+        it('stores the dataset on the resource', function() {
+          expect(this.method({}).dataset).toEqual('viirs-active-fires');
+        });
+      });
+
+      describe('when the forestgain baselayer is selected', function() {
+        beforeEach(function() {
+          this.status.set('baselayer', {
+            slug: 'forestgain'
+          });
+        });
+
+        it('defaults to a fixed period', function() {
+          expect(this.method({}).period).toEqual('2001-01-01,2013-12-31');
+        });
+
+        describe('with a threshold selected', function() {
+          beforeEach(function() {
+            this.status.set('threshold', 40);
+          });
+
+          it('stores the threshold on the resource', function() {
+            expect(this.method({}).thresh).toEqual('?thresh=40');
+          });
+        });
+
+        describe('with no threshold selected', function() {
+          beforeEach(function() {
+            this.status.set('threshold', null);
+          });
+
+          it('defaults to a threshold of 30', function() {
+            expect(this.method({}).thresh).toEqual('?thresh=30');
+          });
+        });
+      });
+
+      describe('when the loss baselayer is selected', function() {
+        beforeEach(function() {
+          this.status.set('baselayer', {
+            slug: 'loss'
+          });
+        });
+
+        describe('with a threshold selected', function() {
+          beforeEach(function() {
+            this.status.set('threshold', 40);
+          });
+
+          it('stores the threshold on the resource', function() {
+            expect(this.method({}).thresh).toEqual('?thresh=40');
+          });
+        });
+
+        describe('with no threshold selected', function() {
+          beforeEach(function() {
+            this.status.set('threshold', null);
+          });
+
+          it('defaults to a threshold of 30', function() {
+            expect(this.method({}).thresh).toEqual('?thresh=30');
+          });
+        });
+      });
+
+      describe('when the forest2000 baselayer is selected', function() {
+        beforeEach(function() {
+          this.status.set('baselayer', {
+            slug: 'forest2000'
+          });
+        });
+
+        describe('with a threshold selected', function() {
+          beforeEach(function() {
+            this.status.set('threshold', 40);
+          });
+
+          it('stores the threshold on the resource', function() {
+            expect(this.method({}).thresh).toEqual('?thresh=40');
+          });
+        });
+
+        describe('with no threshold selected', function() {
+          beforeEach(function() {
+            this.status.set('threshold', null);
+          });
+
+          it('defaults to a threshold of 30', function() {
+            expect(this.method({}).thresh).toEqual('?thresh=30');
+          });
+        });
+      });
+
+      describe('when a baselayer that is not loss, forestgain or forest2000 is selected', function() {
+        beforeEach(function() {
+          this.status.set('baselayer', {
+            slug: 'viirs_fires_alerts'
+          });
+        });
+
+        it('does not set a threshold', function() {
+          expect(this.method({}).thresh).toBeUndefined();
+        });
+      });
+
+    });
+
+  });
+
+});

--- a/jstest/spec/AnalysisResultsPresenter_spec.js
+++ b/jstest/spec/AnalysisResultsPresenter_spec.js
@@ -64,16 +64,6 @@ define([
         presenter._renderResults(AnalysisServiceResponse.fires);
         expect(presenter._renderAnalysis.calls.count()).toEqual(1);
       });
-
-      it('should render failure message from a failure response', function() {
-        presenter._renderResults({failure: true});
-        expect(viewSpy.renderFailure.calls.count()).toEqual(1);
-      });
-
-      it('should render unavailable message from a unvalid resource', function() {
-        presenter._renderResults({unavailable: true});
-        expect(viewSpy.renderFailure.calls.count()).toEqual(1);
-      });
     });
 
     describe('deleteAnalysis()', function() {


### PR DESCRIPTION
Previously the VIIRS layer would break if you visit URLs with begin/end dates in the past...no more! I also wrote some pretty comprehensive tests for the `_buildResource` method for Analyses so that I could tear it apart and refactor it :+1: 

Example:

This doesn't work (the layer shows alerts but the analysis says 0):
http://staging.globalforestwatch.org/map/9/8.90/-11.39/ALL/grayscale/viirs_fires_alerts?tab=analysis-tab&fit_to_geom=true&geojson=%257B%2522type%2522%253A%2522Polygon%2522%252C%2522coordinates%2522%253A%255B%255B%255B-12.1619%252C9.1618%255D%252C%255B-11.1292%252C9.6224%255D%252C%255B-10.8929%252C9.4328%255D%252C%255B-10.7831%252C9.0587%255D%252C%255B-10.6128%252C8.6625%255D%252C%255B-10.7831%252C8.255%255D%252C%255B-11.3818%252C8.1734%255D%252C%255B-11.662%252C8.6733%255D%252C%255B-12.1619%252C9.1618%255D%255D%255D%257D&begin=2016-03-06&end=2016-03-07

This will work, when you change to this branch:
http://localhost:5000/map/9/8.90/-11.39/ALL/grayscale/viirs_fires_alerts?tab=analysis-tab&fit_to_geom=true&geojson=%257B%2522type%2522%253A%2522Polygon%2522%252C%2522coordinates%2522%253A%255B%255B%255B-12.1619%252C9.1618%255D%252C%255B-11.1292%252C9.6224%255D%252C%255B-10.8929%252C9.4328%255D%252C%255B-10.7831%252C9.0587%255D%252C%255B-10.6128%252C8.6625%255D%252C%255B-10.7831%252C8.255%255D%252C%255B-11.3818%252C8.1734%255D%252C%255B-11.662%252C8.6733%255D%252C%255B-12.1619%252C9.1618%255D%255D%255D%257D&begin=2016-03-06&end=2016-03-07