### PR TITLE
Map: check if date is already set

### DIFF
--- a/app/assets/javascripts/map/presenters/tabs/AnalysisPresenter.js
+++ b/app/assets/javascripts/map/presenters/tabs/AnalysisPresenter.js
@@ -82,7 +82,9 @@ define([
     }, {
       'Place/go': function(place) {
         this._setBaselayer(place.layerSpec.getBaselayers());
-        this.status.set('date', [place.params.begin, place.params.end]);
+        if (! !!this.status.get('date')) {
+          this.status.set('date', [place.params.begin, place.params.end]);
+        }
         this.status.set('threshold', place.params.threshold);
         this.status.set('dont_analyze', place.params.dont_analyze);
         this._handlePlaceGo(place.params);


### PR DESCRIPTION
Hey @adammulligan, there is an issue related to this url: [glad](http://www.globalforestwatch.org/glad)

What I've found is that the 'Place/go' event happens after the 'TorqueLayer' has set the dates. So, it tries to get the dates from the url but at this moment they are equal to null. My solution is to check if the status.date exists before changing it. I really don't like it and it may cause some issues with other layers.

Let me know if you find a better solution