### PR TITLE
Feature/mexico protected areas layer

### DIFF
--- a/app/assets/javascripts/map/cartocss/mexicanPA.cartocss
+++ b/app/assets/javascripts/map/cartocss/mexicanPA.cartocss
@@ -1,0 +1,10 @@
+#mex_protected_areas {
+   polygon-opacity: 0.5;
+   line-width: 0.2;
+   line-opacity: 1;
+   polygon-fill: #4D94C4;
+   line-color: #006CB5;
+}
+#mex_protected_areas[tipo='Federal'] {
+  polygon-opacity: 0.9;
+}

--- a/app/assets/javascripts/map/helpers/layersHelper.js
+++ b/app/assets/javascripts/map/helpers/layersHelper.js
@@ -82,6 +82,7 @@ define([
   'map/views/layers/BirdlifeLayer',
   'map/views/layers/AzepolyLayer',
   'map/views/layers/TigersLayer',
+  'map/views/layers/MexicanProtectedAreasLayer',
   'map/views/layers/CarbonLayer',
   'map/views/layers/DamHotspotsLayer',
   'map/views/layers/ColombiaForestChangeLayer',
@@ -241,6 +242,7 @@ define([
   BirdlifeLayer,
   AzepolyLayer,
   TigersLayer,
+  MexicanProtectedAreasLayer,
   CarbonLayer,
   DamHotspotsLayer,
   ColombiaForestChangeLayer,
@@ -573,6 +575,9 @@ define([
     },
     tigers: {
       view: TigersLayer
+    },
+    mexican_pa: {
+      view: MexicanProtectedAreasLayer
     },
     verified_carbon: {
       view: CarbonLayer

--- a/app/assets/javascripts/map/templates/infowindow.handlebars
+++ b/app/assets/javascripts/map/templates/infowindow.handlebars
@@ -27,7 +27,7 @@
             <h2><a href="{{content.data.project_ur}}" target="_blank">{{content.data.project_name}}</a></h2>
           {{else}}
             <h2>{{content.data.project_name}}</h2>
-          {{/if}}
+          {{/if}} 
         {{/if}}
         {{#if content.data.project_na}}
           {{#if content.data.project_ur}}
@@ -382,6 +382,10 @@
         {{#if content.data.validity}}
           <h4>Validity:</h4>
           <p>{{content.data.validity}}</p>
+        {{/if}}
+        {{#if content.data.tipo}}
+          <h4>Tipo:</h4>
+          <p>{{content.data.tipo}}</p>
         {{/if}}
       </div>
     </div>

--- a/app/assets/javascripts/map/templates/infowindow.handlebars
+++ b/app/assets/javascripts/map/templates/infowindow.handlebars
@@ -379,6 +379,10 @@
           <h4>Glad alerts slope trend for last six months:</h4>
           <p>{{content.data.slope_semester}}</p>
         {{/if}}
+        {{#if content.data.validity}}
+          <h4>Validity:</h4>
+          <p>{{content.data.validity}}</p>
+        {{/if}}
       </div>
     </div>
   </div>

--- a/app/assets/javascripts/map/views/layers/MexicanProtectedAreasLayer.js
+++ b/app/assets/javascripts/map/views/layers/MexicanProtectedAreasLayer.js
@@ -5,17 +5,19 @@
  */
 define([
   'abstract/layer/CartoDBLayerClass',
-], function(CartoDBLayerClass) {
+  'text!map/cartocss/mexicanPA.cartocss'
+], function(CartoDBLayerClass,mexicanPA) {
 
   'use strict';
 
   var MexicanProtectedAreasLayer = CartoDBLayerClass.extend({
 
     options: {
-      sql: 'SELECT cartodb_id, the_geom_webmercator, the_geom, nombre as name, cartodb_id, cat_manejo as category, superficie as surface, prim_dec as date_create, tipo as type, vigencia as validity, \'{tableName}\' AS tablename, {analysis} AS analysis, \'{tableName}\' as layer FROM {tableName}',
+      sql: 'SELECT the_geom_webmercator, the_geom, nombre as name, cartodb_id, cat_manejo as category, superficie as original_size_h, prim_dec as date_create, tipo, vigencia as validity, \'{tableName}\' AS tablename, {analysis} AS analysis, \'{tableName}\' as layer FROM {tableName}',
       infowindow: true,
-      interactivity: 'cartodb_id, tablename, name, category, surface, date_create, type, validity, analysis',
+      interactivity: 'cartodb_id, tablename, name, category, original_size_h, date_create, tipo, validity, analysis',
       analysis: true,
+      cartocss: mexicanPA
     },
 
   });

--- a/app/assets/javascripts/map/views/layers/MexicanProtectedAreasLayer.js
+++ b/app/assets/javascripts/map/views/layers/MexicanProtectedAreasLayer.js
@@ -1,0 +1,25 @@
+/**
+ * The MexicanProtectedAreas layer module.
+ *
+ * @return MexicanProtectedAreasLayer class (extends CartoDBLayerClass)
+ */
+define([
+  'abstract/layer/CartoDBLayerClass',
+], function(CartoDBLayerClass) {
+
+  'use strict';
+
+  var MexicanProtectedAreasLayer = CartoDBLayerClass.extend({
+
+    options: {
+      sql: 'SELECT cartodb_id, the_geom_webmercator, the_geom, nombre as name, cartodb_id, cat_magenjo as category, superficie as surface, prim_dec as date_create, tipo as type, vigencia as validity, \'{tableName}\' AS tablename, {analysis} AS analysis, \'{tableName}\' as layer FROM {tableName}',
+      infowindow: true,
+      interactivity: 'cartodb_id, tablename, name, category, surface, date_create, type, validity, analysis',
+      analysis: true,
+    },
+
+  });
+
+  return MexicanProtectedAreasLayer;
+
+});

--- a/app/assets/javascripts/map/views/layers/MexicanProtectedAreasLayer.js
+++ b/app/assets/javascripts/map/views/layers/MexicanProtectedAreasLayer.js
@@ -12,7 +12,7 @@ define([
   var MexicanProtectedAreasLayer = CartoDBLayerClass.extend({
 
     options: {
-      sql: 'SELECT cartodb_id, the_geom_webmercator, the_geom, nombre as name, cartodb_id, cat_magenjo as category, superficie as surface, prim_dec as date_create, tipo as type, vigencia as validity, \'{tableName}\' AS tablename, {analysis} AS analysis, \'{tableName}\' as layer FROM {tableName}',
+      sql: 'SELECT cartodb_id, the_geom_webmercator, the_geom, nombre as name, cartodb_id, cat_manejo as category, superficie as surface, prim_dec as date_create, tipo as type, vigencia as validity, \'{tableName}\' AS tablename, {analysis} AS analysis, \'{tableName}\' as layer FROM {tableName}',
       infowindow: true,
       interactivity: 'cartodb_id, tablename, name, category, surface, date_create, type, validity, analysis',
       analysis: true,


### PR DESCRIPTION
This PR adds a new CartoDB Layer for Mexico, displaying its country-owned protected areas:
![image](https://cloud.githubusercontent.com/assets/704210/15536478/b6972020-2271-11e6-9fb0-f41f289556f2.png)
