### PR TITLE
Version removed. Nightly version is the correct one for develop

### DIFF
--- a/app/views/shared/_gfw_assets.html.erb
+++ b/app/views/shared/_gfw_assets.html.erb
@@ -18,8 +18,4 @@
 
   };
 </script>
-<script type="text/javascript">     
-var version=null,assetsVersions=["a","b","c","d","e"],jsParams={get:function(e,s){s||(s=location.href),e=e.replace(/[\[]/,"\\[").replace(/[\]]/,"\\]");var t="[\\?&]"+e+"=([^&#]*)",o=new RegExp(t),n=o.exec(s);return null==n?null:n[1]}},jsCookiesHelper={get:function(e){if(document.cookie.length>0){var s=document.cookie.indexOf(e+"=");if(-1!=s){s=s+e.length+1;var t=document.cookie.indexOf(";",s);return-1==t&&(t=document.cookie.length),unescape(document.cookie.substring(s,t))}}return""},set:function(e,s,t){var o=new Date;o.setDate(o.getDate()+t),document.cookie=e+"="+escape(s)+(null==t?"":"; expires="+o.toUTCString())+"; path=/"},check:function(e){return e=jsCookiesHelper.get(e),null!=e&&""!=e}};jsParams.get("version")?(version=jsParams.get("version"),jsCookiesHelper.set("assets-version",version,30)):jsCookiesHelper.get("assets-version")?version=jsCookiesHelper.get("assets-version"):(version=assetsVersions[Math.floor(Math.random()*assetsVersions.length)],jsCookiesHelper.set("assets-version",version,30));var script=document.createElement("script");script.id="loader-gfw",script.src="http://gfw-assets.s3.amazonaws.com/static/gfw-assets.2.0.0-"+version+".js",script.dataset.current="<%= @currentNavigation %>",document.head.appendChild(script);
-</script>
-
-<!-- <script id="loader-gfw" data-current="<%= @currentNavigation %>" src="<%#= ENV['GFW_ASSETS_URL'] %>"></script> -->
+<script id="loader-gfw" data-current="<%= @currentNavigation %>" src="<%= ENV['GFW_ASSETS_URL'] %>"></script>


### PR DESCRIPTION
@adammulligan @aagm @apercas @davidsingal @d4weed Please set this var in your .env file `GFW_ASSETS_URL=http://gfw-assets.s3.amazonaws.com/static/gfw-assets.nightly.js`. Since now we will always have the nightly version on local develop and staging. And the http://gfw-assets.s3.amazonaws.com/static/gfw-assets.latest.js` version should be the one set at production. 

Her we have a little documentation of how to use the gfw-assets: https://docs.google.com/a/vizzuality.com/document/d/1m_v-L7WVmDlBhd5eGhnpmHPTmaQ8c7gVvwUTaJweVv4/edit?usp=sharing