### PR TITLE
Analytics cookie domain

### DIFF
--- a/app/views/shared/_js_footer.html.erb
+++ b/app/views/shared/_js_footer.html.erb
@@ -11,7 +11,7 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  ga('create', '<%= ENV["ANALYTICS_PROPERTY_ID"] %>', 'globalforestwatch.org');
+  ga('create', '<%= ENV["ANALYTICS_PROPERTY_ID"] %>', document.location.hostname);
   ga('require', 'displayfeatures');
   ga('send', 'pageview');
   ga('push','_trackPageview');


### PR DESCRIPTION
We are now going to use the document.location.hostname as they recommend on the documentation for the cookieDomain param. https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id#configuring_cookie_field_settings