### PR TITLE
Scale GLAD layer after z12

### DIFF
--- a/app/assets/javascripts/abstract/layer/AnimatedCanvasLayerClass.js
+++ b/app/assets/javascripts/abstract/layer/AnimatedCanvasLayerClass.js
@@ -114,19 +114,6 @@ define([
       }
     },
 
-    _drawCanvasImage: function(canvasData) {
-      var canvas = canvasData.canvas,
-          ctx = canvas.getContext('2d'),
-          image = canvasData.image;
-
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.drawImage(image, 0, 0);
-
-      var I = ctx.getImageData(0, 0, canvas.width, canvas.height);
-      this.filterCanvasImgdata(I.data, canvas.width, canvas.height, canvasData.z);
-      ctx.putImageData(I, 0, 0);
-    },
-
     filterCanvasImgdata: function() {
       throw('filterCanvasImgdata must be implemented');
     }

--- a/app/assets/javascripts/abstract/layer/CanvasLayerClass.js
+++ b/app/assets/javascripts/abstract/layer/CanvasLayerClass.js
@@ -121,7 +121,6 @@ define([
       if (zsteps < 0) {
         ctx.drawImage(image, 0, 0);
       } else {                                          // over the maxzoom, we'll need to scale up each tile
-
         ctx.imageSmoothingEnabled = false;              // disable pic enhancement
         ctx.mozImageSmoothingEnabled = false;
 
@@ -133,6 +132,7 @@ define([
 
         ctx.drawImage(image, srcX, srcY, srcW, srcH, 0, 0, 256, 256);
       }
+
       var I = ctx.getImageData(0, 0, canvas.width, canvas.height);
       this.filterCanvasImgdata(I.data, canvas.width, canvas.height, canvasData.z);
       ctx.putImageData(I, 0, 0);

--- a/app/assets/javascripts/map/views/layers/GladLayer.js
+++ b/app/assets/javascripts/map/views/layers/GladLayer.js
@@ -24,6 +24,7 @@ define([
       this._super(layer, options, map);
       this.presenter.setConfirmedStatus(options.layerOptions);
       this.options.showLoadingSpinner = true;
+      this.options.dataMaxZoom = 12;
       this._setupAnimation();
 
       this.currentDate = [


### PR DESCRIPTION
We only have tiles up to zoom 12 right now, so this changes makes any higher zoom levels use scaled up z12 imagery.