### PR TITLE
Subscription alerts language selector

### DIFF
--- a/app/assets/javascripts/connect/templates/subscriptionListItem.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionListItem.handlebars
@@ -28,6 +28,13 @@
       <span class="dataset">{{topics}}</span>
     </li>
     <li>Date of subscription: {{createdAt}} UTC</li>
+    <li>Language:
+      <span id="subscriptionLanguage">{{language}}</span>
+      <select data-placeholder="Select language" class="chosen-select default notranslate" id="subscriptionLanguageSelector">
+        <option value="EN">English</option>
+        <option value="PT">Portuguese</option>
+      </select>
+    </li>
   </ul>
 </td>
 

--- a/app/assets/javascripts/map/templates/tabs/subscribe.handlebars
+++ b/app/assets/javascripts/map/templates/tabs/subscribe.handlebars
@@ -68,7 +68,14 @@
 
     <div class="subscription-name-container">
       <input class="field" type="text" id="subscriptionName" placeholder="Area name">
-      <label for="subscriptionName">{{date}}</label>
+    </div>
+
+    <div class="subscription-language-container">
+      <label for="subscriptionLanguage">Receive alert emails in...</label>
+      <select data-placeholder="Select language" class="chosen-select default notranslate" id="subscriptionLanguage">
+        <option value="EN">English</option>
+        <option value="PT">Portuguese</option>
+      </select>
     </div>
 
     <button class="btn green uppercase" id="subscribe">Save</button>

--- a/app/assets/javascripts/map/views/layers/GladLayer.js
+++ b/app/assets/javascripts/map/views/layers/GladLayer.js
@@ -12,7 +12,7 @@ define([
 
   'use strict';
 
-  var TILE_URL = 'http://wri-tiles.s3.amazonaws.com/glad_test/test2{/z}{/x}{/y}.png';
+  var TILE_URL = 'http://wri-tiles.s3.amazonaws.com/glad_prod/tiles{/z}{/x}{/y}.png';
 
   var padNumber = function(number) {
     var s = "00" + number;

--- a/app/assets/javascripts/map/views/tabs/SubscribeView.js
+++ b/app/assets/javascripts/map/views/tabs/SubscribeView.js
@@ -38,6 +38,14 @@ define([
       }));
       this.setupAuthLinks();
       this.cache();
+
+      this.$('#subscriptionLanguage').chosen({
+        width: '100%',
+        allow_single_deselect: true,
+        inherit_select_classes: true,
+        no_results_text: 'Oops, nothing found!'
+      });
+
       return this;
     },
 
@@ -53,6 +61,7 @@ define([
     cache: function() {
       this.$spinner = this.$('.subscription-spinner-container');
       this.$subscriptionName = this.$el.find('#subscriptionName');
+      this.$subscriptionLanguage = this.$el.find('#subscriptionLanguage');
       this.$subscriptionEmail = this.$('#subscriptionEmail');
       this.$steps = this.$('.steps');
     },
@@ -107,10 +116,10 @@ define([
     onSubscribeClick: function() {
       this.showSpinner();
 
-      // window.ga('send', 'event', 'Map', 'Subscribe', 'Layer: ' +
-      //   this.presenter.subscription.get('topic') + ', Email: ' + this.presenter.subscription.get('email'));
-
-      this.presenter.subscribe(this.$subscriptionName.val());
+      this.presenter.subscribe(
+        this.$subscriptionName.val(),
+        this.$subscriptionLanguage.val()
+      );
     }
 
   });

--- a/app/assets/stylesheets/connect.scss
+++ b/app/assets/stylesheets/connect.scss
@@ -8,7 +8,7 @@
 @import "home-icons/*.png";
 
 // Global
-// This will load all common settings, mixins and styles needed 
+// This will load all common settings, mixins and styles needed
 @import "global/global";
 
 // Layouts
@@ -29,6 +29,7 @@
 @import "layouts/static";
 @import "modules/select";
 @import "modules/notifications";
+@import "modules/map/country-select";
 
 @import "modules/connect/shared";
 @import "modules/connect/profile-modal";

--- a/app/assets/stylesheets/modules/connect/_subscriptions.scss
+++ b/app/assets/stylesheets/modules/connect/_subscriptions.scss
@@ -131,6 +131,18 @@
     }
   }
 
+  #subscriptionLanguage.editing {
+    display: none;
+  }
+
+  #subscriptionLanguageSelector_chosen {
+    display: none;
+
+    &.editing {
+      display: inline-block;
+    }
+  }
+
   tr {
     display: flex;
     justify-content: space-between;
@@ -212,7 +224,7 @@
   h3 {
     margin-bottom: 20px;
     line-height: 1.25;
-    font-size: 18px;    
+    font-size: 18px;
   }
 
   .delete-button-container {

--- a/app/assets/stylesheets/modules/map/_subscription-modal.scss
+++ b/app/assets/stylesheets/modules/map/_subscription-modal.scss
@@ -132,6 +132,23 @@
 
 .subscription-name-container {
   width: 100%;
+  font-family: "Fira GFW Sans", "Fira Sans";
+}
+
+.subscription-language-container {
+  width: 100%;
+
+  .chosen-container.default .chosen-single {
+    border-radius: 4px;
+    color: #000;
+    text-transform: none;
+    line-height: 1.5em;
+    font-weight: normal;
+  }
+
+  .chosen-container .chosen-single span {
+    font-size: 15px;
+  }
 }
 
 .subscription-authentication {


### PR DESCRIPTION
* Lets users pick a language for subscription emails (right now, portuguese or english, but more coming)
* Updates GLAD tile URL so we can see recent alerts highlighted