### PR TITLE
Remove geostore/go from the place service

### DIFF
--- a/app/assets/javascripts/map/presenters/MapPresenter.js
+++ b/app/assets/javascripts/map/presenters/MapPresenter.js
@@ -35,10 +35,6 @@ define([
         this._onPlaceGo(place);
       }
     },{
-      'Geostore/go': function(geostore) {
-        this.status.set('geostore', geostore);
-      }
-    },{
       'LayerNav/change': function(layerSpec) {
         this._setLayers(layerSpec);
         this._fitToLayers(layerSpec.getLayers());
@@ -111,10 +107,6 @@ define([
       this._updateStatusModel(place.params);
       this._setLayers(place.layerSpec, place.params);
 
-      if (!!place.params.fit_to_geom && !!this.status.get('geostore') && !!this.status.get('geostore').geojson) {
-        this._fitToGeostore(this.status.get('geostore'));
-      }
-
       // Very weird my friend (if if if if if if)
       if ((!!place.params.iso && !!place.params.iso.country && place.params.iso.country == 'ALL') && ! !!place.params.wdpaid && ! !!place.params.geojson) {
         this.view.autolocateQuestion();
@@ -133,10 +125,6 @@ define([
 
       if (params.layer_options) {
         this.status.set('layerOptions', params.layer_options);
-      }
-
-      if (params.fit_to_geom) {
-        this.status.set('fit_to_geom', params.fit_to_geom === 'true');
       }
     },
 
@@ -179,16 +167,6 @@ define([
           bounds = new google.maps.LatLngBounds(southWest, northEast);
 
       this.view.fitBounds(bounds);
-    },
-
-    _fitToGeostore: function(geostore) {
-      if (this.status.get('fit_to_geom') === true) {
-        var paths = geojsonUtilsHelper.geojsonToPath(geostore.geojson),
-            bounds = new google.maps.LatLngBounds();
-
-        paths.forEach(function(point) { bounds.extend(point); });
-        this.view.map.fitBounds(bounds);
-      }
     },
 
     /**

--- a/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
+++ b/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
@@ -10,8 +10,7 @@ define([
   'moment',
   'mps',
   'map/services/RegionService',
-  'helpers/geojsonUtilsHelper'
-], function(PresenterClass, _, Backbone, moment, mps, RegionService, geojsonUtilsHelper) {
+], function(PresenterClass, _, Backbone, moment, mps, RegionService) {
 
   'use strict';
 
@@ -42,16 +41,6 @@ define([
       {
         'LayerNav/change': function(layerSpec) {
           this.status.set('baselayers_full', layerSpec.getBaselayers(), {silent: true});
-        }
-      },
-      {
-        'Geostore/go': function(response) {
-          this.status.set('geojson', response.data.attributes.geojson, {silent: true});
-        }
-      },
-      {
-        'Analysis/store-geojson': function(geojson) {
-          this.status.set('geojson', geojson, {silent: true});
         }
       },
       {

--- a/app/assets/javascripts/map/services/PlaceService.js
+++ b/app/assets/javascripts/map/services/PlaceService.js
@@ -137,12 +137,6 @@ define([
           mps.publish('Place/go', [place]);
         }, this)
       );
-
-      if (place.params.geostore) {
-        GeostoreService.get(place.params.geostore).then(function(geostore) {
-          mps.publish('Geostore/go', [geostore, place.params.fit_to_geom]);
-        });
-      }
     },
 
     /**


### PR DESCRIPTION
Remove 'Geostore/go' from the place service.

It will only fire when a geostore is set on the URL. The one in charge to get the geojson is the AnalysisDrawPresenter, no one else needs it.