### PR TITLE
Map: transifex translations does not break the layersNav

### DIFF
--- a/app/assets/javascripts/map/presenters/LayersNavPresenter.js
+++ b/app/assets/javascripts/map/presenters/LayersNavPresenter.js
@@ -17,6 +17,18 @@ define([
     init: function(view) {
       this.view = view;
       this._super();
+      this.listeners();
+    },
+
+    listeners: function() {
+      if (!!Transifex) {
+        Transifex.live.onTranslatePage(function(language_code) {
+          this.view.fixLegibility();
+        }.bind(this));
+        Transifex.live.onDynamicContent(function(new_strings) {
+          this.view.fixLegibility();
+        }.bind(this));
+      }
     },
 
     /**


### PR DESCRIPTION
This PR just add two listeners to prevent breaking the style of the layersNav on each translation
