### PR TITLE
Fix: Torque Calendar - Set min date from API (Glad, Terra-i)

### DIFF
--- a/app/assets/javascripts/abstract/timeline/TimelineDatePicker.js
+++ b/app/assets/javascripts/abstract/timeline/TimelineDatePicker.js
@@ -167,18 +167,25 @@ define([
       this.presenter.setTorqueDateRange(dateRange);
     },
 
+    setMinMaxDate: function(data) {
+      var tzOffset = new Date().getTimezoneOffset();
+      this.minDate = moment.utc(data.minDate).endOf('day');
+      this.maxDate = moment.utc(data.maxDate);
+
+      var minDate = this.minDate.clone().add(tzOffset, 'minutes').toDate();
+      var maxDate = this.maxDate.clone().add(tzOffset, 'minutes').toDate();
+      this.$('#startDate').pickadate('picker').set('min', minDate);
+      this.$('#endDate').pickadate('picker').set('max', maxDate);
+    },
+
     retrieveAvailableDates: function() {
       var dateService = new this.dataService();
       this.histograms = [];
 
       dateService.fetchDates().then(function(response) {
-        this.maxDate = moment.utc(response.maxDate);
         this.histograms = response.counts;
         this.renderPickers();
-
-        var tzOffset = new Date().getTimezoneOffset();
-        var maxDate = this.maxDate.clone().add(tzOffset, 'minutes').toDate();
-        this.$('#endDate').pickadate('picker').set('max', maxDate);
+        this.setMinMaxDate(response);
       }.bind(this));
     }
 

--- a/app/assets/javascripts/map/services/GladDateService.js
+++ b/app/assets/javascripts/map/services/GladDateService.js
@@ -32,7 +32,7 @@ define([
       var onSuccess = function(result) {
         var data = result.data && result.data.attributes ?
           result.data.attributes : [];
-        deferred.resolve(_.pick(data, 'maxDate', 'counts'));
+        deferred.resolve(_.pick(data, 'minDate', 'maxDate', 'counts'));
       };
 
       var config = {

--- a/app/assets/javascripts/map/services/TerraiDateService.js
+++ b/app/assets/javascripts/map/services/TerraiDateService.js
@@ -32,7 +32,7 @@ define([
       var onSuccess = function(result) {
         var data = result.data && result.data.attributes ?
           result.data.attributes : [];
-        deferred.resolve(_.pick(data, 'maxDate', 'counts'));
+        deferred.resolve(_.pick(data, 'minDate', 'maxDate', 'counts'));
       };
 
       var config = {


### PR DESCRIPTION
Now the min date for the calendar is set from the API data.