### PR TITLE
Contribute data: credentials

### DIFF
--- a/app/assets/javascripts/static/ContributeDataView.js
+++ b/app/assets/javascripts/static/ContributeDataView.js
@@ -78,6 +78,19 @@ define([
 
     model: new (Backbone.Model.extend({
       urlRoot: window.gfw.config.GFW_API_HOST_NEW_API + '/contribution-data/',
+      sync: function(method, model, options) {
+        options || (options = {});
+
+        if (!options.crossDomain) {
+          options.crossDomain = true;
+        }
+
+        if (!options.xhrFields) {
+          options.xhrFields = {withCredentials:true};
+        }
+
+        return Backbone.sync.call(this, method, model, options);
+      },      
     })),
 
     events: {


### PR DESCRIPTION
This PR adds the credentials to the Backbone contribute model so the API will know which user is sending the contribution if it exists.