### PR TITLE
Feat: Google maps: version updated to 3.26

### DIFF
--- a/app/views/shared/_google_carto.html.erb
+++ b/app/views/shared/_google_carto.html.erb
@@ -1,2 +1,2 @@
-<%= javascript_include_tag "http://maps.googleapis.com/maps/api/js?libraries=places,visualization,drawing&sensor=false&key=#{ENV['GOOGLE_MAPS_API_KEY']}&v=3.12" %>
+<%= javascript_include_tag "http://maps.googleapis.com/maps/api/js?libraries=places,visualization,drawing&key=#{ENV['GOOGLE_MAPS_API_KEY']}&v=3.26" %>
 <%= javascript_include_tag "http://libs.cartocdn.com/cartodb.js/v3/3.15.8/cartodb.js" %>


### PR DESCRIPTION
Updated the Google Maps API to version 3.26. Tested all of the basemaps and different overlays but we should test more before moving to prod.

FYI Removed the "sensor" parameter because it's deprecated and it's not needed to be sent in the url.