### PR TITLE
Push files directly to s3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem 'mini_magick'
 gem 'unf'
 gem 'requirejs-rails', '0.9.5'
 gem 'rack-reverse-proxy', '~> 0.11.0', :require => 'rack/reverse_proxy'
+# Amazon Ruby sdk for file upload to S3
+gem 'aws-sdk', '~> 2'
 
 group :development, :test do
   gem 'rspec-rails', '~> 2.0'
@@ -41,3 +43,5 @@ end
 
 gem 'newrelic_rpm'
 gem 'puma'
+
+gem 'dotenv-rails', :groups => [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,12 @@ GEM
     arel (4.0.2)
     autoprefixer-rails (6.3.6.2)
       execjs
+    aws-sdk (2.6.0)
+      aws-sdk-resources (= 2.6.0)
+    aws-sdk-core (2.6.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.6.0)
+      aws-sdk-core (= 2.6.0)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -74,6 +80,10 @@ GEM
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     ethon (0.9.0)
       ffi (>= 1.3.0)
@@ -224,6 +234,7 @@ GEM
     i18n (0.7.0)
     inflecto (0.0.2)
     ipaddress (0.8.3)
+    jmespath (1.3.1)
     jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
@@ -344,6 +355,7 @@ PLATFORMS
 
 DEPENDENCIES
   autoprefixer-rails (~> 6.3.6.2)
+  aws-sdk (~> 2)
   better_errors
   binding_of_caller
   byebug
@@ -352,6 +364,7 @@ DEPENDENCIES
   compass-flexbox
   compass-rails (= 1.1.2)
   database_cleaner
+  dotenv-rails
   factory_girl_rails
   fog
   foreman
@@ -373,3 +386,9 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unf
   useragent
+
+RUBY VERSION
+   ruby 2.1.5p273
+
+BUNDLED WITH
+   1.13.1

--- a/app/assets/javascripts/static/ContributeDataView.js
+++ b/app/assets/javascripts/static/ContributeDataView.js
@@ -133,11 +133,15 @@ define([
       var that = this;
 
       this.$fieldFileUpload.fileupload({
-        url: '/data/upload',
-        dataType: 'json',
+        url: this.$form.data('url'),
+        formData: this.$form.data('form-data'),
+        paramName: 'file',
+        type: 'POST',
+        dataType: 'XML',
         autoUpload: true,
         maxFileSize: MAXFILESIZE, // 10 MB
         timeout: TIMEOUT,
+        fileInput: this.$fieldFileUpload
       })
 
       .on('fileuploadadd', function (e, data) {

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -111,6 +111,7 @@ class StaticController < ApplicationController
     @title = 'Contribute data'
     @desc = 'Share your data with the GFW community by adding it to the GFW Interactive Map.'
     @keywords = 'GFW, forests, forest data, forest monitoring, forest landscapes, maps, apps, applications, fires, commodities, open landscape partnership, map, palm oil transparency toolkit, forest atlas, develop your own app, climate, biodiversity, deforestation, mobile, explore, browse, tools'
+    @s3_direct_post = S3_DATA_BUCKET_NAME.presigned_post(key: "uploads/#{SecureRandom.uuid}/${filename}", success_action_status: '201', acl: 'public-read')
   end
 
   def old

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -111,7 +111,7 @@ class StaticController < ApplicationController
     @title = 'Contribute data'
     @desc = 'Share your data with the GFW community by adding it to the GFW Interactive Map.'
     @keywords = 'GFW, forests, forest data, forest monitoring, forest landscapes, maps, apps, applications, fires, commodities, open landscape partnership, map, palm oil transparency toolkit, forest atlas, develop your own app, climate, biodiversity, deforestation, mobile, explore, browse, tools'
-    @s3_direct_post = S3_DATA_BUCKET_NAME.presigned_post(key: "uploads/#{SecureRandom.uuid}/${filename}", success_action_status: '201', acl: 'public-read')
+    @s3_direct_post = S3_DATA_BUCKET_NAME.presigned_post(key: "uploads/${filename}", success_action_status: '201', acl: 'public-read')
   end
 
   def old

--- a/app/views/static/contribute.html.erb
+++ b/app/views/static/contribute.html.erb
@@ -23,7 +23,7 @@
       </aside> -->
 
       <div class="m-form">
-        <form id="new-contribution">
+        <form id="new-contribution" data-form-data="<%= @s3_direct_post.fields %>" data-url="<%= @s3_direct_post.url %>" data-host="<%= URI.parse(@s3_direct_post.url).host %>">
 
           <!-- Tell us about your data -->
           <div class="field-fieldset">

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,6 +1,6 @@
 Aws.config.update({
   region: 'us-west-2',
-  credentials: Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY']),
+  credentials: Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
 })
 
 S3_DATA_BUCKET_NAME = Aws::S3::Resource.new.bucket(ENV['S3_DATA_BUCKET_NAME'])

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,6 @@
+Aws.config.update({
+  region: 'us-west-2',
+  credentials: Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY']),
+})
+
+S3_DATA_BUCKET_NAME = Aws::S3::Resource.new.bucket(ENV['S3_DATA_BUCKET_NAME'])


### PR DESCRIPTION
This PR applies the instructions available [here](https://devcenter.heroku.com/articles/direct-to-s3-image-uploads-in-rails) to circumvent the Rails server (and hence Heroku) when uploading files to S3. This way the upload is made directly from the browser to S3.

* It adds the aws-sdk gem to manage this.
* It creates an initializer to setup the S3_DATA_BUCKET_NAME constant to instantiate the presigned_post that is then used by jQuery's fileupload plugin.
* It sets the signed post and adds the data fields to the form, that are then used by the jQuery plugin.

I've also added the dotenv-rails gem to the project to be used in development, because when you start the server with `rails server` the dotenv variables weren't being loaded to the ENV.

Currently there seems to be a CORS issue with the bucket we are using, at least from localhost:3000. Not sure if we want to have access to the bucket from anywhere, but if not this will need to be tested on Staging.