### PR TITLE
Subscriptions new

### DIFF
--- a/app/assets/javascripts/abstract/layer/CartoDBLayerClass.js
+++ b/app/assets/javascripts/abstract/layer/CartoDBLayerClass.js
@@ -215,7 +215,7 @@ define([
           use: data.tablename,
           wdpaid: data.id
         });
-        mps.publish('Highlight/shape', [data]);
+        mps.publish('Shape/update', [data]);
       }.bind(this));
     },
 

--- a/app/assets/javascripts/connect/router.js
+++ b/app/assets/javascripts/connect/router.js
@@ -9,8 +9,9 @@ define([
   'connect/views/SubscriptionNewView',
   'connect/views/LoginView',
   'connect/views/SubHeaderView',
-  'views/NotificationsView'
-], function($, Backbone, _, User, UserFormView, StoriesListView, SubscriptionListView, SubscriptionNewView, LoginView, SubHeaderView, NotificationsView) {
+  'views/NotificationsView',
+  'views/SourceModalView'
+], function($, Backbone, _, User, UserFormView, StoriesListView, SubscriptionListView, SubscriptionNewView, LoginView, SubHeaderView, NotificationsView, SourceModalView) {
 
   'use strict';
 
@@ -115,6 +116,7 @@ define([
         router: this
       });
 
+      new SourceModalView();
       new NotificationsView();
     },
 
@@ -151,79 +153,3 @@ define([
   return Router;
 
 });
-
-
-
-// /**
-//  * The router module.
-//  *
-//  * Router handles app routing and URL parameters and updates Presenter.
-//  *
-//  * @return singleton instance of Router class (extends Backbone.Router).
-//  */
-// define([
-//   'underscore',
-//   'backbone',
-//   'amplify',
-//   'map/utils',
-//   'map/services/PlaceService'
-// ], function(_, Backbone, amplify, utils, PlaceService) {
-
-//   'use strict';
-
-//   var Router = Backbone.Router.extend({
-
-//     routes: {
-//       '': 'profilePage',
-//       // 'map(/:zoom)(/:lat)(/:lng)(/:iso)(/:maptype)(/:baselayers)(/:sublayers)(/)': 'map',
-//       // 'embed/map(/:zoom)(/:lat)(/:lng)(/:iso)(/:maptype)(/:baselayers)(/:sublayers)(/)': 'embed'
-//     },
-
-//     /**
-//      * Boot file:
-//      *
-//      * @param  {[type]} boot [description]
-//      */
-//     initialize: function(mainView) {
-//       this.isLocalStorageNameSupported();
-//       this.name = null;
-//       this.mainView = mainView;
-//       this.placeService = new PlaceService(this);
-
-//     },
-
-//     map: function() {
-//       this.name = 'map';
-//       this.initMap.apply(this, arguments);
-//     },
-
-//     embed: function() {
-//       this.name = 'embed/map';
-//       this.initMap.apply(this, arguments);
-//     },
-
-//     initMap: function(zoom, lat, lng, iso, maptype, baselayers, sublayers, subscribe, referral) {
-//       var params = _.extend({
-//         zoom: zoom,
-//         lat: lat,
-//         lng: lng,
-//         iso: iso,
-//         maptype: maptype,
-//         baselayers: baselayers,
-//         sublayers: sublayers,
-//         subscribe_alerts: subscribe,
-//         referral: referral
-//       }, _.parseUrl());
-
-//       this.placeService.initPlace(this.name, params);
-//     },
-
-//     navigateTo: function(route, options) {
-//       this.navigate(route, options);
-//     }
-
-//   });
-
-//   return Router;
-
-// });

--- a/app/assets/javascripts/connect/templates/regionSelection.handlebars
+++ b/app/assets/javascripts/connect/templates/regionSelection.handlebars
@@ -1,6 +1,6 @@
-<label for="select-layers">Jurisdiction</label>
+<label for="select-layers">Select a jurisdiction</label>
 <div class="m-select">
-  <select id="select-region" class="chosen-select default disabled js-select-region" data-placeholder="Select a region" disabled>
+  <select id="select-region" class="chosen-select default disabled js-select-region" data-placeholder="Select a jurisdiction" disabled>
     <option value=""></option>
     {{#each regions}}
       <option value="{{this.id_1}}">{{this.name_1}}</option>

--- a/app/assets/javascripts/connect/templates/subscriptionNew.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNew.handlebars
@@ -13,24 +13,18 @@
       <aside class="m-aside">
         <h3>How it works</h3>
         <p>Subscribing to forest change alerts is easy. Select your area of interest, choose the forest change alerts you would like to receive, and we’ll email you when there are new alerts available within your area of interest.</p>
-        <p>1. Select the area you’d like to receive alerts for:</p>
-        <ul>
-          <li>Draw or upload a shape</li>
-          <li>Select an area from a GFW data set</li>
-          <li>Select a country or jurisdiction</li>
-        </ul>
       </aside>
 
       <div class="m-form">
         <form id="new-subscription">
           <div class="field -default -medium">
-            <label for="aoi">AOI *</label>
+            <label for="aoi">Select the area you’d like to receive alerts for *</label>
             <div class="m-select">
               <select id="aoi" class="chosen-select default" data-placeholder="Select your area of interest">
                 <option value=""></option>
-                <option value="draw">Draw or upload your area of interest</option>
-                <option value="data">GFW data</option>
-                <option value="country">Country or jurisdiction</option>
+                <option value="draw">Draw or upload a shape</option>
+                <option value="data">Select an area from a GFW data set</option>
+                <option value="country">Select a country or jurisdiction</option>
               </select>
             </div>
           </div>

--- a/app/assets/javascripts/connect/templates/subscriptionNew.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNew.handlebars
@@ -1,8 +1,8 @@
 <section class="m-header-static">
   <div class="inner">
     <header>
-      <h2>Subscriptions</h2>
-      <h3>Create your own subscription, you can do it by Area of Interest, by layers or you can upload your own shapefile and create a subscription.</h3>
+      <h2>Monitor forests by subscribing to alerts</h2>
+      <h3>Be the first to know about forest change in areas you care about by subscribing to forest change alerts from Global Forest Watch.</h3>
     </header>
   </div>
 </section>
@@ -11,13 +11,13 @@
   <div class="inner">
     <div class="m-new">
       <aside class="m-aside">
-        <h3>HOW TO CREATE YOUR SUBSCRIPTIONS</h3>
-
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris faucibus dolor a suscipit tincidunt. Ut sagittis porta nunc, nec pellentesque dolor ornare ut. Sed vitae.</p>
-
+        <h3>How it works</h3>
+        <p>Subscribing to forest change alerts is easy. Select your area of interest, choose the forest change alerts you would like to receive, and we’ll email you when there are new alerts available within your area of interest.</p>
+        <p>1. Select the area you’d like to receive alerts for:</p>
         <ul>
-          <li>Country or Jurisdiction</li>
-          <li>Draw or upload your area of interest</li>
+          <li>Draw or upload a shape</li>
+          <li>Select an area from a GFW data set</li>
+          <li>Select a country or jurisdiction</li>
         </ul>
       </aside>
 

--- a/app/assets/javascripts/connect/templates/subscriptionNew.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNew.handlebars
@@ -24,11 +24,6 @@
       <div class="m-form">
         <form id="new-subscription">
           <div class="field -default -medium">
-            <label for="name">Name *</label>
-            <input type="text" name="name" placeholder="Enter the name of your subscription">
-          </div>
-
-          <div class="field -default -medium">
             <label for="aoi">AOI *</label>
             <div class="m-select">
               <select id="aoi" class="chosen-select default" data-placeholder="Select your area of interest">

--- a/app/assets/javascripts/connect/templates/subscriptionNewCountry.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNewCountry.handlebars
@@ -35,7 +35,7 @@
 
 
 <div class="field -default">
-  <label>Data set</label>
+  <label>Select the forest change alerts you would like to receive *</label>
   <div class="checkbox-box">
     <div class="custom-checkbox">
       <input class="dataset-checkbox" type="checkbox" name="datasets" id="umd-loss-gain">
@@ -69,17 +69,17 @@
 </div>
 
 <div class="field -default -medium">
-  <label for="name">Name *</label>
+  <label for="name">Name your subscription *</label>
   <input type="text" name="name" placeholder="Enter the name of your subscription">
 </div>
 
 <div class="field -default -medium">
-  <label for="email">Email *</label>
+  <label for="email">Enter your email address *</label>
   <input type="email" name="email" placeholder="Enter your email" value="{{email}}">
 </div>
 
-<div class="field -default -little">
-  <label for="select-language">Language</label>
+<div class="field -default -medium">
+  <label for="select-language">Select a language for notification emails *</label>
   <div class="m-select">
     <select id="select-language" name="language" class="chosen-select default" data-placeholder="Select a language">
       {{#each languages}}

--- a/app/assets/javascripts/connect/templates/subscriptionNewCountry.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNewCountry.handlebars
@@ -92,6 +92,5 @@
 <div class="field -default">
   <div class="m-btncontainer is-flex-start">
     <input type="submit" id="submit" name="submit" value="Subscribe" class="btn medium green medium huge-padding">
-    <a href="/contribute-data" target="_blank" class="btn medium gray uppercase">Add your own data</a>
   </div>
 </div>

--- a/app/assets/javascripts/connect/templates/subscriptionNewCountry.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNewCountry.handlebars
@@ -3,6 +3,36 @@
   <div id="region-field" class="field -default -medium"></div>
 </div>
 
+<div class="field -default">
+  <div class="m-map">
+    <div>
+      <div id="map" class="map -loading"></div>
+      <div id="map-loader" class="m-spinner">
+        <div class="spinner-box">
+          <div class="icon"></div>
+        </div>
+      </div>
+
+      <div id="map-controls" class="map-controls">
+        <div class="map-controls-box -top -left">
+          <div class="control-zoom">
+            <button type="button" class="map-control-btn js-map-controls-zoom-in"><svg><use xlink:href="#icon-control-plus"></use></svg></button>
+            <button type="button" class="map-control-btn js-map-controls-zoom-out"><svg><use xlink:href="#icon-control-minus"></use></svg></button>
+          </div>
+        </div>
+        <div class="map-controls-box -top -right">
+          <div class="control-search">
+            <input class="map-search-input" id="map-controls-search" type="text" placeholder="Search..."/>
+          </div>
+          <div>
+            <button id="map-controls-autolocate" class="map-control-btn js-map-controls-autolocate" type="button"><svg><use xlink:href="#icon-control-locate"></use></svg></button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 
 <div class="field -default">
   <label>Data set</label>
@@ -36,6 +66,16 @@
       <label for="viirs-active-fires"><span></span> VIIRS Active fires</label>
     </div>
   </div>
+</div>
+
+<div class="field -default -medium">
+  <label for="name">Name *</label>
+  <input type="text" name="name" placeholder="Enter the name of your subscription">
+</div>
+
+<div class="field -default -medium">
+  <label for="email">Email *</label>
+  <input type="text" name="email" placeholder="Enter your email">
 </div>
 
 <div class="field -default -little">

--- a/app/assets/javascripts/connect/templates/subscriptionNewCountry.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNewCountry.handlebars
@@ -75,7 +75,7 @@
 
 <div class="field -default -medium">
   <label for="email">Email *</label>
-  <input type="text" name="email" placeholder="Enter your email">
+  <input type="email" name="email" placeholder="Enter your email" value="{{email}}">
 </div>
 
 <div class="field -default -little">

--- a/app/assets/javascripts/connect/templates/subscriptionNewData.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNewData.handlebars
@@ -39,7 +39,7 @@
 </div>
 
 <div class="field -default">
-  <label>Data set *</label>
+  <label>Select the forest change alerts you would like to receive *</label>
   <div class="checkbox-box">
     <div class="custom-checkbox">
       <input class="dataset-checkbox" type="checkbox" name="datasets" id="umd-loss-gain">
@@ -73,17 +73,17 @@
 </div>
 
 <div class="field -default -medium">
-  <label for="name">Name *</label>
+  <label for="name">Name your subscription *</label>
   <input type="text" name="name" placeholder="Enter the name of your subscription">
 </div>
 
 <div class="field -default -medium">
-  <label for="email">Email *</label>
+  <label for="email">Enter your email address *</label>
   <input type="email" name="email" placeholder="Enter your email" value="{{email}}">
 </div>
 
-<div class="field -default -little">
-  <label for="select-language">Language</label>
+<div class="field -default -medium">
+  <label for="select-language">Select a language for notification emails *</label>
   <div class="m-select">
     <select id="select-language" name="language" class="chosen-select default" data-placeholder="Select a language">
       {{#each languages}}

--- a/app/assets/javascripts/connect/templates/subscriptionNewData.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNewData.handlebars
@@ -96,6 +96,5 @@
 <div class="field -default">
   <div class="m-btncontainer is-flex-start">
     <input type="submit" id="submit" name="submit" value="Subscribe" class="btn medium green medium huge-padding">
-    <a href="/contribute-data" target="_blank" class="btn medium gray uppercase">Add your own data</a>
   </div>
 </div>

--- a/app/assets/javascripts/connect/templates/subscriptionNewData.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNewData.handlebars
@@ -79,7 +79,7 @@
 
 <div class="field -default -medium">
   <label for="email">Email *</label>
-  <input type="text" name="email" placeholder="Enter your email">
+  <input type="email" name="email" placeholder="Enter your email" value="{{email}}">
 </div>
 
 <div class="field -default -little">

--- a/app/assets/javascripts/connect/templates/subscriptionNewData.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNewData.handlebars
@@ -39,7 +39,7 @@
 </div>
 
 <div class="field -default">
-  <label>Data set</label>
+  <label>Data set *</label>
   <div class="checkbox-box">
     <div class="custom-checkbox">
       <input class="dataset-checkbox" type="checkbox" name="datasets" id="umd-loss-gain">
@@ -70,6 +70,16 @@
       <label for="viirs-active-fires"><span></span> VIIRS Active fires</label>
     </div>
   </div>
+</div>
+
+<div class="field -default -medium">
+  <label for="name">Name *</label>
+  <input type="text" name="name" placeholder="Enter the name of your subscription">
+</div>
+
+<div class="field -default -medium">
+  <label for="email">Email *</label>
+  <input type="text" name="email" placeholder="Enter your email">
 </div>
 
 <div class="field -default -little">

--- a/app/assets/javascripts/connect/templates/subscriptionNewDraw.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNewDraw.handlebars
@@ -48,7 +48,7 @@
 
 
 <div class="field -default">
-  <label>Data set</label>
+  <label>Select the forest change alerts you would like to receive *</label>
   <div class="checkbox-box">
     <div class="custom-checkbox">
       <input class="dataset-checkbox" type="checkbox" name="datasets" id="umd-loss-gain">
@@ -82,17 +82,17 @@
 </div>
 
 <div class="field -default -medium">
-  <label for="name">Name *</label>
+  <label for="name">Name your subscription *</label>
   <input type="text" name="name" placeholder="Enter the name of your subscription">
 </div>
 
 <div class="field -default -medium">
-  <label for="email">Email *</label>
+  <label for="email">Enter your email address *</label>
   <input type="email" name="email" placeholder="Enter your email" value="{{email}}">
 </div>
 
-<div class="field -default -little">
-  <label for="select-language">Language</label>
+<div class="field -default -medium">
+  <label for="select-language">Select a language for notification emails *</label>
   <div class="m-select">
     <select id="select-language" name="language" class="chosen-select default" data-placeholder="Select a language">
       {{#each languages}}

--- a/app/assets/javascripts/connect/templates/subscriptionNewDraw.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNewDraw.handlebars
@@ -89,7 +89,7 @@
 
 <div class="field -default -medium">
   <label for="email">Email *</label>
-  <input type="text" name="email" placeholder="Enter your email">
+  <input type="email" name="email" placeholder="Enter your email" value="{{email}}">
 </div>
 
 <div class="field -default -little">

--- a/app/assets/javascripts/connect/templates/subscriptionNewDraw.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNewDraw.handlebars
@@ -30,10 +30,8 @@
 <div class="field -default">
   <ul class="m-btncontainer is-space-between -col50">
     <li>
-      <button type="button" class="btn green uppercase full-width">
-        <div id="map-drawing">
-          Start drawing
-        </div>
+      <button id="map-drawing" type="button" class="btn green uppercase full-width">
+        Start drawing
       </button>
     </li>
     <li>

--- a/app/assets/javascripts/connect/templates/subscriptionNewDraw.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNewDraw.handlebars
@@ -35,8 +35,9 @@
       </button>
     </li>
     <li>
-      <button type="button" class="btn gray uppercase full-width">
+      <button id="map-uploading" type="button" class="btn gray uppercase full-width with-inline-icon">
         Upload a file
+        <svg data-source="drop-shapefile" data-static="true" class="source"><use xlink:href="#shape-info"></use></svg>
         <div id="map-upload" class="m-upload">
           <input type="file" id="input-upload-shape">
         </div>

--- a/app/assets/javascripts/connect/templates/subscriptionNewDraw.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNewDraw.handlebars
@@ -105,6 +105,5 @@
 <div class="field -default">
   <div class="m-btncontainer is-flex-start">
     <input type="submit" id="submit" name="submit" value="Subscribe" class="btn medium green medium huge-padding">
-    <a href="/contribute-data" target="_blank" class="btn medium gray uppercase">Add your own data</a>
   </div>
 </div>

--- a/app/assets/javascripts/connect/templates/subscriptionNewDraw.handlebars
+++ b/app/assets/javascripts/connect/templates/subscriptionNewDraw.handlebars
@@ -82,6 +82,16 @@
   </div>
 </div>
 
+<div class="field -default -medium">
+  <label for="name">Name *</label>
+  <input type="text" name="name" placeholder="Enter the name of your subscription">
+</div>
+
+<div class="field -default -medium">
+  <label for="email">Email *</label>
+  <input type="text" name="email" placeholder="Enter your email">
+</div>
+
 <div class="field -default -little">
   <label for="select-language">Language</label>
   <div class="m-select">

--- a/app/assets/javascripts/connect/views/CountrySelectionView.js
+++ b/app/assets/javascripts/connect/views/CountrySelectionView.js
@@ -106,7 +106,7 @@ define([
     */
     renderCountries: function() {
       this.$countryField.html(this.templateCountries({
-        name: 'Country',
+        name: 'Select a country',
         placeholder: 'Select a country',
         countries: this.countries
       }));

--- a/app/assets/javascripts/connect/views/CountrySelectionView.js
+++ b/app/assets/javascripts/connect/views/CountrySelectionView.js
@@ -134,6 +134,7 @@ define([
         if (! !!$select.data('chosen')) {
           $select.chosen({
             width: '100%',
+            allow_single_deselect: true,
             inherit_select_classes: true,
             no_results_text: "Oops, nothing found!"
           });

--- a/app/assets/javascripts/connect/views/CountrySelectionView.js
+++ b/app/assets/javascripts/connect/views/CountrySelectionView.js
@@ -131,7 +131,6 @@ define([
         if (! !!$select.data('chosen')) {
           $select.chosen({
             width: '100%',
-            disable_search: true,
             inherit_select_classes: true,
             no_results_text: "Oops, nothing found!"
           });

--- a/app/assets/javascripts/connect/views/CountrySelectionView.js
+++ b/app/assets/javascripts/connect/views/CountrySelectionView.js
@@ -7,15 +7,16 @@ define([
   'underscore',
   'handlebars',
   'mps',
+  'core/View',
   'map/services/CountryService',
   'map/services/RegionService',
   'text!connect/templates/countrySelection.handlebars',
   'text!connect/templates/regionSelection.handlebars',
-], function(_, Handlebars, mps, CountryService, RegionService, countryTpl, regionTpl) {
+], function(_, Handlebars, mps, View, CountryService, RegionService, countryTpl, regionTpl) {
 
   'use strict';
 
-  var CountrySelectionView = Backbone.View.extend({
+  var CountrySelectionView = View.extend({
     model: new (Backbone.Model.extend({
       country: null,
       region: null,
@@ -36,6 +37,12 @@ define([
         return;
       }
 
+      View.prototype.initialize.apply(this);
+
+      this.map = map;
+      this.cache();
+      this.listeners();
+
       // Load countries
       CountryService.get()
         .then(function(results) {
@@ -47,16 +54,12 @@ define([
         .error(function(error) {
           console.log(error);
         }.bind(this))
-
-      this.map = map;
-      this.cache();
-      this.listeners();
     },
 
     listeners: function() {
       // We should start using listenTo and handle the remove views
-      this.model.on('change:country', this.changeCountry.bind(this));
-      this.model.on('change:region', this.changeRegion.bind(this));
+      this.listenTo(this.model, 'change:country', this.changeCountry.bind(this));
+      this.listenTo(this.model, 'change:region', this.changeRegion.bind(this));
     },
 
     cache: function() {

--- a/app/assets/javascripts/connect/views/LayerSelectionView.js
+++ b/app/assets/javascripts/connect/views/LayerSelectionView.js
@@ -36,7 +36,7 @@ define([
       if (!this.$el.length) {
         return;
       }
-      
+
       View.prototype.initialize.apply(this);
 
       this.map = map;

--- a/app/assets/javascripts/connect/views/LayerSelectionView.js
+++ b/app/assets/javascripts/connect/views/LayerSelectionView.js
@@ -1,7 +1,7 @@
 /**
- * The CountrySelectionView view.
+ * The LayerSelectionView view.
  *
- * @return CountrySelectionView view (extends Backbone.View)
+ * @return LayerSelectionView view (extends Backbone.View)
  */
 define([
   'underscore',
@@ -16,7 +16,7 @@ define([
 
   'use strict';
 
-  var CountrySelectionView = View.extend({
+  var LayerSelectionView = View.extend({
     model: new (Backbone.Model.extend({
       country: null,
       layers: null,
@@ -143,8 +143,8 @@ define([
           var isos = _.uniq(_.pluck(layers, 'iso'));
 
           this.$countryField.html(this.templateCountries({
-            name: 'Country layers',
-            placeholder: 'Select a country',
+            name: 'Select an area from a country-specific data set',
+            placeholder: 'Select a country...',
             countries: _.filter(this.countries, function(country) {
               return (isos.indexOf(country.iso) != -1)
             })
@@ -162,10 +162,10 @@ define([
 
     renderLayers: function() {
       this.$layersField.html(this.templateLayers({
-        name: 'Global layers',
-        placeholder: 'Select a global layer',
+        name: 'Select an area from a global data set',
+        placeholder: 'Select a data set...',
         layers: this.layers,
-        hint: 'After selecting a layer, please choose one shape of the map by clicking it (Please, send me this text. Miguel)'
+        hint: 'Select an area by clicking a shape on the map'
       }));
       this.renderChosen();
     },
@@ -173,7 +173,7 @@ define([
     renderCountryLayers: function() {
       this.$layersCountryField.html(this.templateLayers({
         name: '',
-        placeholder: 'Select a country layer',
+        placeholder: 'Select a data set...',
         layers: (!_.isEmpty(this.countryLayers)) ? this.countryLayers : null,
         hint: ''
       }));
@@ -217,6 +217,6 @@ define([
     }
   });
 
-  return CountrySelectionView;
+  return LayerSelectionView;
 
 });

--- a/app/assets/javascripts/connect/views/LayerSelectionView.js
+++ b/app/assets/javascripts/connect/views/LayerSelectionView.js
@@ -73,9 +73,8 @@ define([
     },
 
     listeners: function() {
-      // We should start using listenTo and handle the remove views
-      this.model.on('change:country', this.changeCountry.bind(this));
-      this.model.on('change:layers', this.changeLayers.bind(this));
+      this.listenTo(this.model, 'change:country', this.changeCountry.bind(this));
+      this.listenTo(this.model, 'change:layers', this.changeLayers.bind(this));
     },
 
     cache: function() {

--- a/app/assets/javascripts/connect/views/LayerSelectionView.js
+++ b/app/assets/javascripts/connect/views/LayerSelectionView.js
@@ -7,15 +7,16 @@ define([
   'underscore',
   'handlebars',
   'mps',
+  'core/View',
   'map/services/LayerSpecService',
   'map/services/CountryService',
   'text!connect/templates/countrySelection.handlebars',
   'text!connect/templates/layerSelection.handlebars',
-], function(_, Handlebars, mps, LayerSpecService, CountryService, countryTpl, layerTpl) {
+], function(_, Handlebars, mps, View, LayerSpecService, CountryService, countryTpl, layerTpl) {
 
   'use strict';
 
-  var CountrySelectionView = Backbone.View.extend({
+  var CountrySelectionView = View.extend({
     model: new (Backbone.Model.extend({
       country: null,
       layers: null,
@@ -35,6 +36,8 @@ define([
       if (!this.$el.length) {
         return;
       }
+      
+      View.prototype.initialize.apply(this);
 
       this.map = map;
       this.cache();

--- a/app/assets/javascripts/connect/views/LayerSelectionView.js
+++ b/app/assets/javascripts/connect/views/LayerSelectionView.js
@@ -187,6 +187,7 @@ define([
           $select.chosen({
             width: '100%',
             disable_search: true,
+            allow_single_deselect: true,
             inherit_select_classes: true,
             no_results_text: "Oops, nothing found!"
           });

--- a/app/assets/javascripts/connect/views/MapMiniControlsView.js
+++ b/app/assets/javascripts/connect/views/MapMiniControlsView.js
@@ -7,11 +7,13 @@ define([
   'underscore',
   'handlebars',
   'mps',
-], function(_, Handlebars, mps) {
+  'core/View',
+
+], function(_, Handlebars, mps, View) {
 
   'use strict';
 
-  var MapMiniControlsView = Backbone.View.extend({
+  var MapMiniControlsView = View.extend({
 
     el: '#map-controls',
 
@@ -26,7 +28,9 @@ define([
       if (!this.$el.length) {
         return;
       }
-      
+
+      View.prototype.initialize.apply(this);
+
       this.map = map;
       this.cache();
       this.listeners();

--- a/app/assets/javascripts/connect/views/MapMiniDrawingView.js
+++ b/app/assets/javascripts/connect/views/MapMiniDrawingView.js
@@ -110,9 +110,7 @@ define([
           is_drawn = this.status.get('is_drawn');
 
       mps.publish('Drawing/delete');
-      if (!is_drawn) {
-        mps.publish('Drawing/toggle', [!is_drawing]);
-      }
+      mps.publish('Drawing/toggle', [!is_drawing && !is_drawn]);
     },
 
 
@@ -168,15 +166,17 @@ define([
      * @return {void}
      */
     completeDrawing: function(e) {
+      this.stopDrawingManager();
+
       // Check if the drawing is enabled
       if (this.status.get('is_drawing')) {
-        mps.publish('Drawing/overlay', [e.overlay]);
+        mps.publish('Drawing/overlay', [e.overlay], { save: true });
         mps.publish('Drawing/toggle', [false]);
       } else {
+        mps.publish('Drawing/overlay', [e.overlay], { save: false });
+        mps.publish('Drawing/toggle', [false]);
         mps.publish('Drawing/delete');
       }
-
-      this.stopDrawingManager();
     },
 
   });

--- a/app/assets/javascripts/connect/views/MapMiniDrawingView.js
+++ b/app/assets/javascripts/connect/views/MapMiniDrawingView.js
@@ -10,13 +10,14 @@ define([
   'amplify',
   'turf',
   'mps',
+  'core/View',
   'map/services/GeostoreService',
   'helpers/geojsonUtilsHelper',
-], function(_, Handlebars, amplify, turf, mps, GeostoreService, geojsonUtilsHelper) {
+], function(_, Handlebars, amplify, turf, mps, View, GeostoreService, geojsonUtilsHelper) {
 
   'use strict';
 
-  var MapMiniDrawingView = Backbone.View.extend({
+  var MapMiniDrawingView = View.extend({
 
     el: '#map-drawing',
 
@@ -38,18 +39,24 @@ define([
         return;
       }
 
+      View.prototype.initialize.apply(this);
+
       this.map = map;
       this.listeners();
     },
 
+    _subscriptions: [
+      // HIGHLIGHT
+      {
+        'Drawing/toggle': function(toggle){
+          this.status.set('is_drawing', toggle);
+        }
+      }
+    ],
+
     listeners: function() {
       // Status listeners
-      this.status.on('change:is_drawing', this.changeIsDrawing.bind(this));
-
-      // MPS listeners
-      mps.subscribe('Drawing/toggle', function(toggle){
-        this.status.set('is_drawing', toggle);
-      }.bind(this))
+      this.listenTo(this.status, 'change:is_drawing', this.changeIsDrawing.bind(this));
     },
 
 

--- a/app/assets/javascripts/connect/views/MapMiniSelectedView.js
+++ b/app/assets/javascripts/connect/views/MapMiniSelectedView.js
@@ -39,7 +39,7 @@ define([
       this.model.on('change', this.render.bind(this));
 
       // HIGHLIGHT
-      mps.subscribe('Highlight/shape', function(data){
+      mps.subscribe('Shape/update', function(data){
         this.model.clear({ silent: true }).set(data);
       }.bind(this));
     },

--- a/app/assets/javascripts/connect/views/MapMiniSelectedView.js
+++ b/app/assets/javascripts/connect/views/MapMiniSelectedView.js
@@ -7,12 +7,13 @@ define([
   'underscore',
   'handlebars',
   'mps',
+  'core/View',
   'text!connect/templates/subscriptionNewDataSelection.handlebars',
-], function(_, Handlebars, mps, tpl) {
+], function(_, Handlebars, mps, View, tpl) {
 
   'use strict';
 
-  var MapMiniSelectedView = Backbone.View.extend({
+  var MapMiniSelectedView = View.extend({
     model: new (Backbone.Model.extend({
 
     })),
@@ -30,18 +31,24 @@ define([
         return;
       }
 
+      View.prototype.initialize.apply(this);
+
       this.map = map;
       this.cache();
       this.listeners();
     },
 
-    listeners: function() {
-      this.model.on('change', this.render.bind(this));
-
+    _subscriptions: [
       // HIGHLIGHT
-      mps.subscribe('Shape/update', function(data){
-        this.model.clear({ silent: true }).set(data);
-      }.bind(this));
+      {
+        'Shape/update': function(data){
+          this.model.clear({ silent: true }).set(data);
+        }
+      }
+    ],
+
+    listeners: function() {
+      this.listenTo(this.model, 'change', this.render.bind(this));
     },
 
     cache: function() {

--- a/app/assets/javascripts/connect/views/MapMiniUploadView.js
+++ b/app/assets/javascripts/connect/views/MapMiniUploadView.js
@@ -10,13 +10,14 @@ define([
   'amplify',
   'turf',
   'mps',
+  'core/View',
   'map/services/ShapefileNewService',
   'helpers/geojsonUtilsHelper',
-], function(_, Handlebars, amplify, turf, mps, ShapefileService, geojsonUtilsHelper) {
+], function(_, Handlebars, amplify, turf, mps, View, ShapefileService, geojsonUtilsHelper) {
 
   'use strict';
 
-  var MapMiniUploadView = Backbone.View.extend({
+  var MapMiniUploadView = View.extend({
 
     config: {
       FILE_SIZE_LIMIT: 1000000,
@@ -38,19 +39,27 @@ define([
         return;
       }
 
+      View.prototype.initialize.apply(this);
+
       this.map = map;
       this.cache();
       this.listeners();
     },
+
+    _subscriptions: [
+      // HIGHLIGHT
+      {
+        'Drawing/toggle': function(toggle){
+          this.$inputUploadShape.val('')
+        }
+      }
+    ],
 
     cache: function() {
       this.$inputUploadShape = this.$el.find('#input-upload-shape');
     },
 
     listeners: function() {
-      mps.subscribe('Drawing/toggle', function(toggle){
-        this.$inputUploadShape.val('')
-      }.bind(this));
     },
 
     /**

--- a/app/assets/javascripts/connect/views/MapMiniUploadView.js
+++ b/app/assets/javascripts/connect/views/MapMiniUploadView.js
@@ -24,9 +24,10 @@ define([
       FILE_SIZE_MESSAGE: 'The selected file is quite large and uploading it might result in browser instability. Do you want to continue?'
     },
 
-    el: '#map-upload',
+    el: '#map-uploading',
 
     events: {
+      'click' : 'onClickUploading',
       'change #input-upload-shape' : 'onChangeFileShape',
       'dragenter' : 'onDragenterShape',
       'dragleave' : 'onDragleaveShape',
@@ -64,11 +65,18 @@ define([
 
     /**
      * UI EVENTS
+     * - onClickUploading
      * - onChangeFileShape
      * - onDragoverShape
      * - onDragendShape
      * - onDropShape
     */
+    onClickUploading: function(e) {
+      if (e.target.id === 'map-uploading') {
+        this.$inputUploadShape.trigger('click');
+      }
+    },
+
     onChangeFileShape: function(e) {
       var file = e.currentTarget.files[0];
       if (file) {

--- a/app/assets/javascripts/connect/views/MapMiniView.js
+++ b/app/assets/javascripts/connect/views/MapMiniView.js
@@ -362,6 +362,9 @@ define([
         strokeColor: '#A2BC28'
       });
 
+      console.log(geojson);
+      console.log(this.map);
+      console.log(overlay);
       overlay.setMap(this.map);
 
       this.status.set('overlay', overlay, { silent: true });

--- a/app/assets/javascripts/connect/views/MapMiniView.js
+++ b/app/assets/javascripts/connect/views/MapMiniView.js
@@ -116,6 +116,8 @@ define([
           var iso = iso;
           if (!!iso && !!iso.country) {
             this.getCountryShape(iso);
+          } else {
+            this.deleteGeojson();
           }
         }
       },
@@ -312,6 +314,8 @@ define([
     getCountryShape: function(iso) {
       var iso = iso;
       if (!!iso.country) {
+        mps.publish('Map/loading', [true]);
+
         if (!!iso.region) {
           RegionService.show(iso.country, iso.region)
             .then(function(results,status) {
@@ -326,6 +330,8 @@ define([
               // Draw geojson of country
               this.deleteGeojson();
               this.drawGeojson(geojson);
+
+              mps.publish('Map/loading', [false]);
             }.bind(this));
 
         } else {
@@ -347,6 +353,7 @@ define([
               this.deleteGeojson();
               this.drawGeojson(geojson);
 
+              mps.publish('Map/loading', [false]);
             }.bind(this));
         }
       }

--- a/app/assets/javascripts/connect/views/MapMiniView.js
+++ b/app/assets/javascripts/connect/views/MapMiniView.js
@@ -122,7 +122,6 @@ define([
 
       {
         'Shape/update': function(data) {
-          console.log(data);
           if (!!data.wdpaid) {
             this.getShape('protected_areas', data.wdpaid);
           }

--- a/app/assets/javascripts/connect/views/MapMiniView.js
+++ b/app/assets/javascripts/connect/views/MapMiniView.js
@@ -142,10 +142,12 @@ define([
       },
 
       {
-        'Drawing/overlay': function(overlay){
+        'Drawing/overlay': function(overlay, options){
           this.status.set('overlay', overlay);
-          this.status.set('geojson', this.getGeojson(overlay));
-          this.eventsGeojson();
+          if (!!options && options.save) {
+            this.status.set('geojson', this.getGeojson(overlay));
+            this.eventsGeojson();
+          }
         }
       },
 

--- a/app/assets/javascripts/connect/views/MapMiniView.js
+++ b/app/assets/javascripts/connect/views/MapMiniView.js
@@ -10,6 +10,7 @@ define([
   'mps',
   'cookie',
   'topojson',
+  'core/View',
   'map/views/maptypes/grayscaleMaptype',
   'map/services/GeostoreService',
   'map/services/ShapeService',
@@ -17,11 +18,11 @@ define([
   'map/services/RegionService',
   'map/helpers/layersHelper',
   'helpers/geojsonUtilsHelper',
-], function(Backbone, _, mps, Cookies, topojson, grayscaleMaptype, GeostoreService, ShapeService, CountryService, RegionService, layersHelper, geojsonUtilsHelper) {
+], function(Backbone, _, mps, Cookies, topojson, View, grayscaleMaptype, GeostoreService, ShapeService, CountryService, RegionService, layersHelper, geojsonUtilsHelper) {
 
   'use strict';
 
-  var MapMiniView = Backbone.View.extend({
+  var MapMiniView = View.extend({
 
     el: '#map',
 
@@ -60,8 +61,10 @@ define([
       if (!this.$el.length) {
         return;
       }
+
+      View.prototype.initialize.apply(this);
+
       this.layerInst = {};
-      this._cachedSubscriptions = [];
       this.render();
       this.cache();
       this.listeners();
@@ -72,9 +75,8 @@ define([
     },
 
     listeners: function() {
-      this.status.on('change:geojson', this.changeGeojson.bind(this));
-      this.status.on('change:geostore', this.changeGeostore.bind(this));
-      this._subscribe();
+      this.listenTo(this.status, 'change:geojson', this.changeGeojson.bind(this));
+      this.listenTo(this.status, 'change:geostore', this.changeGeostore.bind(this));
     },
 
     _subscriptions: [
@@ -166,24 +168,6 @@ define([
       },
 
     ],
-
-    /**
-     * Subscribe && unsubscribe to events and append them to this._cachedSubscriptions.
-     */
-    _subscribe: function() {
-      _.each(this._subscriptions, _.bind(function(subscription) {
-        _.each(subscription, _.bind(function(callback, name) {
-          this._cachedSubscriptions.push(
-            mps.subscribe(name, _.bind(callback, this)));
-        },this));
-      }, this));
-    },
-
-    _unsubscribe: function() {
-      for (var i = 0; i < this._cachedSubscriptions.length; i++) {
-        mps.unsubscribe(this._cachedSubscriptions[i]);
-      }
-    },
 
     /**
      * Creates the Google Maps and attaches it to the DOM.

--- a/app/assets/javascripts/connect/views/SubscriptionNewView.js
+++ b/app/assets/javascripts/connect/views/SubscriptionNewView.js
@@ -159,6 +159,7 @@ define([
 
       if (!!aoi) {
         this.$formType.html(this.templates[aoi]({
+          email: this.user.get('email'),
           languages: languagesList
         }));
         this.cache();

--- a/app/assets/javascripts/connect/views/SubscriptionNewView.js
+++ b/app/assets/javascripts/connect/views/SubscriptionNewView.js
@@ -118,7 +118,7 @@ define([
         console.log(this.subscription.get('params'));
       }.bind(this));
 
-      mps.subscribe('Highlight/shape', function(data) {
+      mps.subscribe('Shape/update', function(data) {
         var defaults = this.subscription.get('defaults').params;
 
         if (!!data.use && this.usenames.indexOf(data.use) === -1) {
@@ -210,6 +210,10 @@ define([
         if (!!view.model) {
           view.model.clear({ silent: true })
         }
+        if (!!view._unsubscribe) {
+          view._unsubscribe();
+        }
+
         view.undelegateEvents();
         view.remove();
       })

--- a/app/assets/javascripts/connect/views/SubscriptionNewView.js
+++ b/app/assets/javascripts/connect/views/SubscriptionNewView.js
@@ -285,7 +285,7 @@ define([
             this.router.navigateTo('subscriptions', {
               trigger: true
             });
-            mps.publish('Notification/open', ['notification-my-gfw-subscription-correct']);
+            mps.publish('Notification/open', ['notification-my-gfw-subscription-correct2']);
           }.bind(this))
 
           .fail(function(){

--- a/app/assets/javascripts/connect/views/SubscriptionNewView.js
+++ b/app/assets/javascripts/connect/views/SubscriptionNewView.js
@@ -206,6 +206,9 @@ define([
 
     removeSubViews: function() {
       _.each(this.subViews, function(view){
+        if (!!view.model) {
+          view.model.clear({ silent: true })
+        }
         view.undelegateEvents();
         view.remove();
       })

--- a/app/assets/javascripts/connect/views/SubscriptionNewView.js
+++ b/app/assets/javascripts/connect/views/SubscriptionNewView.js
@@ -207,15 +207,7 @@ define([
 
     removeSubViews: function() {
       _.each(this.subViews, function(view){
-        if (!!view.model) {
-          view.model.clear({ silent: true })
-        }
-        if (!!view._unsubscribe) {
-          view._unsubscribe();
-        }
-
-        view.undelegateEvents();
-        view.remove();
+        view._remove();
       })
     },
 

--- a/app/assets/javascripts/connect/views/SubscriptionNewView.js
+++ b/app/assets/javascripts/connect/views/SubscriptionNewView.js
@@ -163,6 +163,7 @@ define([
         }));
         this.cache();
         this.renderChosen();
+        this.removeSubViews();
         this.initSubViews();
       } else {
         this.$formType.html('');
@@ -192,13 +193,22 @@ define([
 
     initSubViews: function() {
       var mapView = new MapMiniView();
+      this.subViews = {
+        mapView: mapView,
+        mapControlsView: new MapMiniControlsView(mapView.map),
+        mapDrawingView: new MapMiniDrawingView(mapView.map),
+        mapUploadView: new MapMiniUploadView(mapView.map),
+        mapSelectedView: new MapMiniSelectedView(mapView.map),
+        countrySelectionView: new CountrySelectionView(mapView.map),
+        layerSelectionView: new LayerSelectionView(mapView.map),
+      };
+    },
 
-      new MapMiniControlsView(mapView.map);
-      new MapMiniDrawingView(mapView.map);
-      new MapMiniUploadView(mapView.map);
-      new MapMiniSelectedView(mapView.map);
-      new CountrySelectionView(mapView.map);
-      new LayerSelectionView(mapView.map);
+    removeSubViews: function() {
+      _.each(this.subViews, function(view){
+        view.undelegateEvents();
+        view.remove();
+      })
     },
 
     /**

--- a/app/assets/javascripts/core/View.js
+++ b/app/assets/javascripts/core/View.js
@@ -49,6 +49,7 @@ define([
       this.model && this.model.clear({ silent: true });
       this._unsubscribe && this._unsubscribe();
       this.undelegateEvents();
+      this.remove();
     }
 
   });

--- a/app/assets/javascripts/core/View.js
+++ b/app/assets/javascripts/core/View.js
@@ -1,0 +1,57 @@
+/**
+ * The Core view.
+ * @return View Backbone View
+ */
+define([
+  'backbone',
+  'underscore',
+  'mps'
+], function(Backbone, _, mps) {
+
+  'use strict';
+
+  // This view is for always having the posibility of subscribing to mps events
+  var View = Backbone.View.extend({
+
+    initialize: function(view, options) {
+      options = _.extend({}, this.defaults, options);
+      this._cachedSubscriptions = [];
+
+      if (this._subscriptions) {
+        this._subscribe();
+      }
+    },
+
+    /**
+     * Unsubscribe presenter mps subscriptions.
+     */
+    _unsubscribe: function() {
+      if (!!this._cachedSubscriptions) {
+        for (var i = 0; i < this._cachedSubscriptions.length; i++) {
+          mps.unsubscribe(this._cachedSubscriptions[i]);
+        }
+      }
+    },
+
+    /**
+     * Subscribe to events and append them to this._subs.
+     */
+    _subscribe: function() {
+      _.each(this._subscriptions, _.bind(function(subscription) {
+        _.each(subscription, _.bind(function(callback, name) {
+          this._cachedSubscriptions.push(
+            mps.subscribe(name, _.bind(callback, this)));
+        },this));
+      }, this));
+    },
+
+    _remove: function() {
+      this.model && this.model.clear({ silent: true });
+      this._unsubscribe && this._unsubscribe();
+      this.undelegateEvents();
+    }
+
+  });
+
+  return View;
+});

--- a/app/assets/javascripts/views/SourceModalView.js
+++ b/app/assets/javascripts/views/SourceModalView.js
@@ -67,12 +67,17 @@ define([
       this.sourceModel = new SourceModel({
         slug: this.$current.data('source'),
       });
-      this.sourceModel.fetch({
-        update:true,
-        parse: true,
-        success: this.sourceSuccess.bind(this),
-        error: this.sourceError.bind(this),
-      });
+
+      if (!!this.$current.data('static')) {
+        this.sourceStatic();
+      } else {
+        this.sourceModel.fetch({
+          update:true,
+          parse: true,
+          success: this.sourceSuccess.bind(this),
+          error: this.sourceError.bind(this),
+        });
+      }
     },
 
     sourceSuccess: function() {

--- a/app/assets/stylesheets/modules/_buttons.scss
+++ b/app/assets/stylesheets/modules/_buttons.scss
@@ -173,7 +173,7 @@
     @media (min-width: $br-mobile) {
       padding-right: 36px;
     }
-    svg{
+    svg {
       width: 26px;
       height: 26px;
       position: absolute;
@@ -181,6 +181,20 @@
       right: 5px;
       fill: $dark;
       transform: translate(0,-50%);
+    }
+  }
+
+  &.with-inline-icon {
+    svg {
+      width: 16px;
+      height: 16px;
+      padding: 3px;
+      position: relative;
+      top: 3px;
+      fill: $white;
+      background: $cGreen;
+      border-radius: 50%;
+      margin: 0 0 0 5px;
     }
   }
 

--- a/app/assets/stylesheets/modules/_section-new.scss
+++ b/app/assets/stylesheets/modules/_section-new.scss
@@ -149,16 +149,6 @@ $aside-width: 270px;
         @include animation(loader2,1s,infinite,$easeInOutCubic);
       }
     }
-
-    &.-drawing {
-      svg {
-        display: none;
-        &.-inactive {
-          display: block;
-        }
-      }
-    }
-
   }
 
   .control-pin {

--- a/app/assets/stylesheets/modules/_select.scss
+++ b/app/assets/stylesheets/modules/_select.scss
@@ -212,7 +212,7 @@
       abbr {
         position: absolute;
         top: 50%;
-        right: 30px;
+        right: 50px;
         display: none;
         width: 16px;
         height: 16px;

--- a/app/assets/stylesheets/modules/_select.scss
+++ b/app/assets/stylesheets/modules/_select.scss
@@ -257,10 +257,10 @@
       position: relative;
       z-index: 1010;
       margin: 0;
-      padding: 3px 16px;
+      padding: 10px 16px 0;
       white-space: nowrap;
       input {
-        margin: 1px 0;
+        margin: 0;
         padding: 8px 4px 8px 26px;
         width: 100%;
         outline: 0;
@@ -268,7 +268,7 @@
         border: 1px solid $border;
         font-size: 1em;
         font-family: sans-serif;
-        // background: url('svg-map/control-search.svg') no-repeat 5px center;
+        background: url('svg-map/control-search.svg') no-repeat 5px center;
       }
     }
 

--- a/app/assets/stylesheets/modules/_uploads.scss
+++ b/app/assets/stylesheets/modules/_uploads.scss
@@ -3,16 +3,12 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
+  width: 0;
+  height: 0;
+  overflow: hidden;
   opacity: 0;
 
   input[type="file"] {
     display: block;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
   }
 }

--- a/app/views/layouts/connect.html.erb
+++ b/app/views/layouts/connect.html.erb
@@ -48,6 +48,10 @@
         <%= render 'shared/footer_landing' %>
     </div>
 
+    <div style="display:none">
+      <%= render 'shared/sources_map' %>
+    </div>
+    
     <!-- Javascript -->
     <%= render 'shared/google_carto' %>
     <%= requirejs_include_tag 'connect' %>

--- a/app/views/shared/_notifications.html.erb
+++ b/app/views/shared/_notifications.html.erb
@@ -110,6 +110,10 @@
     <p>Your subscription has been saved correctly.</p>
   </div>
 
+  <div id="notification-my-gfw-subscription-correct2" data-type="success">
+    <p>Your subscription has been saved correctly. <a href="/contribute-data" target="_blank" class="btn medium gray uppercase">Add your own data</a></p>
+  </div>
+
   <div id="notification-my-gfw-subscription-incorrect" data-type="error">
     <p>Sorry, there was an error submitting your subscription.</p>
   </div>


### PR DESCRIPTION
This PR contains several fixes and improvements from the subscription page:
- Core VIEW with a subscribe, unsubscribe and remove function
- Country/region selection shown on map
- Email (auto populate from user)
- Several UX improvements
- Added the same info window for uploading as the map has



There are still some **pending**:
- Remove button to add data to map (add it to "subscription saved" window that appears after the user subscribes (see attached)). I don't want this button to compete with the subscribe button!
- Don't make people sign in (or create a profile) until after they have clicked subscribe
- At least for data sets on GFW, can we change the URL, so, for example, we could send a link to protected area managers with the protected area data set and GLAD alerts pre-selected?
- Replace the text on the page with the text in the attached word document