### PR TITLE
Bug/stories link

### DIFF
--- a/app/assets/javascripts/stories/templates/story.handlebars
+++ b/app/assets/javascripts/stories/templates/story.handlebars
@@ -1,7 +1,7 @@
 <section class="header-stories">
   <div class="inner">
     <header>
-      <a class="back-btn desktop-show" href="/stayinformed/crowdsourced-stories">
+      <a class="back-btn desktop-show" href="/stories/crowdsourcedstories">
         <svg><use xlink:href="#shape-fast-forward-left"></use></svg>
         Back to crowdsourced stories
       </a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,9 @@ Gfw::Application.routes.draw do
   get '/sources' => redirect("http://data.globalforestwatch.org/")
   get '/sources(/:section)' => redirect("http://data.globalforestwatch.org/")
 
+  # stories
+  get '/stayinformed/crowdsourced-stories' => redirect('/stories')
+
   # stayinformed
   get '/stayinformed' => redirect("/")
   get '/stayinformed(/:section)' => redirect("/")
@@ -54,9 +57,6 @@ Gfw::Application.routes.draw do
   # getinvolved
   get '/getinvolved' => redirect("/developers-corner")
   get '/getinvolved(/:section)' => redirect("/developers-corner")
-
-  # stories
-  get '/stayinformed/crowdsourced-stories' => redirect('/stories')
 
   # static
   get '/data' => redirect("sources")


### PR DESCRIPTION
Fix the redirect to `stayinformed` in main menu.
Fix the link to back crowdsourced histories in history detail.