### PR TITLE
Fix/legend tree loss category

### DIFF
--- a/app/assets/javascripts/map/services/MapLayerService.js
+++ b/app/assets/javascripts/map/services/MapLayerService.js
@@ -126,6 +126,7 @@ define([
                 source_json, \
                 category_color, \
                 category_slug, \
+                is_forest_clearing, \
                 category_name, \
                 external, \
                 iso, \

--- a/app/assets/javascripts/map/views/LegendView.js
+++ b/app/assets/javascripts/map/views/LegendView.js
@@ -59,7 +59,7 @@ define([
   'text!map/templates/legend/mex_forest_prod.handlebars',
   'text!map/templates/legend/mex_forest_rest.handlebars',
   'text!map/templates/legend/bra_landcover.handlebars',
-  
+
 ], function(_, Handlebars, Presenter, tpl, lossTpl, imazonTpl, firesTpl,
     forest2000Tpl, pantropicalTpl, idnPrimaryTpl, intact2013Tpl, grumpTpl, storiesTpl, terra_iTpl, concesionesTpl,
     concesionesTypeTpl, hondurasForestTPL,colombiaForestChangeTPL, tigersTPL, dam_hotspotsTPL, us_land_coverTPL,
@@ -156,7 +156,7 @@ define([
       per_protected_areas:Handlebars.compile(perPATpl),
       mex_land_cover:Handlebars.compile(mex_land_coverTpl),
       bra_land_cover:Handlebars.compile(bra_landcoverTPL)
-      
+
     },
 
     events: {
@@ -248,9 +248,8 @@ define([
 
       }, this);
 
-      categoriesGlobal = this.statusCategories(_.groupBy(layersGlobal, function(layer){ return layer.category_slug }));
-      categoriesIso = this.statusCategories(_.groupBy(layersIso, function(layer){ return layer.category_slug }));
-
+      categoriesGlobal = this.statusCategories(this.getLayersByCategory(layersGlobal));
+      categoriesIso = this.statusCategories(this.getLayersByCategory(layersIso));
       // Render
       this.render(this.template({
         categories: (_.isEmpty(categoriesGlobal)) ? false : categoriesGlobal,
@@ -263,13 +262,21 @@ define([
       this.presenter.toggleLayerOptions();
     },
 
+    getLayersByCategory: function(layers){
+      return _.groupBy(layers, function(layer){
+        // Hack to keep the forest_clearing slug in layers which has to be analyzed but not grouped by them in the legend
+        if (layer.category_slug === 'forest_clearing' && !layer.is_forest_clearing) return 'forest_clearing_2';
+        return layer.category_slug;
+      })
+    },
+
     statusCategories: function(array){
       // Search for layer 'nothing'
       var categories_status = this.model.get('categories_status');
       _.each(array, function(category) {
         for (var i = 0; i< category.length; i++) {
           // Mantain categories closed in rendering
-          (categories_status.indexOf(category[i]['category_status']) != -1) ? category['closed'] = true : category['closed'] = false;
+          category['closed'] = categories_status.indexOf(category[i]['category_status']) != -1;
           // Get layer's length of each category
           category['layers_length'] = i + 1;
         }

--- a/app/assets/javascripts/map/views/LegendView.js
+++ b/app/assets/javascripts/map/views/LegendView.js
@@ -264,7 +264,7 @@ define([
 
     getLayersByCategory: function(layers){
       return _.groupBy(layers, function(layer){
-        // Hack to keep the forest_clearing slug in layers which has to be analyzed but not grouped by them in the legend
+        // Hack to keep the forest_clearing slug in layers which have to be analyzed but not grouped by the said slug in the legend
         if (layer.category_slug === 'forest_clearing' && !layer.is_forest_clearing) return 'forest_clearing_2';
         return layer.category_slug;
       })


### PR DESCRIPTION
We have to group by different category to the legend but we have to keep the category_slug for analyze the layer so that's why we add a new column called 'is_forest_changing' and grouped in a different category to the legend in that kind of layers.
![captura de pantalla 2016-10-14 a las 11 29 41](https://cloud.githubusercontent.com/assets/10500650/19383424/7929884c-9204-11e6-9e8c-3f314c03e10f.png)
