### PR TITLE
Add contact form to about page

### DIFF
--- a/app/assets/javascripts/static.js
+++ b/app/assets/javascripts/static.js
@@ -18,6 +18,7 @@ require([
   'static/ApplicationsModalView',
   'static/ContributeDataView',
   'static/GalleryView',
+  'static/ContactUsView',
   'views/HeaderView',
   'views/FooterView',
   'views/SidebarNavView',
@@ -26,7 +27,7 @@ require([
   'views/NotificationsView',
   '_string'
 ], function($, _, Class, Backbone, mps, handlebarsHelpers, RouterStatic, CarrouselView, VideoView, SearchView, FeedbackView, ApplicationsNavView, ApplicationsGridView, ApplicationsModalView, ContributeDataView,
-            GalleryView, HeaderView, FooterView, SidebarNavView, InterestingView, SourceMobileFriendlyView, NotificationsView) {
+            GalleryView, ContactUsView, HeaderView, FooterView, SidebarNavView, InterestingView, SourceMobileFriendlyView, NotificationsView) {
   'use strict';
 
   var LandingPage = Class.extend({
@@ -85,6 +86,7 @@ require([
       new ApplicationsModalView();
       new ContributeDataView();
       new GalleryView();
+      new ContactUsView();
       new NotificationsView();
     }
   });

--- a/app/assets/javascripts/static/ContactUsView.js
+++ b/app/assets/javascripts/static/ContactUsView.js
@@ -208,7 +208,7 @@ define([
 
     validateInput(name, value) {
       let errors = validate.single(value, constraints[name]);
-      if (!!errors) {
+      if (!!errors && this.errors) {
         this.errors[name] = errors[0];
       } else {
         this.errors && this.errors[name] && delete this.errors[name];

--- a/app/assets/javascripts/static/ContactUsView.js
+++ b/app/assets/javascripts/static/ContactUsView.js
@@ -73,6 +73,8 @@ define([
       this.$step = this.$el.find('.step');
       this.$stepBtn = this.$el.find('.step-btn');
       this.$contactMessage = this.$el.find('#contact-message');
+      this.$body = $('html, body');
+      this.$container = $('.content-static');
     },
 
     actionSubmit(e) {
@@ -92,6 +94,9 @@ define([
 
       xhr.onload = function() {
         if (xhr.status === 200 || xhr.status === 201) {
+          this.$body.animate({
+            scrollTop: this.$container.offset().top
+          }, 'slow');
           this.changeStep('success');
           this.resetForm();
           this.$spinner.removeClass('-start');

--- a/app/assets/javascripts/static/ContactUsView.js
+++ b/app/assets/javascripts/static/ContactUsView.js
@@ -64,6 +64,7 @@ define([
     events: {
       'click .js-btn-submit': 'actionSubmit',
       'change input, textarea, select': 'changeInput',
+      'change #contact-topic': 'changeTopic'
     },
 
     initialize: function() {

--- a/app/assets/javascripts/static/ContactUsView.js
+++ b/app/assets/javascripts/static/ContactUsView.js
@@ -1,0 +1,244 @@
+define([
+  'jquery',
+  'backbone'
+], function($, Backbone) {
+
+  'use strict';
+
+  const topics = {
+    'report-a-bug-or-error-on-gfw': {
+      name: 'Report a bug or error on GFW',
+      placeholder: 'Explain the bug or error and tell us where on the website you encountered it. What browser (e.g., Chrome version 50.0.2661.94 m) and operating system (e.g., Windows 8.1) do you use?',
+    },
+    'provide-feedback': {
+      name: 'Provide feedback',
+      placeholder: 'Tell us about your experience with GFW! Examples: How can we improve GFW? Why did you visit GFW? How do you use GFW? If and how is the information provided by GFW useful for your work? Are there any additional features and/or data that would be useful?  Was anything confusing or difficult to use?  Etc...',
+    },
+    'media-request': {
+      name: 'Media request',
+      placeholder: 'How can we help you?',
+    },
+    'data-related-inquiry': {
+      name: 'Data-related inquiry or suggestion',
+      placeholder: 'How can we help you?',
+    },
+    'gfw-commodities-inquiry': {
+      name: 'GFW Commodities inquiry',
+      placeholder: 'How can we help you?',
+    },
+    'gfw-fires-inquiry': {
+      name: 'GFW Fires inquiry',
+      placeholder: 'How can we help you?',
+    },
+    'gfw-climate-inquiry': {
+      name: 'GFW Climate inquiry',
+      placeholder: 'How can we help you?',
+    },
+    'gfw-water-inquiry': {
+      name: 'GFW Water inquiry',
+      placeholder: 'How can we help you?',
+    },
+    'general-inquiry': {
+      name: 'General inquiry',
+      placeholder: 'How can we help you?',
+    },
+  }
+
+  const constraints = {
+    'contact-email': {
+      presence: true,
+      email: true
+    },
+    'contact-topic': {
+      presence: true
+    },
+    'contact-message': {
+      presence: true
+    }
+  };
+
+  var ContacUsView = Backbone.View.extend({
+
+    el: '#contact_us',
+
+    events: {
+      'click .js-btn-submit': 'actionSubmit',
+      'change input, textarea, select': 'changeInput',
+    },
+
+    initialize: function() {
+      this.$spinner = this.$el.find('.m-spinner');
+      this.$form = this.$el.find('#contact-form');
+      this.$step = this.$el.find('.step');
+      this.$stepBtn = this.$el.find('.step-btn');
+      this.$contactMessage = this.$el.find('#contact-message');
+    },
+
+    actionSubmit(e) {
+      e && e.preventDefault();
+      (this.validate(e)) ? this.sendForm() : this.updateForm();
+    },
+
+    // Send the data to the API
+    sendForm() {
+      // Production send request
+      // Send request
+      this.$spinner.addClass('-start');
+      var xhr = new XMLHttpRequest();
+
+      xhr.open('POST', window.gfw.config.GFW_API_HOST + '/emails');
+      xhr.setRequestHeader('Content-Type', 'application/json; charset=utf-8');
+
+      xhr.onload = function() {
+        if (xhr.status === 200 || xhr.status === 201) {
+          this.changeStep('success');
+          this.resetForm();
+          this.$spinner.removeClass('-start');
+        } else {
+          this.changeStep('error');
+          this.$spinner.removeClass('-start');
+        }
+      }.bind(this);
+
+      xhr.onerror = () => {
+        this.changeStep('error');
+        this.$spinner.removeClass('-start');
+      }
+
+      xhr.send(JSON.stringify(this.serialize(this.$form[0])));
+
+      // // Develop Send request
+      // // Comment this code if this is going to pro
+      // if (true) {
+      //   this.changeStep('success');
+      //   this.$spinner.removeClass('-start');
+      // } else {
+      //   this.changeStep('error');
+      //   this.$spinner.removeClass('-start');
+      // }
+    },
+
+    updateForm() {
+      this.$form.find('input, textarea, select').removeClass('-error');
+      this.$form.find('label').removeClass('-error');
+      for (var key in this.errors) {
+        var $input = this.$form.find('#'+key);
+        var $label = this.$form.find('label[for='+key+']');
+        $input.addClass('-error');
+        $label.addClass('-error');
+      }
+    },
+
+    resetForm() {
+      this.$form.find('input, textarea, select').val(null);
+    },
+
+    serialize(form) {
+    	if (!form || form.nodeName !== "FORM") {
+    		return;
+    	}
+    	let obj = {};
+    	for (let i = form.elements.length - 1; i >= 0; i = i - 1) {
+    		if (form.elements[i].name === "") {
+    			continue;
+    		}
+    		switch (form.elements[i].nodeName) {
+    		case 'INPUT':
+    			switch (form.elements[i].type) {
+    			case 'text':
+    			case 'email':
+    			case 'hidden':
+    			case 'password':
+    			case 'button':
+    			case 'reset':
+    			case 'submit':
+    				obj[form.elements[i].name] = form.elements[i].value;
+    				break;
+    			case 'checkbox':
+    			case 'radio':
+            if (form.elements[i].checked) {
+              obj[form.elements[i].name] = form.elements[i].value;
+            } else if (!obj[form.elements[i].name]) {
+              obj[form.elements[i].name] = false;
+            }
+    				break;
+    			case 'file':
+    				break;
+    			}
+    			break;
+    		case 'TEXTAREA':
+    			obj[form.elements[i].name] = form.elements[i].value;
+    			break;
+    		case 'SELECT':
+    			switch (form.elements[i].type) {
+    			case 'select-one':
+    				obj[form.elements[i].name] = form.elements[i].value;
+    				break;
+    			case 'select-multiple':
+    				for (let j = form.elements[i].options.length - 1; j >= 0; j = j - 1) {
+    					if (form.elements[i].options[j].selected) {
+    						obj[form.elements[i].name] = form.elements[i].options[j].value;
+    					}
+    				}
+    				break;
+    			}
+    			break;
+    		case 'BUTTON':
+    			switch (form.elements[i].type) {
+    			case 'reset':
+    			case 'submit':
+    			case 'button':
+    				obj[form.elements[i].name] = form.elements[i].value;
+    				break;
+    			}
+    			break;
+    		}
+    	}
+    	return obj;
+    },
+
+    validate(e) {
+      e && e.preventDefault();
+      let attributes = this.serialize(this.$form[0]);
+
+      // Validate form, if is valid the response will be undefined
+      this.errors = validate(attributes, constraints);
+      return ! !!this.errors;
+    },
+
+    validateInput(name, value) {
+      let errors = validate.single(value, constraints[name]);
+      if (!!errors) {
+        this.errors[name] = errors[0];
+      } else {
+        this.errors && this.errors[name] && delete this.errors[name];
+      }
+    },
+
+    changeInput(e) {
+      e && e.preventDefault();
+      this.validateInput(e.currentTarget.name, e.currentTarget.value);
+      this.updateForm();
+    },
+
+    changeStep(step) {
+      this.$step.removeClass('-active');
+      this.$stepBtn.removeClass('-active');
+
+      // Set actives
+      this.$el.find('.step[data-step="'+step+'"]').addClass('-active');
+      this.$el.find('.step-btn[data-step="'+step+'"]').addClass('-active');
+    },
+
+    changeTopic(e) {
+      var topic = e.currentTarget.value;
+      if (!!topic) {
+        var placeholder = topics[topic]['placeholder'];
+        this.$contactMessage.attr('placeholder', placeholder);
+      }
+    }
+
+  });
+
+  return ContacUsView;
+});

--- a/app/assets/stylesheets/modules/_steps.scss
+++ b/app/assets/stylesheets/modules/_steps.scss
@@ -1,0 +1,15 @@
+.steps {
+
+  > li {
+    display: none;
+    text-transform: none;
+
+    &.-active {
+      display: block;
+    }
+
+    .step-content {
+      padding: 20px 0 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -30,5 +30,6 @@
 @import "modules/section-static";
 @import "modules/section-new";
 @import "modules/static/spinner";
+@import "modules/steps";
 @import "modules/terms";
 @import "layouts/static";

--- a/app/views/shared/_navbar2_landing.html.erb
+++ b/app/views/shared/_navbar2_landing.html.erb
@@ -53,7 +53,7 @@
           <li><a href="/about/videos">Videos</a></li>
           <li><a href="/about/awards_and_testimonials">Awards & testimonials</a></li>
           <li><a href="/about/data_policy">Data policy</a></li>
-          <li><a class="contact-link" href="/about/contact-us">Contact us & feedback</a></li>
+          <li><a href="/about/contact_us">Contact us & feedback</a></li>
         </ul>
       </li>
     </ul>

--- a/app/views/sitemap/index.html.erb
+++ b/app/views/sitemap/index.html.erb
@@ -28,7 +28,7 @@
             <li><a href="/about/videos">Videos</a></li>
             <li><a href="/about/awards_and_testimonials">Awards & testimonials</a></li>
             <li><a href="/about/data_policy">Data Policy</a></li>
-            <li><a class="contact-link" href="/about/contact-us">Contact us & feedback</a></li>
+            <li><a href="/about/contact_us">Contact us & feedback</a></li>
           </ul>
         </div>
 

--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -1,7 +1,7 @@
 <div id="loader-mobile" class="m-spinner -fixed -start">
   <div class="spinner-box">
     <div class="icon"></div>
-  </div>    
+  </div>
 </div>
 
 <section class="header-static">
@@ -45,6 +45,7 @@
           <li><%= link_to 'Videos', "#{about_path}/videos", :"data-slug" => 'videos', :"data-interesting" => 'about_fires, about_commodities, faqs', :class => 'nav-item videos' %><svg class="ico"><use xlink:href="#shape-arrow-right"></use></svg></li>
           <li><%= link_to 'Awards & Testimonials', "#{about_path}/awards_and_testimonials", :"data-slug" => 'awards_and_testimonials', :"data-interesting" => 'about_fires, about_commodities, faqs', :class => 'nav-item awards_and_testimonials' %><svg class="ico"><use xlink:href="#shape-arrow-right"></use></svg></li>
           <li><%= link_to 'Data Policy', "#{about_path}/data-policy", :"data-slug" => 'data_policy', :"data-interesting" => 'about_fires, about_commodities, faqs', :class => 'nav-item data_policy' %><svg class="ico"><use xlink:href="#shape-arrow-right"></use></svg></li>
+          <li><%= link_to 'Contact us', "#{about_path}/contact-us", :"data-slug" => 'contact_us', :"data-interesting" => '', :class => 'nav-item contact_us' %><svg class="ico"><use xlink:href="#shape-arrow-right"></use></svg></li>
         </ul>
       </aside>
       <div id="sources-box" class="sources-box">
@@ -52,7 +53,7 @@
           <div id="sources-spinner" class="m-spinner -start">
             <div class="spinner-box">
               <div class="icon"></div>
-            </div>    
+            </div>
           </div>
 
           <article id='about-gfw' class='source-article'>
@@ -353,6 +354,94 @@
                       </ul>
                     </div>
                   </div>
+                </li>
+              </ul>
+            </div>
+          </article>
+
+          <article id='contact_us' class="source-article">
+            <div class="m-spinner">
+              <div class="spinner-box">
+                <div class="icon"></div>
+              </div>
+            </div>
+            <div>
+              <ul class="steps">
+                <!-- STEP CONTACT -->
+                <li class="step -active" data-step="contact">
+                  <header>
+                    <h2>Contact us & feedback</h2>
+                    <h3>Question, comment, request, feedback? We want to hear from you! Help us improve Global Forest Watch by completing the form below.</h3>
+                  </header>
+                  <div class="step-content">
+                    <form id="contact-form">
+                      <div class="field -default">
+                        <label for="contact-email">Email *</label>
+                        <input id="contact-email" type="email" name="contact-email">
+                      </div>
+                      <div class="field -default">
+                        <label for="contact-topic">Topic *</label>
+                        <div class="m-select">
+                          <select id="contact-topic" class="js- chosen-select default required" name="contact-topic" data-placeholder="Please select a topic so that we can best respond">
+                            <option value="">Select a topic</option>
+                            <option value="report-a-bug-or-error-on-gfw">Report a bug or error on GFW</option>
+                            <option value="provide-feedback">Provide feedback</option>
+                            <option value="media-request">Media request</option>
+                            <option value="data-related-inquiry">Data related inquiry or suggestion</option>
+                            <option value="gfw-commodities-inquiry">GFW Commodities inquiry</option>
+                            <option value="gfw-fires-inquiry">GFW Fires inquiry</option>
+                            <option value="gfw-climate-inquiry">GFW Climate inquiry</option>
+                            <option value="gfw-water-inquiry">GFW Water inquiry</option>
+                            <option value="general-inquiry">General inquiry</option>
+                          </select>
+                        </div>
+                      </div>
+                      <div class="field -default">
+                        <label for="contact-message">Message *</label>
+                        <textarea id="contact-message" name="contact-message" placeholder="How can we help you?"></textarea>
+                      </div>
+                      <div class="field -default">
+                        <h3>INTERESTED IN TESTING NEW FEATURES ON GFW?</h3>
+                        <p>Sign up and become an official GFW tester!</p>
+                        <div class="radio-box -inline">
+                          <div class="custom-radio">
+                            <input id="contact-signup-true" type="radio" name="contact-signup" value="true">
+                            <label for="contact-signup-true">
+                              <span></span> Yes, sign me up.
+                            </label>
+                          </div>
+                          <div class="custom-radio">
+                            <input id="contact-signup-false" type="radio" name="contact-signup" value="false" checked>
+                            <label for="contact-signup-false">
+                              <span></span> No thanks.
+                            </label>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="m-btncontainer">
+                        <button class="btn green medium huge-padding uppercase step-btn js-dinamic-color js-btn-submit -active">Submit</button>
+                      </div>
+                    </form>
+                  </div>
+                </li>
+
+                <!-- STEP SUCCESS -->
+                <li class="step" data-step="success">
+                  <header>
+                    <h2>Thank you for contacting us!</h2>
+                    <h3>Someone will be in touch shortly.</h3>
+                  </header>
+                  <!-- Let's wait until the Pardot team has prepared the newsletter -->
+                  <!-- <div class="step-content">
+                    <iframe src="http://connect.wri.org/l/120942/2016-02-08/2trw5q" width="100%" height="900" type="text/html" frameborder="0" allowTransparency="true" style="border: 0"></iframe>
+                  </div> -->
+                </li>
+
+                <!-- STEP ERROR -->
+                <li class="step" data-step="error">
+                  <header>
+                    <h2>We're sorry, </br>but something went wrong</h2>
+                  </header>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
Use a new form in the about page instead the feedback form of the gfw-assets.

TODO: move the endpoint url to the new one when it is ready.

![image](https://cloud.githubusercontent.com/assets/10500650/19522538/e7a11a80-9617-11e6-875f-43d2aa7e14c7.png)
