### PR TITLE
Feat: User - Required profile data

### DIFF
--- a/app/assets/javascripts/connect/templates/userForm.handlebars
+++ b/app/assets/javascripts/connect/templates/userForm.handlebars
@@ -51,7 +51,11 @@
 
       <label class="m-sel-container">
         Language
+        {{#if errors.language}}
+          <span class="my-gfw-form-error">{{errors.language}}</span>
+        {{/if}}
         <select class="default" name="language">
+          <option disabled selected>Choose your language</option>
           {{#each languages}}
             <option value="{{@key}}">{{this}}</option>
           {{/each}}

--- a/app/views/shared/_notifications.html.erb
+++ b/app/views/shared/_notifications.html.erb
@@ -103,7 +103,11 @@
   </div>
 
   <div id="notification-my-gfw-profile-errors" data-type="error">
-    <p>Please enter your email to sign up as an official tester.</p>
+    <p>Please check the information you've entered.</p>
+  </div>
+
+  <div id="notification-my-gfw-profile-incomplete" data-type="error">
+    <p>Please fill in the missing information in your profile.</p>
   </div>
 
   <div id="notification-my-gfw-subscription-correct" data-type="success">


### PR DESCRIPTION
Support for a new flag for new registered users, to redirect them to their user profile to fill the required information.

The redirect is handled by the gfw-assets bar, then the app handles the rest.