### PR TITLE
Fix: Subscriptions - Legend listeners and remove

### DIFF
--- a/app/assets/javascripts/connect/views/SubscriptionNewView.js
+++ b/app/assets/javascripts/connect/views/SubscriptionNewView.js
@@ -361,7 +361,11 @@ define([
 
     removeSubViews: function() {
       _.each(this.subViews, function(view){
-        view._remove();
+        if (view._remove) {
+          view._remove();
+        } else {
+          view.remove();
+        }
       })
     },
 

--- a/app/assets/javascripts/map/views/LegendView.js
+++ b/app/assets/javascripts/map/views/LegendView.js
@@ -199,7 +199,7 @@ define([
     },
 
     listeners: function() {
-      this.model.on('change:hidden', this.toogleModule, this);
+      this.listenTo(this.model, 'change:hidden', this.toogleModule, this);
     },
 
     render: function(html) {


### PR DESCRIPTION
Solves issue when removing the view, also changed the way the listener was being attached so it gets removed automatically when using `view.remove();`