### PR TITLE
Feature: tooltip for subscriptions draw map

### DIFF
--- a/app/assets/javascripts/connect/views/MapMiniDrawingView.js
+++ b/app/assets/javascripts/connect/views/MapMiniDrawingView.js
@@ -107,9 +107,11 @@ define([
     },
 
     addTooltip: function() {
+      this.clickState = 0;
       this.$map.append('<div class="tooltip">Click to start drawing shape</div>');
       this.$map.mousemove(this.showTooltip.bind(this));
       this.$tooltip = $('.tooltip');
+      this.$map.click(this.updateTooltip.bind(this));
     },
 
     showTooltip: function(e) {
@@ -119,8 +121,22 @@ define([
       }
     },
 
+    updateTooltip: function() {
+      this.clickState++;
+      var newText = '';
+      if (this.clickState === 0) {
+        newText = 'Click to start drawing shape';
+      } else if (this.clickState === 1) {
+        newText = 'Click to continue drawing shape';
+      } else {
+        newText = 'Click the first point to close shape';
+      }
+      this.$tooltip.html(newText);
+    },
+
     removeTooltip: function() {
       this.$tooltip.remove();
+      this.$map.off('click');
       this.$map.off('mousemove');
     },
 

--- a/app/assets/javascripts/connect/views/MapMiniDrawingView.js
+++ b/app/assets/javascripts/connect/views/MapMiniDrawingView.js
@@ -81,7 +81,6 @@ define([
 
       if (is_drawing) {
         this.$el.text('Cancel');
-        this.$el.text('Cancel');
         this.startDrawingManager();
       } else {
         if (is_drawn) {
@@ -108,7 +107,7 @@ define([
     },
 
     addTooltip: function() {
-      this.$map.append('<div class="tooltip">click map to draw</div>');
+      this.$map.append('<div class="tooltip">Click to start drawing shape</div>');
       this.$map.mousemove(this.showTooltip.bind(this));
       this.$tooltip = $('.tooltip');
     },

--- a/app/assets/javascripts/map/views/analysis/AnalysisDrawView.js
+++ b/app/assets/javascripts/map/views/analysis/AnalysisDrawView.js
@@ -63,6 +63,10 @@ define([
       // Upload
       this.$dropable = this.$el.find('#area-dropable-shape');
       this.$fileSelector = this.$el.find('#file-upload-shape');
+
+      // Map for tooltip
+      this.$map = $('#map');
+      this.$offset = this.$map.offset();
     },
 
 
@@ -138,8 +142,23 @@ define([
       return false;
     },
 
+    addTooltip: function() {
+      this.$map.append('<div class="tooltip">Click to start drawing shape</div>');
+      this.$map.mousemove(this.showTooltip.bind(this));
+      this.$tooltip = $('.tooltip');
+    },
 
+    showTooltip: function(e) {
+      for (var i = this.$tooltip.length; i--;) {
+          this.$tooltip[i].style.left = e.pageX - this.$offset.left + 'px';
+          this.$tooltip[i].style.top = e.pageY - this.$offset.top + 'px';
+      }
+    },
 
+    removeTooltip: function() {
+      this.$tooltip.remove();
+      this.$map.off('mousemove');
+    },
 
 
 
@@ -200,6 +219,8 @@ define([
         }
       }.bind(this));
 
+      this.addTooltip();
+
       google.maps.event.addListener(this.drawingManager, 'overlaycomplete', this.completeDrawing.bind(this));
     },
 
@@ -215,6 +236,8 @@ define([
 
       // Bindings
       $(document).off('keyup.drawing');
+
+      this.removeTooltip();
 
       google.maps.event.clearListeners(this.drawingManager, 'overlaycomplete');
     },

--- a/app/assets/javascripts/map/views/analysis/AnalysisDrawView.js
+++ b/app/assets/javascripts/map/views/analysis/AnalysisDrawView.js
@@ -143,9 +143,11 @@ define([
     },
 
     addTooltip: function() {
+      this.clickState = 0;
       this.$map.append('<div class="tooltip">Click to start drawing shape</div>');
       this.$map.mousemove(this.showTooltip.bind(this));
       this.$tooltip = $('.tooltip');
+      this.$map.click(this.updateTooltip.bind(this));
     },
 
     showTooltip: function(e) {
@@ -155,8 +157,22 @@ define([
       }
     },
 
+    updateTooltip: function() {
+      this.clickState++;
+      var newText = '';
+      if (this.clickState === 0) {
+        newText = 'Click to start drawing shape';
+      } else if (this.clickState === 1) {
+        newText = 'Click to continue drawing shape';
+      } else {
+        newText = 'Click the first point to close shape';
+      }
+      this.$tooltip.html(newText);
+    },
+
     removeTooltip: function() {
       this.$tooltip.remove();
+      this.$map.off('click');
       this.$map.off('mousemove');
     },
 

--- a/app/assets/javascripts/map/views/analysis/AnalysisDrawView.js
+++ b/app/assets/javascripts/map/views/analysis/AnalysisDrawView.js
@@ -343,10 +343,8 @@ define([
         .then(function(response) {
             var features = response.data.attributes.features;
             if (!!features && features.length < this.config.FILE_FEATURE_LIMIT) {
-              debugger
               var geojson = features.reduce(turf.union),
               geometry = geojson.geometry;
-              debugger
               this.presenter.status.set({
                 geojson: geometry,
                 fit_to_geom: true
@@ -369,7 +367,8 @@ define([
               } else if (error.detail.indexOf('ERROR 4') > -1) {
                 this.presenter.publishNotification('notification-file-corrupt');
               } else {
-                this.presenter.publishCustomNotification('<p>File issue: ' + error.detail + '</p>', 'error');
+                var error = JSON.parse(error.detail);
+                this.presenter.publishCustomNotification('<p>File issue: ' + error.errors[0].detail + '</p>', 'error');
                }
             }
           }.bind(this))

--- a/app/assets/stylesheets/layouts/_map.scss
+++ b/app/assets/stylesheets/layouts/_map.scss
@@ -108,7 +108,7 @@ body,html{
 
         a {
           position: relative;
-          
+
           &.google-logo, &.gee-logo, &.cartodb-logo {
             top: 2px;
           }
@@ -194,6 +194,7 @@ body,html{
   &.is-loaded {
     opacity: 1;
   }
+
   &.urthecast-incorrect-zoom {
     &:after {
       content: "";
@@ -203,6 +204,22 @@ body,html{
       height: 100%;
       width: 100%;
     }
+  }
+
+  &:hover .tooltip {
+    opacity: 0.6;
+    transition: opacity 0.5s ease-in-out;
+  }
+
+  .tooltip {
+    opacity: 0;
+    background: #000000;
+    color: $white;
+    margin-left: 15px;
+    padding: 15px;
+    position: absolute;
+    z-index: 1000;
+    font-size: 12px;
   }
 }
 
@@ -323,4 +340,3 @@ body,html{
     font-size: 8px !important;
   }
 }
-

--- a/app/assets/stylesheets/modules/connect/_subscription.scss
+++ b/app/assets/stylesheets/modules/connect/_subscription.scss
@@ -17,17 +17,19 @@
       position: relative;
 
       &:hover .tooltip {
-        opacity: 1;
+        opacity: 0.6;
         transition: opacity 0.5s ease-in-out;
       }
 
       .tooltip {
-          opacity: 0;
-          background: #ffffff;
-          margin-left: 5px;
-          padding: 10px 20px;
-          position: absolute;
-          z-index: 1000;
+        opacity: 0;
+        background: #000000;
+        color: $white;
+        margin-left: 15px;
+        padding: 15px;
+        position: absolute;
+        z-index: 1000;
+        font-size: 12px;
       }
     }
 

--- a/app/assets/stylesheets/modules/connect/_subscription.scss
+++ b/app/assets/stylesheets/modules/connect/_subscription.scss
@@ -14,6 +14,21 @@
   .m-map {
     .map {
       height: 400px;
+      position: relative;
+
+      &:hover .tooltip {
+        opacity: 1;
+        transition: opacity 0.5s ease-in-out;
+      }
+
+      .tooltip {
+          opacity: 0;
+          background: #ffffff;
+          margin-left: 5px;
+          padding: 10px 20px;
+          position: absolute;
+          z-index: 1000;
+      }
     }
 
     .map-controls-box {


### PR DESCRIPTION
Add an instruction tooltip to the map when user begins drawing on subscriptions map:
- Append tooltip when user clicks 'start drawing' button
- Add listener for mousemove with tooltip tracking with cursor location
- CSS transition opacity for smooth view (no official design yet)
- When user finishes drawing or cancels drawing, remove tooltip and listener