### PR TITLE
Fixes query to get ranking for forest gain

### DIFF
--- a/app/assets/javascripts/countries/views/CountryOverviewView.js
+++ b/app/assets/javascripts/countries/views/CountryOverviewView.js
@@ -315,7 +315,7 @@ define([
         $('.countries_list__header__minioverview').hide();
         var mode = JSON.parse(sessionStorage.getItem('OVERVIEWMODE'));
 
-        var sql = 'SELECT umd.iso, c.name, c.enabled, Sum(umd.gain) gain FROM umd_nat_final_1 umd, gfw2_countries c WHERE umd.iso = c.iso AND NOT loss = 0 AND umd.year > 2000 GROUP BY umd.iso, c.name, c.enabled ORDER BY gain DESC ';
+        var sql = 'SELECT umd.iso, c.name, c.enabled, Sum(umd.gain) gain FROM umd_nat_final_1 umd, gfw2_countries c WHERE umd.iso = c.iso AND NOT loss = 0 AND gain IS NOT NULL AND umd.year > 2000 GROUP BY umd.iso, c.name, c.enabled ORDER BY gain DESC ';
         if (!!mode && mode.mode == 'percent')
             sql = 'SELECT (u.gain*12/u.extent_2000)*100 as ratio, country as name, c.iso as iso, c.enabled, u.iso as iso2 from umd_nat_final_1 u, gfw2_countries c  WHERE thresh = 50 AND u.gain IS NOT NULL AND c.iso = u.iso AND extent_2000 > 10  group by ratio, country, u.iso, c.iso, c.enabled order by ratio desc ';
         if (e) {


### PR DESCRIPTION
The query wasn't ignoring null rows, now it does.