### PR TITLE
Feat: Add Canadian petrolium and natural gas

### DIFF
--- a/app/assets/javascripts/map/cartocss/style.cartocss
+++ b/app/assets/javascripts/map/cartocss/style.cartocss
@@ -205,6 +205,13 @@
     polygon-clip: false;
   }
 
+  [layer='can_oil'] {
+     polygon-fill: #d980ff;
+     line-color: #c233ff;
+     line-clip: false;
+     polygon-clip: false;
+  }
+
   [layer='cmr_mining'] {
     polygon-fill: #fd8d3c;
     line-color: #fd8d3c;

--- a/app/assets/javascripts/map/helpers/layersHelper.js
+++ b/app/assets/javascripts/map/helpers/layersHelper.js
@@ -29,6 +29,7 @@ define([
   'map/views/layers/CogLoggingLayer',
   'map/views/layers/MysLoggingLayer',
   'map/views/layers/MiningLayer',
+  'map/views/layers/CanOilLayer',
   'map/views/layers/CanMiningLayer',
   'map/views/layers/CmrMiningLayer',
   'map/views/layers/CodMiningLayer',

--- a/app/assets/javascripts/map/helpers/layersHelper.js
+++ b/app/assets/javascripts/map/helpers/layersHelper.js
@@ -208,6 +208,7 @@ define([
   CogLoggingLayer,
   MysLoggingLayer,
   MiningLayer,
+  CanOilLayer,
   CanMiningLayer,
   CmrMiningLayer,
   CodMiningLayer,
@@ -448,6 +449,9 @@ define([
     },
     mining: {
       view: MiningLayer
+    },
+    can_oil: {
+      view: CanOilLayer
     },
     can_mining: {
       view: CanMiningLayer

--- a/app/assets/javascripts/map/models/LayerSpecModel.js
+++ b/app/assets/javascripts/map/models/LayerSpecModel.js
@@ -121,6 +121,7 @@ define([
       "bra_mining",
       "mex_mining",
       "per_mining",
+      "can_oil",
       "can_mining",
       "col_mining",
       "khm_mining",

--- a/app/assets/javascripts/map/templates/infowindow.handlebars
+++ b/app/assets/javascripts/map/templates/infowindow.handlebars
@@ -73,6 +73,14 @@
           <h4>Loss alert date:</h4>
           <p>{{content.data.dates}}</p>
         {{/if}}
+        {{#if content.data.date_issued}}
+          <h4>Date issued:</h4>
+          <p>{{content.data.date_issued}}</p>
+        {{/if}}
+        {{#if content.data.expiry_date}}
+          <h4>Expiry date:</h4>
+          <p>{{content.data.expiry_date}}</p>
+        {{/if}}
         {{#if content.data.mineral}}
           <h4>Mineral:</h4>
           <p>{{content.data.mineral}}</p>

--- a/app/assets/javascripts/map/views/layers/CanOilLayer.js
+++ b/app/assets/javascripts/map/views/layers/CanOilLayer.js
@@ -1,0 +1,27 @@
+/**
+ * The Canadian Oil layer module (copied from the CanMiningLayer module originally).
+ *
+ * @return OilLayer class (extends CartoDBLayerClass)
+ */
+define([
+  'abstract/layer/CartoDBLayerClass',
+], function(CartoDBLayerClass) {
+
+  'use strict';
+
+  var CanOilLayer = CartoDBLayerClass.extend({
+
+    options: {
+      sql: 'SELECT \'can_oil\' as tablename, cartodb_id, the_geom_webmercator, tenure_nam as name, tenure_num as permit_num, company as owner, tenure_typ as type, date_issue as date_issued, date_end as expiry_date, \'{tableName}\' AS layer, {analysis} AS analysis FROM {tableName}' ,
+      infowindow: true,
+      interactivity: 'cartodb_id, tablename, name, tenure_num, owner, permit_num, type, province, date_issued, expiry_date, analysis',
+      analysis: true
+    }
+
+
+
+  });
+
+  return CanOilLayer;
+
+});

--- a/app/assets/javascripts/map/views/layers/CanOilLayer.js
+++ b/app/assets/javascripts/map/views/layers/CanOilLayer.js
@@ -12,9 +12,9 @@ define([
   var CanOilLayer = CartoDBLayerClass.extend({
 
     options: {
-      sql: 'SELECT \'can_oil\' as tablename, cartodb_id, the_geom_webmercator, tenure_nam as name, tenure_num as permit_num, company as owner, tenure_typ as type, date_issue as date_issued, date_end as expiry_date, \'{tableName}\' AS layer, {analysis} AS analysis FROM {tableName}' ,
+      sql: 'SELECT \'can_oil\' as tablename, cartodb_id, the_geom_webmercator, province, tenure_nam as name, tenure_num as permit_num, company as owner, tenure_typ as type, date_issue as date_issued, date_end as expiry_date, \'{tableName}\' AS layer, {analysis} AS analysis FROM {tableName}' ,
       infowindow: true,
-      interactivity: 'cartodb_id, tablename, name, tenure_num, owner, permit_num, type, province, date_issued, expiry_date, analysis',
+      interactivity: 'cartodb_id, tablename, name, owner, permit_num, type, province, date_issued, expiry_date, analysis',
       analysis: true
     }
 


### PR DESCRIPTION
This PR addresses the bascamp issue **Add Canada petroleum and natural gas to staging**

![screen shot 2017-04-26 at 10 23 14](https://cloud.githubusercontent.com/assets/6503031/25425046/e5da8b9a-2a6a-11e7-987e-68f72e44196d.png)

Note. The Info box slug *can_oil* is correctly connected on the *layerspec*, however, in testing no metadata was returned indicating a problem on the gfw-owned micro-service side.