### PR TITLE
Feat: Update Indonedia Leuser boundary

### DIFF
--- a/app/assets/javascripts/map/cartocss/style.cartocss
+++ b/app/assets/javascripts/map/cartocss/style.cartocss
@@ -572,7 +572,8 @@
     line-opacity: 1;
   }
 
-  [layer='idn_leuser']{
+  [layer='idn_leuser'],
+  [layer='leuser_ecosystem_province_boundary']{
     polygon-fill: #5CA2AA;
     polygon-opacity: 0.7;
     line-color: #5CA0AA;

--- a/app/assets/javascripts/map/views/layers/IdnLeuserLayer.js
+++ b/app/assets/javascripts/map/views/layers/IdnLeuserLayer.js
@@ -12,7 +12,7 @@ define([
   var IdnLeuserLayer = CartoDBLayerClass.extend({
 
     options: {
-      sql: 'SELECT \'idn_leuser\' as tablename, cartodb_id, the_geom_webmercator, name,  round(area_ha::float) as area_ha, \'{tableName}\' AS layer, {analysis} AS analysis FROM {tableName}' ,
+      sql: 'SELECT \'leuser_ecosystem_province_boundary\' as tablename, cartodb_id, the_geom_webmercator, name,  round(area_ha::float) as area_ha, \'{tableName}\' AS layer, {analysis} AS analysis FROM {tableName}' ,
       infowindow: true,
       interactivity: 'cartodb_id, tablename, name, area_ha, analysis',
       analysis: true


### PR DESCRIPTION
We have been asked to update the boundary of the Lesure Ecosystem, via a Basecamp issue from Alyssa Barrett. Previous boundary had details removed. They sent a new shape-file, which I added to a [new table](https://wri-01.carto.com/tables/leuser_ecosystem_province_boundary/table) on WRI01 carto account. After this, a minor update to modify the table name in the JS class and css were needed. The effect of the changes are shown below:

![old_jagged](https://cloud.githubusercontent.com/assets/6503031/25657021/0fc7c210-2ffc-11e7-8e2c-4d7a537150e7.png)

![updated_hd](https://cloud.githubusercontent.com/assets/6503031/25657020/0fc74d3a-2ffc-11e7-8352-837cfc775d57.png)


