### PR TITLE
closed SGF application period

### DIFF
--- a/app/views/small_grants_fund/index.html.erb
+++ b/app/views/small_grants_fund/index.html.erb
@@ -94,15 +94,7 @@
         <h2 class="section-title _light">How to apply</h2>
       </header>
       <p>
-        The Small Grants Fund is currently accepting applications for the 2017 cycle.
-        Please read the
-        <a target="_blank "href="https://s3.amazonaws.com/gfw-files/Guidelines_for_Applicants_2016_final_v2.pdf">Guidelines for Applicants</a>
-        thoroughly before applying. You may also want to review the
-        <a target="_blank" href="/howto/categories/faqs/?filters=%5b%22small-grants-fund%22%5d&page=0">SGF Frequently Asked Questions</a>,
-        the tutorials on the <a target="_blank" href="/howto/">How To Portal</a>,
-        and the
-        <a target="_blank" href="http://blog.globalforestwatch.org/gfw-community/2017-small-grants-fund-applications-now-open.html">call for applications announcement</a>
-        on the GFW blog. For questions write to <a href="mailto:gfwfund@wri.org">gfwfund@wri.org</a>
+        The Small Grants Fund application period is now closed. For questions about the Small Grants Fund, or to sign up to be notified when the application period opens, please write to <a href="mailto:gfwfund@wri.org">gfwfund@wri.org</a>.
       </p>
       <p><a class="btn -primary" target="_blank" href="https://gfw.fluidreview.com/">Apply now</a></p>
     </div>


### PR DESCRIPTION
Under How To Apply, changed text to: The Small Grants Fund application period is now closed. For questions about the Small Grants Fund, or to sign up to be notified when the application period opens, please write to gfwfund@wri.org.