### PR TITLE
User data for Haiti watershed areas

### DIFF
--- a/app/assets/javascripts/map/cartocss/style.cartocss
+++ b/app/assets/javascripts/map/cartocss/style.cartocss
@@ -702,12 +702,14 @@
   line-width: 0.5;
   line-opacity: 1;
 }
-  [layer='sen_user_protected_areas'] {
+
+  [layer='sen_user_protected_areas'],[layer='hti_user_watersheds'] {
     polygon-fill: #fecc5c;
     line-color: #b15928;
     line-clip: false;
     polygon-clip: false;
   }
+  
   [layer='ecu_user_protected_areas'] {
     polygon-fill: #fecc5c;
     line-color: #b15928;

--- a/app/assets/javascripts/map/helpers/layersHelper.js
+++ b/app/assets/javascripts/map/helpers/layersHelper.js
@@ -162,6 +162,7 @@ define([
   'map/views/layers/LbrDevExL',
   'map/views/layers/PakUserMangrovesLayer',
   'map/views/layers/SenUserProtectedAreasLayer',
+  'map/views/layers/HaitiWatershedLayer',
   'map/views/layers/EcuUserProtectedAreasLayer',
   'map/views/layers/BolUserFireFrequencyLayer',
   // high resolution maps
@@ -340,6 +341,7 @@ define([
   LbrDevExL,
   PakUserMangrovesLayer,
   SenUserProtectedAreasLayer,
+  HaitiWatershedLayer,
   EcuUserProtectedAreasLayer,
   BolUserFireFrequencyLayer,
   //highres layers
@@ -851,6 +853,9 @@ define([
     },
     sen_user_protected_areas: {
       view: SenUserProtectedAreasLayer
+    },
+    hti_user_watersheds: {
+      view: HaitiWatershedLayer
     },
     ecu_user_protected_areas: {
       view: EcuUserProtectedAreasLayer

--- a/app/assets/javascripts/map/models/LayerSpecModel.js
+++ b/app/assets/javascripts/map/models/LayerSpecModel.js
@@ -65,6 +65,7 @@ define([
       "idn_peat_lands",
       "pak_user_mangroves",
       "sen_user_protected_areas",
+      "hti_user_watersheds",
       "ecu_user_protected_areas",
       "bol_user_fire_frequency",
       // PEOPLE

--- a/app/assets/javascripts/map/views/layers/HaitiWatershedLayer.js
+++ b/app/assets/javascripts/map/views/layers/HaitiWatershedLayer.js
@@ -1,0 +1,27 @@
+/**
+ * The Haiti Watershed User Data layer module.
+ *
+ * @return HaitiWatershed class (extends CartoDBLayerClass)
+ */
+define([
+  'abstract/layer/CartoDBLayerClass',
+], function(CartoDBLayerClass) {
+
+  'use strict';
+
+  var HaitiWatershedLayer = CartoDBLayerClass.extend({
+
+    options: {
+      sql: 'SELECT cartodb_id, the_geom_webmercator, \'{tableName}\' as tablename, area_ha, zone_1 as zone, nom as name , \'{tableName}\' AS layer, {analysis} AS analysis FROM {tableName}',
+      infowindow: true,
+      interactivity: 'cartodb_id, tablename, area_ha, name, zone, analysis',
+      analysis: true
+    }
+
+
+
+  });
+
+  return HaitiWatershedLayer;
+
+});


### PR DESCRIPTION
Added a new layer for Haiti Watersheds (user data) in response to a [basecamp request](https://basecamp.com/3063126/projects/10726176/todos/308528958).

![screen shot 2017-05-17 at 14 29 43](https://cloud.githubusercontent.com/assets/6503031/26153878/a18c201c-3b0d-11e7-862c-fd300e1447ba.png)
