### PR TITLE
Feat: FORMA Active clearing alerts - Updated timeframe

### DIFF
--- a/app/assets/javascripts/map/views/layers/FormaActivityLayer.js
+++ b/app/assets/javascripts/map/views/layers/FormaActivityLayer.js
@@ -27,9 +27,9 @@ define([
       _.bindAll(this, 'setCurrentDate');
       this.presenter = new Presenter(this);
 
-      // Default to 24 hours
+      // Default to 48 hours
       var currentDate = options.currentDate ||
-        [moment().subtract(24, 'hours'), moment()];
+        [moment().subtract(2, 'days').utc(), moment()];
       this.setCurrentDate(DatesHelper.getRangeForDates(currentDate));
 
       this._super(layer, options, map);

--- a/app/assets/javascripts/map/views/timeline/FormaActivityTimeline.js
+++ b/app/assets/javascripts/map/views/timeline/FormaActivityTimeline.js
@@ -18,15 +18,15 @@ define([
     label: 'past month',
     duration: 0
   }, {
-    start: moment().subtract(2, 'days').utc(),
+    start: moment().subtract(7, 'days').utc(),
     end: moment().utc(),
     label: 'past week',
-    duration: 48
+    duration: 168
   }, {
-    start: moment().subtract(1, 'days').utc(),
+    start: moment().subtract(2, 'days').utc(),
     end: moment().utc(),
-    label: 'past 24 hours',
-    duration: 24
+    label: 'past 48 hours',
+    duration: 48
   }];
 
   var FormaActivityTimeline = TimelineBtnClass.extend({
@@ -42,10 +42,9 @@ define([
       };
 
       if (!(currentDate && currentDate[0] && currentDate[1])) {
-        currentDate = [moment().subtract(24, 'hours'), moment()];
+        currentDate = [moment().subtract(2, 'days').utc(), moment.utc()];
       }
       currentDate = DatesHelper.getRangeForDates(currentDate, AVAILABLE_DATE_RANGES);
-
 
       FormaActivityTimeline.__super__.initialize.apply(this, [layer, currentDate]);
     },


### PR DESCRIPTION
Updated default timeframe to be 48 hours instead of 24.

![screen shot 2017-05-22 at 15 25 12](https://cloud.githubusercontent.com/assets/4885740/26310944/e2d783ec-3f02-11e7-9840-0e1f80e127a8.png)

