### PR TITLE
Landsat 2016 basemap

### DIFF
--- a/app/assets/javascripts/map/templates/maptype.handlebars
+++ b/app/assets/javascripts/map/templates/maptype.handlebars
@@ -32,6 +32,7 @@
           <li class="maptype landsat" data-maptype="landsat2013"><i></i>Landsat 2013</li>
           <li class="maptype landsat" data-maptype="landsat2014"><i></i>Landsat 2014</li>
           <li class="maptype landsat" data-maptype="landsat2015"><i></i>Landsat 2015</li>
+          <li class="maptype landsat" data-maptype="landsat2016"><i></i>Landsat 2016</li>
         </ul>
       </ul>
     </div>

--- a/app/assets/javascripts/map/templates/tabs/basemaps.handlebars
+++ b/app/assets/javascripts/map/templates/tabs/basemaps.handlebars
@@ -22,9 +22,9 @@
       <li class="maptype landsat2004" data-maptype="landsat2004">Landsat 2004</li>
       <li class="maptype landsat2005" data-maptype="landsat2005">Landsat 2005</li>
       <li class="maptype landsat2006" data-maptype="landsat2006">Landsat 2006</li>
+      <li class="maptype landsat2007" data-maptype="landsat2007">Landsat 2007</li>
     </div>
     <div>
-      <li class="maptype landsat2007" data-maptype="landsat2007">Landsat 2007</li>
       <li class="maptype landsat2008" data-maptype="landsat2008">Landsat 2008</li>
       <li class="maptype landsat2009" data-maptype="landsat2009">Landsat 2009</li>
       <li class="maptype landsat2010" data-maptype="landsat2010">Landsat 2010</li>
@@ -32,7 +32,8 @@
       <li class="maptype landsat2012" data-maptype="landsat2012">Landsat 2012</li>
       <li class="maptype landsat2013" data-maptype="landsat2013">Landsat 2013</li>
       <li class="maptype landsat2014" data-maptype="landsat2014">Landsat 2014</li>
-      <li class="maptype landsat2014" data-maptype="landsat2015">Landsat 2015</li>
+      <li class="maptype landsat2015" data-maptype="landsat2015">Landsat 2015</li>
+      <li class="maptype landsat2016" data-maptype="landsat2016">Landsat 2016</li>
     </div>
   </ul>
 

--- a/app/assets/javascripts/map/views/MapView.js
+++ b/app/assets/javascripts/map/views/MapView.js
@@ -458,7 +458,7 @@ define([
       this.map.mapTypes.set('dark', darkMaptype());
       this.map.mapTypes.set('positron', positronMaptype());
       this.map.mapTypes.set('openstreet', openStreetMaptype());
-      for (var i = 1999; i <= 2015; i++) {
+      for (var i = 1999; i <= 2016; i++) {
         this.map.mapTypes.set('landsat{0}'.format(i), landsatMaptype([i]));
       }
     },

--- a/app/assets/javascripts/map/views/maptypes/landsatMaptype.js
+++ b/app/assets/javascripts/map/views/maptypes/landsatMaptype.js
@@ -18,6 +18,9 @@ define([], function () {
         if (year[0] === 2015) {
           url = 'https://storage.googleapis.com/landsat-cache/2015/{0}/{1}/{2}.png'.format(z, x, ll.y);
         }
+        if (year[0] === 2016) {
+          url = 'https://storage.googleapis.com/landsat-cache/2016/{0}/{1}/{2}.png'.format(z, x, ll.y);
+        }
         return url;
       },
     };


### PR DESCRIPTION
* We have added tiles for Landsat 2016 (up to z-level 6) and hooked them up to the front-end

Note: the Earth Engine specifics to replicate these data are:

```javascript
var collection = ee.ImageCollection('LANDSAT/LC8_L1T').filterDate('2016-01-01T00:00','2017-01-01T00:00');
var composite = ee.Algorithms.Landsat.simpleComposite({collection: collection, percentile: 50, maxDepth:80, cloudScoreRange: 1, asFloat:true});
var hsv2 = composite.select(['B4', 'B3', 'B2']).rgbToHsv();    
var sharpened2 = ee.Image.cat([hsv2.select('hue'), hsv2.select('saturation'), composite.select('B8')]).hsvToRgb().visualize({gain:1000, gamma: [1.15, 1.4, 1.15]});
```
The tiles were exported to the GCS bucket `landsat-cache/2016/`

![screen shot 2017-05-26 at 11 57 16](https://cloud.githubusercontent.com/assets/6503031/26490252/dd045ba6-420a-11e7-8646-e4158224e4dc.png)
