### PR TITLE
Forma metadata

### DIFF
--- a/app/assets/javascripts/map/templates/layersNav.handlebars
+++ b/app/assets/javascripts/map/templates/layersNav.handlebars
@@ -29,12 +29,12 @@
             </li>
             <li class="layer" data-layer="forma_month_3">
               <span class="onoffradio"><span></span></span>
-              <span class="layer-title">FORMA alerts<a href='#' data-source='forma' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
+              <span class="layer-title">FORMA alerts<a href='#' data-source='forma_250_alerts' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
               <span class="layer-info">(daily,  250m, tropics, WRI/Google)</span>
             </li>
             <li class="layer" data-layer="forma_activity">
               <span class="onoffradio"><span></span></span>
-              <span class="layer-title">FORMA active clearing alerts<a href='#' data-source='forma' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
+              <span class="layer-title">FORMA active clearing alerts<a href='#' data-source='forma_250_active_clearing_alerts' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
               <span class="layer-info">(daily, 250m, tropics, WRI/Google)</span>
             </li>
             <li class="layer" data-layer="terrailoss">


### PR DESCRIPTION
Added metadata for Forma menu items (alerts and active clearing alerts). Connected to [BC thread](https://basecamp.com/3063126/projects/10726176/todos/303096581#events_todo_303096581).

Layerspec (nuclear_hazard) has also been updated: `source_json` entries 936 and 937.

![forma2](https://user-images.githubusercontent.com/6503031/27072875-25f82f7a-5022-11e7-8f25-830b16d3df8a.gif)
