### PR TITLE
Improve tree cover loss alerts widget

### DIFF
--- a/app/assets/javascripts/common/views/LineGraphView.js
+++ b/app/assets/javascripts/common/views/LineGraphView.js
@@ -41,7 +41,12 @@ define([
     initialize: function(settings) {
       this.defaults = _.extend({}, this.defaults, settings);
       this.data = this.defaults.data;
-
+      if (this.data.length > 12 && this.defaults.treeCoverLossAlerts) {
+        var pastMonths = this.data.length - 12;
+        for (var i = 0; i < pastMonths; i++) {
+          this.data.shift();
+        }
+      }
       this._initChart();
 
       // Sets listeners

--- a/app/assets/javascripts/countries/templates/widgets/treeCoverLossAlerts.handlebars
+++ b/app/assets/javascripts/countries/templates/widgets/treeCoverLossAlerts.handlebars
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="small-12">
       <h4 class="title -icons">
-        Monthly tree cover loss alerts
+        Monthly counts
       <div class="widget-actions">
         <svg class="icon icon-info-green"><use xlink:href="#icon-info-green"></use></svg>
         <svg class="icon icon-gray-share js-share-link" data-share-embed-url="/embed/country_widget/tree_cover_loss_alerts/{{iso}}{{#if region}}/{{region}}{{/if}}" data-share-embed-width="600" data-share-embed-height="420"><use xlink:href="#icon-gray-share"></use></svg>

--- a/app/assets/javascripts/countries/views/widgets/TreeCoverLossAlertsView.js
+++ b/app/assets/javascripts/countries/views/widgets/TreeCoverLossAlertsView.js
@@ -250,9 +250,14 @@ define([
         this.widgetViews = [];
         this.$widgets.html('');
         this.data = _.sortBy(this.data, 'alerts');
-        for(var i = 0; i < this.data.length; i++) {
-          this.data[i].alerts = parseInt((this.data[i].alerts).replace(',',''));
+        for (var i = 0; i < this.data.length; i++) {
+          for (var j = 0; j < this.data[i].data.length; j++) {
+            if (j === this.data[i].data.length - 1) {
+              this.data[i].alerts = this.data[i].data[j].value;
+            }
+          }
         }
+        this.data = _.sortBy(this.data, 'alerts');
         this.data = _.sortBy(this.data, 'alerts');
         var keys = Object.keys(this.data);
         keys.forEach(function(key, index) {

--- a/app/assets/javascripts/countries/views/widgets/TreeCoverLossAlertsView.js
+++ b/app/assets/javascripts/countries/views/widgets/TreeCoverLossAlertsView.js
@@ -74,13 +74,13 @@ define([
     },
     wdpa: {
       glad: {
-        top: '/query?sql=SELECT SUM (alerts) as alerts, year, wdpa_id, state_id FROM {dataset} WHERE year={year} AND country_iso=\'{iso}\' {region} GROUP BY wdpa_id, state_id ORDER BY alerts DESC limit {widgetsNum}',
-        data: '/query?sql=select sum(alerts) as alerts, year, month, wdpa_id from {dataset} WHERE country_iso=\'{iso}\' AND year={year} AND wdpa_id IN({ids}) AND group by wdpa_id, month, year ORDER BY month ASC',
+        top: '/query?sql=SELECT SUM (alerts) as alerts, year, state_id FROM {dataset} WHERE year={year} AND country_iso=\'{iso}\' {region} GROUP BY state_id ORDER BY alerts DESC limit {widgetsNum}',
+        data: '/query?sql=select alerts, year, month, state_id from {dataset} WHERE country_iso=\'{iso}\' AND year IN({year},{pastYear}) AND state_id IN({ids}) ORDER BY state_id, year, month ASC',
         names: 'SELECT name WHERE wdpa_pid IN({wdpaIds})'
       },
       terrai: {
-        top: '/query?sql=SELECT SUM (count) as alerts, year, wdpa_id FROM {dataset} WHERE year={year} AND country_id=\'{iso}\' {region} GROUP BY wdpa_id ORDER BY alerts DESC limit {widgetsNum}',
-        data: '/query?sql=select sum(count) as alerts, year, month, wdpa_id from {dataset} WHERE country_id=\'{iso}\' AND year={year} AND wdpa_id IN({ids}) AND group by wdpa_id, month, year ORDER BY month ASC',
+        top: '/query?sql=SELECT SUM (count) as alerts, year, state_id FROM {dataset} WHERE year={year} AND country_id=\'{iso}\' {region} GROUP BY state_id ORDER BY count DESC limit {widgetsNum}',
+        data: '/query?sql=select count, year, month, state_id from {dataset} WHERE country_id=\'{iso}\' AND year IN({year},{pastYear}) AND state_id IN({ids}) ORDER BY state_id, year, month ASC',
         names: 'SELECT name WHERE wdpa_pid IN({wdpaIds})'
       }
     },
@@ -282,14 +282,14 @@ define([
       var pastYear = year - 1;
       var queryTemplate = API_HOST + QUERIES[origin][source].top;
       var url = new UriTemplate(queryTemplate).fillFromObject({
-        widgetsNum: origin === 'wdpa' ? 3 : WIDGETS_NUM,
+        widgetsNum: origin === 'wdpa' ? WIDGETS_NUM : WIDGETS_NUM,
         dataset: DATASETS[origin][source],
         iso: iso,
         year: year,
         region: this.region != 0 ? 'AND state_id = '+this.region+'' : '',
       });
+      console.log(url);
       var promise = $.Deferred();
-
       $.ajax({ url: url, type: 'GET' })
         .done(function(topResponse) {
           if (topResponse.data.length > 0) {
@@ -310,7 +310,7 @@ define([
                 });
 
                 var ids = topResponse.data.map(function(item) {
-                  return origin === 'wdpa' ? item.wdpa_id : item.state_id
+                  return origin === 'wdpa' ? item.state_id : item.state_id
                 }).join('\',\'');
 
                 var url = API_HOST + new UriTemplate(QUERIES[origin][source].data).fillFromObject({

--- a/app/assets/javascripts/countries/views/widgets/TreeCoverLossAlertsView.js
+++ b/app/assets/javascripts/countries/views/widgets/TreeCoverLossAlertsView.js
@@ -250,11 +250,15 @@ define([
         this.widgetViews = [];
         this.$widgets.html('');
         this.data = _.sortBy(this.data, 'alerts');
+        for(var i = 0; i < this.data.length; i++) {
+          this.data[i].alerts = parseInt((this.data[i].alerts).replace(',',''));
+        }
+        this.data = _.sortBy(this.data, 'alerts');
         var keys = Object.keys(this.data);
         keys.forEach(function(key, index) {
           this.$widgets.append(this.cardTemplate({
             ranking: index + 1,
-            alerts: this.data[key].alerts,
+            alerts: this.data[key].alerts.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ","),
             name: this.data[key].name,
             linkImagery: '/map/9/'+this.longitude+'/'+this.latitude+'/'+countryLink+'-'+regionLink+'/grayscale/'+layerLink+'/685?tab=hd-tab&hresolution=eyJ6b29tIjo5LCJzYXRlbGxpdGUiOiJoaWdocmVzIiwiY29sb3JfZmlsdGVyIjoicmdiIiwicmVuZGVyZXIiOiJSR0IgKFJlZCBHcmVlbiBCbHVlKSIsInNlbnNvcl9wbGF0Zm9ybSI6InNlbnRpbmVsLTIiLCJzZW5zb3JfbmFtZSI6IlNlbnRpbmVsIDIiLCJjbG91ZCI6IjMwIiwibWluZGF0ZSI6IjIwMTctMDEtMjUiLCJtYXhkYXRlIjoiMjAxNy0wNS0yNSJ9',
             linkSubscribe: '/my_gfw/subscriptions/new?aoi=country&datasets='+sourceLink+'&country='+countryLink+'&region='+regionLink+'',
@@ -288,7 +292,6 @@ define([
         year: year,
         region: this.region != 0 ? 'AND state_id = '+this.region+'' : '',
       });
-      console.log(url);
       var promise = $.Deferred();
       $.ajax({ url: url, type: 'GET' })
         .done(function(topResponse) {

--- a/app/assets/javascripts/countries/views/widgets/TreeCoverLossAlertsView.js
+++ b/app/assets/javascripts/countries/views/widgets/TreeCoverLossAlertsView.js
@@ -249,6 +249,7 @@ define([
         var layerLink = this.status.get('layerLink');
         this.widgetViews = [];
         this.$widgets.html('');
+        this.data = _.sortBy(this.data, 'alerts');
         var keys = Object.keys(this.data);
         keys.forEach(function(key, index) {
           this.$widgets.append(this.cardTemplate({
@@ -341,7 +342,7 @@ define([
           promise.reject(err);
         });
       return promise;
-    }
+    },
   });
   return TreeCoverLossView;
 

--- a/app/assets/javascripts/countries/views/widgets/TreeCoverLossAlertsView.js
+++ b/app/assets/javascripts/countries/views/widgets/TreeCoverLossAlertsView.js
@@ -69,7 +69,7 @@ define([
       },
       terrai: {
         top: '/query/{dataset}?sql=SELECT SUM (count) as alerts, year, state_id FROM data WHERE year={year} AND country_id=\'{iso}\' {region} GROUP BY state_id ORDER BY alerts DESC limit {widgetsNum}',
-        data: '/query/{dataset}?sql=select sum(count) as alerts, year, month, state_id from data WHERE country_id=\'{iso}\' AND year={year} AND state_id IN({ids}) AND group by state_id, month, year ORDER BY month ASC'
+        data: '/query/{dataset}?sql=select count, year, month, state_id from data WHERE country_id=\'{iso}\' AND year IN({year},{pastYear}) AND state_id IN({ids}) AND ORDER BY state_id, year, month ASC'
       }
     },
     wdpa: {
@@ -288,7 +288,6 @@ define([
         year: year,
         region: this.region != 0 ? 'AND state_id = '+this.region+'' : '',
       });
-
       var promise = $.Deferred();
 
       $.ajax({ url: url, type: 'GET' })
@@ -324,10 +323,10 @@ define([
                 $.ajax({ url: url, type: 'GET' })
                   .done(function(dataResponse) {
                     dataResponse.data.forEach(function(item) {
-                      if (data[item.state_id] && item.alerts) {
+                      if (data[item.state_id] && item.alerts || item.count) {
                         data[item.state_id].data.push({
                           date: moment.utc().year(item.year).month(item.month),
-                          value: item.alerts
+                          value: item.alerts ? item.alerts : item.count
                         })
                       }
                     });

--- a/app/assets/stylesheets/modules/countries/widgets/_tree-cover-loss-alerts.scss
+++ b/app/assets/stylesheets/modules/countries/widgets/_tree-cover-loss-alerts.scss
@@ -86,6 +86,8 @@ $card-ranking-color: #b6b6ba;
     display: flex;
     justify-content: space-between;
     padding: 0 14px;
+    margin-top: -20px;
+    margin-bottom: 20px;
 
     > .link {
       font-size: 12px;


### PR DESCRIPTION
- Change "MONTHLY TREE COVER LOSS ALERTS" to "MONTHLY COUNTS"
- On "Data Shown" selector, change "By month" to "Subnational"
- Fix spacing of the Hi-res and Subscribe buttons (they're good on zeplin)
- Add more months to the spark line, should show 12

**Before**
![image](https://user-images.githubusercontent.com/8074563/27126384-9015d5f8-50f7-11e7-9718-7ace8f068328.png)

**After**
![image](https://user-images.githubusercontent.com/8074563/27126398-a03d16b2-50f7-11e7-9c9e-48cb8a132306.png)

