### PR TITLE
replace double update with better logic

### DIFF
--- a/app/assets/javascripts/connect/views/CountrySelectionView.js
+++ b/app/assets/javascripts/connect/views/CountrySelectionView.js
@@ -72,18 +72,20 @@ define([
      * Sets params from the URL
      */
     _setParams: function() {
-      if (this.params.params.iso.country) {
-        this.model.set({
-          country: this.params.params.iso.country
-        }, { silent: true });
-        this.changeCountry();
-      }
+      var iso = this.params.params.iso;
 
-      if (this.params.params.iso.region) {
+      if (!!iso.country) {
+
         this.model.set({
-          region: this.params.params.iso.region
+          country: iso.country,
+          region: iso.region
         }, { silent: true });
-        this.changeRegion();
+
+        if (!!iso.region) {
+          this.changeRegion();
+        } else {
+          this.changeCountry();
+        }
       }
     },
 


### PR DESCRIPTION
The logic handling country changes and region changes was triggering model updates twice, and one render would override the other, causing the wrong centering of the region regardless of it being set or not. I separated the logic blocks so we only call the updates once. (please note that the case of region being null/undefined it's handled separately several times down the chain.)