### PR TITLE
Added Indonesian Palm Oil Suitability layer to Indonesia 

### DIFF
--- a/app/assets/javascripts/map/helpers/layersHelper.js
+++ b/app/assets/javascripts/map/helpers/layersHelper.js
@@ -38,6 +38,7 @@ define([
   'map/views/layers/ColMiningLayer',
   'map/views/layers/KhmMiningLayer',
   'map/views/layers/OilPalmLayer',
+  'map/views/layers/IdnSuitabilityLayer',
   'map/views/layers/CogOilPalmLayer',
   'map/views/layers/LbrOilPalmLayer',
   'map/views/layers/CmrOilPalmLayer',
@@ -219,6 +220,7 @@ define([
   ColMiningLayer,
   KhmMiningLayer,
   OilPalmLayer,
+  IdnSuitabilityLayer,
   CogOilPalmLayer,
   LbrOilPalmLayer,
   CmrOilPalmLayer,
@@ -480,6 +482,9 @@ define([
     },
     oil_palm: {
       view: OilPalmLayer
+    },
+    idn_suitability: {
+      view: IdnSuitabilityLayer
     },
     cog_oil_palm: {
       view: CogOilPalmLayer

--- a/app/assets/javascripts/map/models/LayerSpecModel.js
+++ b/app/assets/javascripts/map/models/LayerSpecModel.js
@@ -120,6 +120,7 @@ define([
       "lbr_oil_palm",
       "cmr_oil_palm",
       "idn_oil_palm",
+      "idn_suitability",
       "mys_oil_palm",
       "oil_palm",
       "bra_mining",

--- a/app/assets/javascripts/map/templates/legend/idnSuitability.handlebars
+++ b/app/assets/javascripts/map/templates/legend/idnSuitability.handlebars
@@ -1,0 +1,6 @@
+<div class="layer-details layer-details-idn-suitability">
+  <ul class="layer-colors">
+    <li><i class="circle" style='background:#66549e;'></i>Potential</li>
+    <li><i class="circle" style='background:#ffffc5;'></i>Not Suitable</li>
+  </ul>
+</div>

--- a/app/assets/javascripts/map/views/LegendView.js
+++ b/app/assets/javascripts/map/views/LegendView.js
@@ -46,6 +46,7 @@ define([
   'text!map/templates/legend/mysPA.handlebars',
   'text!map/templates/legend/idn_peat.handlebars',
   'text!map/templates/legend/IdnForestArea.handlebars',
+  'text!map/templates/legend/idnSuitability.handlebars',
   'text!map/templates/legend/mys_peat.handlebars',
   'text!map/templates/legend/raisg_mining.handlebars',
   'text!map/templates/legend/per_mining.handlebars',
@@ -73,7 +74,7 @@ define([
     concesionesTypeTpl, hondurasForestTPL,colombiaForestChangeTPL, tigersTPL, dam_hotspotsTPL, us_land_coverTPL,
     global_land_coverTPL, formaTPL, forma_month_TPL,bra_biomesTPL, gfwPlantationByTypeTpl, gfwPlantationBySpeciesTpl, oil_palmTpl,
     gtm_forest_changeTpl,gtm_forest_coverTpl,gtm_forest_densityTpl,khm_eco_land_concTpl,usa_forest_ownershipTpl,guyra_deforestationTpl,logging_roadsTpl,
-    rus_hrvTpl, raisg_land_rightsTpl, mysPATpl, idn_peatTpl, IdnForestAreaTpl, mys_peatTpl,raisg_miningTpl, per_miningTpl, gladTpl, highresTpl,mex_forest_catTpl,mex_forest_subcatTpl,
+    rus_hrvTpl, raisg_land_rightsTpl, mysPATpl, idn_peatTpl, IdnForestAreaTpl,idnSuitabilityTpl, mys_peatTpl,raisg_miningTpl, per_miningTpl, gladTpl, highresTpl,mex_forest_catTpl,mex_forest_subcatTpl,
     paTpl, places2watchTPL, mex_landrightsTpl, mexPATpl, perPATpl,mex_land_coverTpl,mex_forest_conservTPL,mex_forest_prodTPL,mex_forest_restTPL, bra_landcoverTPL, lbr_miningTPL,
     lbr_forestTpl,lbr_communityTpl, mangrove2Tpl, bol_user_fire_frequencyTpl) {
 
@@ -127,6 +128,7 @@ define([
       khm_plantations_type: Handlebars.compile(gfwPlantationByTypeTpl),
       idn_plantations_type: Handlebars.compile(gfwPlantationByTypeTpl),
       idn_forest_area: Handlebars.compile(IdnForestAreaTpl),
+      idn_suitability: Handlebars.compile(idnSuitabilityTpl),
       mys_plantations_type: Handlebars.compile(gfwPlantationByTypeTpl),
       plantations_by_species: Handlebars.compile(gfwPlantationBySpeciesTpl),
       bra_plantations_species: Handlebars.compile(gfwPlantationBySpeciesTpl),

--- a/app/assets/javascripts/map/views/layers/IdnSuitabilityLayer.js
+++ b/app/assets/javascripts/map/views/layers/IdnSuitabilityLayer.js
@@ -1,0 +1,24 @@
+/**
+ * The Indonesian Oil Palm Suitability layer module.
+ * connected to BC issue https://basecamp.com/3063126/projects/10726176/todos/311103503
+ * based on IdnPrimaryLayer
+ * @return
+ */
+define([
+  'abstract/layer/ImageLayerClass',
+], function(ImageLayerClass) {
+
+  'use strict';
+
+  var IdnSuitabilityLayer = ImageLayerClass.extend({
+
+    options: {
+      urlTemplate: 'https://storage.googleapis.com/gfw-data-layers/idn_suitability/{z}/{x}/{y}.png',
+      dataMaxZoom: 13
+    }
+
+  });
+
+  return IdnSuitabilityLayer;
+
+});


### PR DESCRIPTION
See [Basecamp issue](https://basecamp.com/3063126/projects/10726176/todos/311103503)

* I uploaded the raster data to Earth Engine, and created a webmap, exported to our GCS account for tiles from z0 to z13.
* Added the new layer to the Indonesian data section on the map

<img width="1169" alt="screen shot 2017-07-12 at 11 54 27" src="https://user-images.githubusercontent.com/6503031/28127139-93ebb964-66f9-11e7-8a01-c0e92ded6b01.png">
<img width="1149" alt="screen shot 2017-07-12 at 11 54 35" src="https://user-images.githubusercontent.com/6503031/28127140-93ec05a4-66f9-11e7-9581-8f985a16703c.png">

