### PR TITLE
Responsible Soy layer working for Brazil

### DIFF
--- a/app/assets/javascripts/map/helpers/layersHelper.js
+++ b/app/assets/javascripts/map/helpers/layersHelper.js
@@ -139,6 +139,7 @@ define([
   'map/views/layers/PerMiningLayer',
   'map/views/layers/MexMiningLayer',
   'map/views/layers/BraMiningLayer',
+  'map/views/layers/BraRTRSLayer',
   'map/views/layers/ViirsLayer',
   'map/views/layers/PerMinamCoverLayer',
   'map/views/layers/CanIntactForestLayer',
@@ -321,6 +322,7 @@ define([
   PerMiningLayer,
   MexMiningLayer,
   BraMiningLayer,
+  BraRTRSLayer,
   ViirsLayer,
   PerMinamCoverLayer,
   CanIntactForestLayer,
@@ -793,6 +795,9 @@ define([
     },
     bra_mining: {
       view:  BraMiningLayer
+    },
+    bra_rtrs: {
+      view: BraRTRSLayer
     },
     per_minam_tree_cover: {
       view:  PerMinamCoverLayer

--- a/app/assets/javascripts/map/helpers/layersHelper.js
+++ b/app/assets/javascripts/map/helpers/layersHelper.js
@@ -140,6 +140,7 @@ define([
   'map/views/layers/MexMiningLayer',
   'map/views/layers/BraMiningLayer',
   'map/views/layers/BraRTRSLayer',
+  'map/views/layers/PryRTRSLayer',
   'map/views/layers/ViirsLayer',
   'map/views/layers/PerMinamCoverLayer',
   'map/views/layers/CanIntactForestLayer',
@@ -323,6 +324,7 @@ define([
   MexMiningLayer,
   BraMiningLayer,
   BraRTRSLayer,
+  PryRTRSLayer,
   ViirsLayer,
   PerMinamCoverLayer,
   CanIntactForestLayer,
@@ -798,6 +800,9 @@ define([
     },
     bra_rtrs: {
       view: BraRTRSLayer
+    },
+    pry_rtrs:{
+      view: PryRTRSLayer
     },
     per_minam_tree_cover: {
       view:  PerMinamCoverLayer

--- a/app/assets/javascripts/map/models/LayerSpecModel.js
+++ b/app/assets/javascripts/map/models/LayerSpecModel.js
@@ -35,6 +35,7 @@ define([
       "gtm_forest_cover",
       "bra_land_cover",
       "bra_rtrs",
+      "pry_rtrs",
       "gtm_forest_density",
       "gtm_forest_change2",
       "gtm_forest_change1",

--- a/app/assets/javascripts/map/models/LayerSpecModel.js
+++ b/app/assets/javascripts/map/models/LayerSpecModel.js
@@ -34,6 +34,7 @@ define([
       "mex_land_cover",
       "gtm_forest_cover",
       "bra_land_cover",
+      "bra_rtrs",
       "gtm_forest_density",
       "gtm_forest_change2",
       "gtm_forest_change1",

--- a/app/assets/javascripts/map/templates/legend/bra_rtrs.handlebars
+++ b/app/assets/javascripts/map/templates/legend/bra_rtrs.handlebars
@@ -1,0 +1,9 @@
+<div class="layer-details layer-details-bra-rtrs">
+  <ul class="layer-colors">
+    <li><i class="circle" style='background:#D46369;'></i>No expansion allowed</li>
+    <li><i class="circle" style='background:#D0E291;'></i>Expansion potentially allowed after HCVA assessment</li>
+    <li><i class="circle" style='background:#FDFDCE;'></i>Responsible expansion as per legislation</li>
+    <li><i class="circle" style='background:#A4C38B;'></i>No land available for expansion</li>
+    <li><i class="circle" style='background:#B796F6;'></i>Areas deforested after 2009</li>
+  </ul>
+</div>

--- a/app/assets/javascripts/map/templates/legend/pry_rtrs.handlebars
+++ b/app/assets/javascripts/map/templates/legend/pry_rtrs.handlebars
@@ -1,0 +1,9 @@
+<div class="layer-details layer-details-pry-rtrs">
+  <ul class="layer-colors">
+    <li><i class="circle" style='background:#D46369;'></i>No expansion allowed</li>
+    <li><i class="circle" style='background:#D0E291;'></i>Expansion potentially allowed after HCVA assessment</li>
+    <li><i class="circle" style='background:#FDFDCE;'></i>Responsible expansion as per legislation</li>
+    <li><i class="circle" style='background:#A4C38B;'></i>No land available for expansion</li>
+    <li><i class="circle" style='background:#B796F6;'></i>Areas deforested after 2009</li>
+  </ul>
+</div>

--- a/app/assets/javascripts/map/views/LegendView.js
+++ b/app/assets/javascripts/map/views/LegendView.js
@@ -65,6 +65,7 @@ define([
   'text!map/templates/legend/mex_forest_rest.handlebars',
   'text!map/templates/legend/bra_landcover.handlebars',
   'text!map/templates/legend/bra_rtrs.handlebars',
+  'text!map/templates/legend/pry_rtrs.handlebars',
   'text!map/templates/legend/lbr_mining.handlebars',
   'text!map/templates/legend/lbr_forest.handlebars',
   'text!map/templates/legend/lbr_community.handlebars',
@@ -76,7 +77,7 @@ define([
     global_land_coverTPL, formaTPL, forma_month_TPL,bra_biomesTPL, gfwPlantationByTypeTpl, gfwPlantationBySpeciesTpl, oil_palmTpl,
     gtm_forest_changeTpl,gtm_forest_coverTpl,gtm_forest_densityTpl,khm_eco_land_concTpl,usa_forest_ownershipTpl,guyra_deforestationTpl,logging_roadsTpl,
     rus_hrvTpl, raisg_land_rightsTpl, mysPATpl, idn_peatTpl, IdnForestAreaTpl,idnSuitabilityTpl, mys_peatTpl,raisg_miningTpl, per_miningTpl, gladTpl, highresTpl,mex_forest_catTpl,mex_forest_subcatTpl,
-    paTpl, places2watchTPL, mex_landrightsTpl, mexPATpl, perPATpl,mex_land_coverTpl,mex_forest_conservTPL,mex_forest_prodTPL,mex_forest_restTPL, bra_landcoverTPL, bra_rtrs, lbr_miningTPL,
+    paTpl, places2watchTPL, mex_landrightsTpl, mexPATpl, perPATpl,mex_land_coverTpl,mex_forest_conservTPL,mex_forest_prodTPL,mex_forest_restTPL, bra_landcoverTPL, bra_rtrs, pry_rtrs, lbr_miningTPL,
     lbr_forestTpl,lbr_communityTpl, mangrove2Tpl, bol_user_fire_frequencyTpl) {
 
   'use strict';
@@ -173,6 +174,7 @@ define([
       mex_land_cover:Handlebars.compile(mex_land_coverTpl),
       bra_land_cover:Handlebars.compile(bra_landcoverTPL),
       bra_rtrs:Handlebars.compile(bra_rtrs),
+      pry_rtrs:Handlebars.compile(pry_rtrs),
       lbr_logging:Handlebars.compile(lbr_forestTpl),
       lbr_mineral_exploration_license:Handlebars.compile(lbr_miningTPL),
       lbr_resource_rights:Handlebars.compile(lbr_communityTpl),

--- a/app/assets/javascripts/map/views/LegendView.js
+++ b/app/assets/javascripts/map/views/LegendView.js
@@ -64,6 +64,7 @@ define([
   'text!map/templates/legend/mex_forest_prod.handlebars',
   'text!map/templates/legend/mex_forest_rest.handlebars',
   'text!map/templates/legend/bra_landcover.handlebars',
+  'text!map/templates/legend/bra_rtrs.handlebars',
   'text!map/templates/legend/lbr_mining.handlebars',
   'text!map/templates/legend/lbr_forest.handlebars',
   'text!map/templates/legend/lbr_community.handlebars',
@@ -75,7 +76,7 @@ define([
     global_land_coverTPL, formaTPL, forma_month_TPL,bra_biomesTPL, gfwPlantationByTypeTpl, gfwPlantationBySpeciesTpl, oil_palmTpl,
     gtm_forest_changeTpl,gtm_forest_coverTpl,gtm_forest_densityTpl,khm_eco_land_concTpl,usa_forest_ownershipTpl,guyra_deforestationTpl,logging_roadsTpl,
     rus_hrvTpl, raisg_land_rightsTpl, mysPATpl, idn_peatTpl, IdnForestAreaTpl,idnSuitabilityTpl, mys_peatTpl,raisg_miningTpl, per_miningTpl, gladTpl, highresTpl,mex_forest_catTpl,mex_forest_subcatTpl,
-    paTpl, places2watchTPL, mex_landrightsTpl, mexPATpl, perPATpl,mex_land_coverTpl,mex_forest_conservTPL,mex_forest_prodTPL,mex_forest_restTPL, bra_landcoverTPL, lbr_miningTPL,
+    paTpl, places2watchTPL, mex_landrightsTpl, mexPATpl, perPATpl,mex_land_coverTpl,mex_forest_conservTPL,mex_forest_prodTPL,mex_forest_restTPL, bra_landcoverTPL, bra_rtrs, lbr_miningTPL,
     lbr_forestTpl,lbr_communityTpl, mangrove2Tpl, bol_user_fire_frequencyTpl) {
 
   'use strict';
@@ -171,6 +172,7 @@ define([
       per_protected_areas:Handlebars.compile(perPATpl),
       mex_land_cover:Handlebars.compile(mex_land_coverTpl),
       bra_land_cover:Handlebars.compile(bra_landcoverTPL),
+      bra_rtrs:Handlebars.compile(bra_rtrs),
       lbr_logging:Handlebars.compile(lbr_forestTpl),
       lbr_mineral_exploration_license:Handlebars.compile(lbr_miningTPL),
       lbr_resource_rights:Handlebars.compile(lbr_communityTpl),

--- a/app/assets/javascripts/map/views/layers/BraRTRSLayer.js
+++ b/app/assets/javascripts/map/views/layers/BraRTRSLayer.js
@@ -1,0 +1,24 @@
+/**
+ * The Brazilian RTRS soy layer module.
+ * connected to BC issue https://basecamp.com/3063126/projects/10726176/todos/311103365
+ * based on IdnPrimaryLayer
+ * @return
+ */
+define([
+  'abstract/layer/ImageLayerClass',
+], function(ImageLayerClass) {
+
+  'use strict';
+
+  var BraRTRSLayer = ImageLayerClass.extend({
+
+    options: {
+      urlTemplate: 'https://storage.googleapis.com/gfw-data-layers/BRA_RTRS_soy/{z}/{x}/{y}.png',
+      dataMaxZoom: 13
+    }
+
+  });
+
+  return BraRTRSLayer;
+
+});

--- a/app/assets/javascripts/map/views/layers/PryRTRSLayer.js
+++ b/app/assets/javascripts/map/views/layers/PryRTRSLayer.js
@@ -1,0 +1,24 @@
+/**
+ * The Paraguay RTRS soy layer module.
+ * connected to BC issue https://basecamp.com/3063126/projects/10726176/todos/311103365
+ * based on IdnPrimaryLayer
+ * @return
+ */
+define([
+  'abstract/layer/ImageLayerClass',
+], function(ImageLayerClass) {
+
+  'use strict';
+
+  var PryRTRSLayer = ImageLayerClass.extend({
+
+    options: {
+      urlTemplate: 'https://storage.googleapis.com/gfw-data-layers/BRA_RTRS_soy/{z}/{x}/{y}.png',
+      dataMaxZoom: 13
+    }
+
+  });
+
+  return PryRTRSLayer;
+
+});


### PR DESCRIPTION
[Moving raster data from GFW commodities](http://commodities.globalforestwatch.org/#v=map&x=-51.73&y=-13.93&l=5&lyrs=responsibleSoy) by means of Earth Engine upload to GCS bucket.

[Basecamp issue](https://basecamp.com/3063126/projects/10726176/todos/311103365)

Two identical layers added:
* One for Brazil country data
* One for Paraguay country data
* layerspec_nuclear_hazard rows 950 and 948
* Processed data added to GCS bucket gfw-data-layers/BRA_RTRS_soy

<img width="1298" alt="screen shot 2017-07-13 at 14 36 00" src="https://user-images.githubusercontent.com/6503031/28182495-594853e4-67da-11e7-8cde-c946d6d90108.png">
