### PR TITLE
Brazilian soy data layer for map

### DIFF
--- a/app/assets/javascripts/map/cartocss/style.cartocss
+++ b/app/assets/javascripts/map/cartocss/style.cartocss
@@ -476,6 +476,13 @@
     line-width: 1;
     line-opacity: 1;
   }
+  [layer='bra_soy_vector']{
+  polygon-fill: #ca9024;
+  polygon-opacity: 0.9;
+  line-color: #FFF;
+  line-width: 0.0;
+  line-opacity: 0.0;
+}
   [layer='can_land_rights'] {
     polygon-fill: #4d658f;
     polygon-opacity: 0.7;

--- a/app/assets/javascripts/map/helpers/layersHelper.js
+++ b/app/assets/javascripts/map/helpers/layersHelper.js
@@ -139,6 +139,7 @@ define([
   'map/views/layers/PerMiningLayer',
   'map/views/layers/MexMiningLayer',
   'map/views/layers/BraMiningLayer',
+  'map/views/layers/BraSoyCerradoLayer',
   'map/views/layers/BraRTRSLayer',
   'map/views/layers/PryRTRSLayer',
   'map/views/layers/ViirsLayer',
@@ -323,6 +324,7 @@ define([
   PerMiningLayer,
   MexMiningLayer,
   BraMiningLayer,
+  BraSoyCerradoLayer,
   BraRTRSLayer,
   PryRTRSLayer,
   ViirsLayer,
@@ -797,6 +799,9 @@ define([
     },
     bra_mining: {
       view:  BraMiningLayer
+    },
+    bra_soy: {
+      view: BraSoyCerradoLayer
     },
     bra_rtrs: {
       view: BraRTRSLayer

--- a/app/assets/javascripts/map/models/LayerSpecModel.js
+++ b/app/assets/javascripts/map/models/LayerSpecModel.js
@@ -126,6 +126,7 @@ define([
       "mys_oil_palm",
       "oil_palm",
       "bra_mining",
+      "bra_soy",
       "mex_mining",
       "per_mining",
       "can_oil",

--- a/app/assets/javascripts/map/views/layers/BraSoyCerradoLayer.js
+++ b/app/assets/javascripts/map/views/layers/BraSoyCerradoLayer.js
@@ -1,0 +1,25 @@
+/**
+ * The Brazil Soy Cerrado layer module.
+ *
+ * @return SoyCerradoLayer class (extends CartoDBLayerClass)
+ */
+define([
+  'abstract/layer/CartoDBLayerClass',
+], function(CartoDBLayerClass) {
+
+  'use strict';
+
+  var BraSoyCerradoLayer = CartoDBLayerClass.extend({
+
+    options: {
+      sql: 'SELECT *, \'{tableName}\' as tablename, \'{tableName}\' as layer FROM {tableName}',
+      infowindow: false,
+      interactivity: '',
+      analysis: false
+    }
+
+  });
+
+  return BraSoyCerradoLayer;
+
+});


### PR DESCRIPTION
Added Brazilian Soy in Cerrado to map in Brazil country data, according to [BC thread](https://basecamp.com/3063126/projects/10726176/todos/311103798).

* New [table in Carto](https://wri-01.carto.com/tables/bra_soy_vector)
* New row in layerspec nuclear hazard (row 951)

![screen shot 2017-07-24 at 13 45 08](https://user-images.githubusercontent.com/6503031/28522090-f41eb184-7076-11e7-805d-d2462df91a9b.png)
![screen shot 2017-07-24 at 13 45 19](https://user-images.githubusercontent.com/6503031/28522091-f421b85c-7076-11e7-9de8-bdf33c9c1bfe.png)
 