### PR TITLE
Improve and fix styles on legend

### DIFF
--- a/app/assets/javascripts/map/presenters/LayersNavPresenter.js
+++ b/app/assets/javascripts/map/presenters/LayersNavPresenter.js
@@ -65,13 +65,17 @@ define([
      *
      * @param  {string} layerSlug
      */
-    toggleLayer: function(layerSlug) {
+    toggleLayer: function(layerSlug, checkedSublayer) {
       var where = [{slug: layerSlug}];
 
       layerSpecService.toggle(where,
         _.bind(function(layerSpec) {
           mps.publish('LayerNav/change', [layerSpec]);
           mps.publish('Place/update', [{go: false}]);
+
+          if (checkedSublayer !== null) {
+            this.toggleLayer(checkedSublayer, null);
+          }
         }, this));
     },
   });

--- a/app/assets/javascripts/map/templates/layersNav.handlebars
+++ b/app/assets/javascripts/map/templates/layersNav.handlebars
@@ -12,7 +12,7 @@
         <ul class="layers-list scroll-thin-dark">
           <div class="layer-group">
             <span class="group-name">Deforestation alerts <em>(near real-time)</em></span>
-            <li class="layer" data-layer="umd_as_it_happens">
+            <li class="layer" data-layer="umd_as_it_happens" data-open-with-sublayer="places_to_watch">
               <span class="onoffswitch"><span></span></span>
               <span class="layer-title">GLAD alerts<a href='#' data-source='umd_landsat_alerts' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
               <span class="layer-info">(weekly, 30m, select countries, UMD/GLAD)

--- a/app/assets/javascripts/map/templates/legend/concesiones_forestales.handlebars
+++ b/app/assets/javascripts/map/templates/legend/concesiones_forestales.handlebars
@@ -1,4 +1,13 @@
-<div class="layer-details layer-details-concesiones-forestales">
+<div class="layer-details layer-details-select">
+  <span class="container-select-option">
+    Display concessions
+    <div class="select-container">
+      <select class="select-option js-toggle-concessions">
+        <option value="concesiones_forestales" selected>by Supervision status</option>
+        <option value="concesiones_forestalesNS">by Concession type</option>
+      </select>
+    </div>
+  </span>
   <ul class="layer-colors">
     <li><i class="circle" style="background:#1F78B4"></i>Supervised concessions <i>Supervisado por OSINFOR</i></li>
     <li><i class="circle" style="background:#A6CEE3"></i>Unsupervised concessions <i>No supervisado</i></li>

--- a/app/assets/javascripts/map/templates/legend/concesiones_forestalesType.handlebars
+++ b/app/assets/javascripts/map/templates/legend/concesiones_forestalesType.handlebars
@@ -1,4 +1,13 @@
-<div class="layer-details layer-details-concesiones-forestales">
+<div class="layer-details layer-details-select">
+  <span class="container-select-option">
+    Display concessions
+    <div class="select-container">
+      <select class="select-option js-toggle-concessions">
+        <option value="concesiones_forestales">by Supervision status</option>
+        <option value="concesiones_forestalesNS" selected>by Concession type</option>
+      </select>
+    </div>
+  </span>
   <ul class="layer-colors">
     <li><i class="circle" style="background:#1F78B4"></i>Timber <i>Madera</i></li>
     <li><i class="circle" style="background:#F9FF00"></i>Reforestation <i>Forestación y reforestación</i></li>

--- a/app/assets/javascripts/map/templates/legend/glad.handlebars
+++ b/app/assets/javascripts/map/templates/legend/glad.handlebars
@@ -6,6 +6,10 @@
 <div data-autotoggle="true" data-sublayer="places_to_watch" data-parent="umd_as_it_happens" class="layer-sublayer js-toggle-sublayer">
   <span class="onoffswitch" style="background-color:#f69;"><span></span></span>
   <div class="sublayer-title">Places to watch</div>
+  <div class="layer-details layer-details-places-to-watch">
+    <p class="canopy">To receive monthly email updates</p>
+    <p class="canopy"><a href="http://www.wri.org/global-forest-watch-updates-and-newsletter" target="_blank">Sign up for the PTW newsletter ➤</a></p>
+  </div>
 </div>
 <div data-autotoggle="false" data-sublayer="uncurated_places_to_watch" data-parent="umd_as_it_happens" class="layer-sublayer js-toggle-sublayer">
   <span class="onoffswitch" style="background-color:#f69;"><span></span></span>

--- a/app/assets/javascripts/map/templates/legend/glad.handlebars
+++ b/app/assets/javascripts/map/templates/legend/glad.handlebars
@@ -16,8 +16,7 @@
   <div class="sublayer-title">
     Show only confirmed alerts
 		<a href="#" data-source="umd_as_it_happens_show_only_confirmed_alerts" class="source source-shape-info">
-      <svg class="icon-info-green"><use xlink:href="#shape-info"></use></svg>
-      <svg class="icon-info-grey"><use xlink:href="#shape-info-grey"></use></svg>
+      <svg class="icon-info-green -source"><use xlink:href="#shape-info"></use></svg>
     </a>
   </div>
 </div>

--- a/app/assets/javascripts/map/templates/legend/legend.handlebars
+++ b/app/assets/javascripts/map/templates/legend/legend.handlebars
@@ -51,14 +51,12 @@
                   {{/if}}
                   {{#if this.source_json}}
                     <a href='#' data-source='{{this.source_json}}' class='source js-tooltip source-shape-info' data-description="{{this.subtitle}}">
-                      <svg class="icon-info-green"><use xlink:href="#shape-info"></use></svg>
-                      <svg class="icon-info-grey"><use xlink:href="#shape-info-grey"></use></svg>
+                      <svg class="icon-info-green -source"><use xlink:href="#shape-info"></use></svg>
                     </a>
                   {{else}}
                     {{#if this.source}}
                       <a href='#' data-source='{{this.source}}' class='source js-tooltip source-shape-info' data-description="{{this.subtitle}}">
-                        <svg class="icon-info-green"><use xlink:href="#shape-info"></use></svg>
-                        <svg class="icon-info-grey"><use xlink:href="#shape-info-grey"></use></svg>
+                        <svg class="icon-info-green -source"><use xlink:href="#shape-info"></use></svg>
                       </a>
                     {{/if}}
                   {{/if}}
@@ -117,14 +115,12 @@
               {{/if}}
               {{#if this.source_json}}
                 <a href='#' data-source='{{this.source_json}}' class='source js-tooltip source-shape-info' data-description="{{this.subtitle}}">
-                  <svg class="icon-info-green"><use xlink:href="#shape-info"></use></svg>
-                  <svg class="icon-info-grey"><use xlink:href="#shape-info-grey"></use></svg>
+                  <svg class="icon-info-green -source"><use xlink:href="#shape-info"></use></svg>
                 </a>
               {{else}}
                 {{#if this.source}}
                   <a href='#' data-source='{{this.source}}' class='source js-tooltip source-shape-info' data-description="{{this.subtitle}}">
-                    <svg class="icon-info-green"><use xlink:href="#shape-info"></use></svg>
-                    <svg class="icon-info-grey"><use xlink:href="#shape-info-grey"></use></svg>
+                    <svg class="icon-info-green -source"><use xlink:href="#shape-info"></use></svg>
                   </a>
                 {{/if}}
               {{/if}}
@@ -141,8 +137,7 @@
                 <span class="onoffswitch {{this.geographic}}" {{#if this.geographic}}style="background-color:#f69;"{{/if}}><span></span></span>
                 <div class="sublayer-title">{{this.geographicTitle}}
                   <a href='#' data-source='{{this.source}}_source' class='source source-shape-info'>
-                    <svg class="icon-info-green"><use xlink:href="#shape-info"></use></svg>
-                    <svg class="icon-info-grey"><use xlink:href="#shape-info-grey"></use></svg>
+                    <svg class="icon-info-green -source"><use xlink:href="#shape-info"></use></svg>
                   </a>
                 </div>
               </div>

--- a/app/assets/javascripts/map/templates/legend/plantations_by_species.handlebars
+++ b/app/assets/javascripts/map/templates/legend/plantations_by_species.handlebars
@@ -1,4 +1,4 @@
-<div class="layer-details layer-details-gfw-plantations-by-species">
+<div class="layer-details layer-details-select">
   <span class="container-select-option">
     Display trees
     <div class="select-container">

--- a/app/assets/javascripts/map/templates/legend/plantations_by_type.handlebars
+++ b/app/assets/javascripts/map/templates/legend/plantations_by_type.handlebars
@@ -1,4 +1,4 @@
-<div class="layer-details layer-details-gfw-plantations-by-type">
+<div class="layer-details layer-details-select">
   <span class="container-select-option">
     Display trees
     <div class="select-container">

--- a/app/assets/javascripts/map/views/LayersNavView.js
+++ b/app/assets/javascripts/map/views/LayersNavView.js
@@ -128,6 +128,7 @@ define([
         var $elem = $(event.currentTarget);
         var layerSlug = $elem.data('layer');
         var isSubLayer = $elem.data('parent') || false;
+        var openWithSublayer = $elem.data('open-with-sublayer');
 
         if ($elem.hasClass('wrapped')) {
           event && event.stopPropagation();
@@ -136,7 +137,7 @@ define([
             //as the toggle are switches, we should turn off the others (siblings) before turning on our layer
             for (var i=0;i < $elem.siblings().length; i++) {
               if ($($elem.siblings()[i]).hasClass('selected')) {
-                this.presenter.toggleLayer($($elem.siblings()[i]).data('layer'));
+                this.presenter.toggleLayer($($elem.siblings()[i]).data('layer'), null);
               }
               $elem.parents('li').data('layer' , $elem.data('layer')).addClass('selected');
             }
@@ -148,7 +149,7 @@ define([
           this._toggleParent($elem);
         }
 
-        this.presenter.toggleLayer(layerSlug);
+        this.presenter.toggleLayer(layerSlug, openWithSublayer);
         ga('send', 'event', 'Map', 'Toggle', 'Layer: ' + layerSlug);
       }
     },
@@ -171,7 +172,7 @@ define([
           var sublayerAuto = $(this).data('autotoggle');
           if ((subLayerSlug && layerChecked === subLayerChecked) && (!layerChecked && sublayerAuto || layerChecked)) {
             setTimeout(function() {
-              _this.presenter.toggleLayer(subLayerSlug);
+              _this.presenter.toggleLayer(subLayerSlug, null);
               ga('send', 'event', 'Map', 'Toggle', 'Layer: ' + subLayerSlug);
             }, 100);
           }
@@ -184,7 +185,7 @@ define([
       var $parentEl = $elem.closest('[data-layer=\'' + parentSlug + '\']');
       if (!$elem.hasClass('selected')) {
         if (!$parentEl.hasClass('selected')) {
-          this.presenter.toggleLayer(parentSlug);
+          this.presenter.toggleLayer(parentSlug, null);
           ga('send', 'event', 'Map', 'Toggle', 'Layer: ' + parentSlug);
         }
       }
@@ -197,12 +198,12 @@ define([
           _.each($layers, _.bind(function(layer){
             if ($(layer).hasClass('selected')) {
               var layerSlug = $(layer).data('layer');
-              this.presenter.toggleLayer(layerSlug);
+              this.presenter.toggleLayer(layerSlug, null);
             }
           }, this ))
         }else{
           var layerSlug = $($layers[0]).data('layer');
-          this.presenter.toggleLayer(layerSlug)
+          this.presenter.toggleLayer(layerSlug, null)
         }
       }
     },
@@ -249,9 +250,9 @@ define([
           var selected = $(layer).hasClass('selected');
           var layerSlug = $(layer).data('layer');
           if (checked) {
-            (selected) ? this.presenter.toggleLayer(layerSlug) : null;
+            (selected) ? this.presenter.toggleLayer(layerSlug, null) : null;
           }else{
-            (!selected) ? this.presenter.toggleLayer(layerSlug) : null;
+            (!selected) ? this.presenter.toggleLayer(layerSlug, null) : null;
           }
         }, this));
       }

--- a/app/assets/javascripts/map/views/LegendView.js
+++ b/app/assets/javascripts/map/views/LegendView.js
@@ -469,6 +469,8 @@ define([
       var top = position.top - 10;
       var left = position.left - 92;
       var text = $(e.target).attr('data-description');
+      text = text.replace('(', '');
+      text = text.replace(')', '');
       var dataSource = $(e.target).attr('data-source');
       if (text != '') {
         $('body').append('<div class="tooltip-info-legend" id="tooltip-info-legend" style="top:'+top+'px; left:'+left+'px;"><div class="triangle"><span>'+text+'</span><p>Click to see more</p></div></div>');

--- a/app/assets/javascripts/map/views/LegendView.js
+++ b/app/assets/javascripts/map/views/LegendView.js
@@ -198,6 +198,7 @@ define([
       'click .js-toggle-threshold' : 'toggleThreshold',
       'change .js-tree-plantation' : 'togglePlantation',
       'change .js-tree-plantation-country' : 'togglePlantationCountry',
+      'change .js-toggle-concessions' : 'toggleConcessions',
       'click .js-toggle-legend' : 'toogleLegend',
       'click .js-toggle-embed-legend' : 'toogleEmbedLegend',
       'click .js-select-layer': 'selectLayer',
@@ -446,6 +447,11 @@ define([
       var species = iso+'_plantations_species';
       this.presenter.toggleLayer(types);
       this.presenter.toggleLayer(species);
+    },
+
+    toggleConcessions: function(e) {
+      this.presenter.toggleLayer('concesiones_forestales');
+      this.presenter.toggleLayer('concesiones_forestalesNS');
     },
 
     // layers

--- a/app/assets/stylesheets/modules/map/_module-legend.scss
+++ b/app/assets/stylesheets/modules/map/_module-legend.scss
@@ -843,6 +843,18 @@
   }
 
   /****************************/
+  /* Places to Watch details */
+  /****************************/
+  .layer-details-places-to-watch {
+    a {
+      color: #F69;
+      &:hover{
+        color: lighten(#F69, 10%);
+      }
+    }
+  }
+
+  /****************************/
   /* OilPalmLayer details */
   /****************************/
   .layer-details-oil {
@@ -874,32 +886,28 @@
     font-weight: 500;
   }
 
-  .layer-details-gfw-plantations-by-type,
-  .layer-details-gfw-plantations-by-species
-   {
-    .container-select-option {
-      display: block;
-      margin-top: 10px;
-      margin-bottom: 10px;
+  .layer-details-select .container-select-option {
+    display: block;
+    margin-top: 10px;
+    margin-bottom: 10px;
 
-      .select-container {
-        display: inline-block;
-        border: 1px solid #9e9e9e;
-        border-radius: 10px;
-        padding: 1px 5px 2px;
-      }
+    .select-container {
+      display: inline-block;
+      border: 1px solid #9e9e9e;
+      border-radius: 10px;
+      padding: 1px 5px 2px;
+    }
 
-      .select-option {
-        outline: 0;
-        background: transparent;
-        color: #9e9e9e;
-        display: inline-block;
-        padding: 1px 5px 0;
-        margin: 0 2px;
-        cursor: pointer;
-        border: 0;
-        appearance: none;
-      }
+    .select-option {
+      outline: 0;
+      background: transparent;
+      color: #9e9e9e;
+      display: inline-block;
+      padding: 1px 5px 0;
+      margin: 0 2px;
+      cursor: pointer;
+      border: 0;
+      appearance: none;
     }
   }
 }

--- a/app/assets/stylesheets/modules/map/_module-legend.scss
+++ b/app/assets/stylesheets/modules/map/_module-legend.scss
@@ -141,6 +141,7 @@
 
           em {
             display: inline-block;
+            margin-left: 6px;
           }
         }
       }
@@ -339,13 +340,15 @@
         &.-desactivate {
           .icon-info-green {
             display: none;
+            &.-source {
+              display: block;
+            }
           }
           .icon-info-grey {
             display: block;
           }
 
           .alerts,
-          .source,
           .canopy-button,
           .onoffswitch,
           .layer-sublayer {
@@ -357,12 +360,20 @@
             color: #ccc !important;
           }
 
+          svg {
+            fill: #ccc !important;
+          }
+
           .onoffswitch {
             pointer-events: none;
           }
 
           .sublayer-title {
             color: #ccc !important;
+          }
+
+          .circle {
+            background-color: #ccc !important;
           }
         }
       }
@@ -388,7 +399,7 @@
         .container-eye-icon {
           cursor: pointer;
           position: absolute;
-          top: -1px;
+          top: 2px;
           left: 0;
 
 


### PR DESCRIPTION
Fix&Improve:
-  Leave the metadata icons enabled even if the layer is made invisible.
- Make the legend elements gray as well when the layer is set to invisible.
- Add space between Category name and number of layers.

(https://www.pivotaltracker.com/story/show/149555321)