### PR TITLE
Added 2013 and 2014 landsat layers

### DIFF
--- a/app/assets/javascripts/map/views/MapView.js
+++ b/app/assets/javascripts/map/views/MapView.js
@@ -464,7 +464,7 @@ define([
 
     _setLandsatTiles: function () {
       for (var i = 1999; i <= 2016; i++) {
-        if (i === 2015 || i === 2016) {
+        if (i >= 2013) {
           landsatService.getTiles(i)
             .then(function(year, results) {
               landsatService.getRefreshTiles(year, results.attributes.url);

--- a/app/assets/javascripts/map/views/maptypes/landsatMaptype.js
+++ b/app/assets/javascripts/map/views/maptypes/landsatMaptype.js
@@ -6,8 +6,10 @@ define([], function () {
   'use strict';
 
   var LandsatMaptype = function(year, tileUrl) {
-    // We want to set the zoom level differently depending on the year of the
-    // landsat data. As diffrent z-levels exist for diffrent tile-sets.
+    // We want to set the url differently depending on the z level and year of
+    // landsat data. For years before 2013 data is all pre-processed by google.
+    // from 2013 onwards, we have pre-processed the z-levels between 0 and 11
+    // in GCS. For higher z-levels the tiles come from a live EE-based service. 
 
     var config = {
       name: 'Landsat ' + year,
@@ -19,6 +21,8 @@ define([], function () {
         var x = Math.abs(ll.x % (1 << z)); // jshint ignore:line
 
         switch (year) {
+          case 2013:
+          case 2014:
           case 2015:
           case 2016:
             return z > 11


### PR DESCRIPTION
Using the same method as for the 2015/2016 layers I have gone back and re-created the 2014 and 2013 landsat layers, pre-calculating the tiles between z0 and z11 (inclusive), and also added them to the micro-service so the higher z-levels are live from Earth Engine.

![screen shot 2017-07-31 at 11 32 15](https://user-images.githubusercontent.com/6503031/28771660-ef7581e0-75e3-11e7-97e6-66e826ca3119.png)
