### PR TITLE
Deactivating bad RASIG layers

### DIFF
--- a/app/assets/javascripts/map/templates/layersNav.handlebars
+++ b/app/assets/javascripts/map/templates/layersNav.handlebars
@@ -156,11 +156,11 @@
               <span class="layer-title">Mining<a href='#' data-source='gfw_mining' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
               <span class="layer-info">(select countries)</span>
             </li>
-            <li class="layer" data-layer="raisg_mining">
+            <!--<li class="layer" data-layer="raisg_mining">
               <span class="onoffswitch"><span></span></span>
               <span class="layer-title">Amazon basin mining concessions <a href='#' data-source='raisg_mining' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
               <span class="layer-info">(RAISG)</span>
-            </li>
+            </li>-->
             <li class="layer" data-layer="oil_palm">
               <span class="onoffswitch"><span></span></span>
               <span class="layer-title">Oil palm<a href='#' data-source='gfw_oil_palm' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
@@ -257,11 +257,11 @@
             <span class="layer-title">Population density<a href='#' data-source='population_density' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
             <span class="layer-info">(2000)</span>
           </li>
-          <li class="layer" data-layer="raisg">
+          <!--<li class="layer" data-layer="raisg">
             <span class="onoffswitch"><span></span></span>
             <span class="layer-title">Amazon basin indigenous territories<a href='#' data-source='raisg_indigenous_territories' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
             <span class="layer-info">(RAISG)</span>
-          </li>
+          </li>-->
         </ul>
       </div>
     </li>

--- a/app/assets/javascripts/map/views/layers/RaisgLayer.js
+++ b/app/assets/javascripts/map/views/layers/RaisgLayer.js
@@ -1,6 +1,8 @@
 /**
  * The RaisgLayer layer module.
- *
+ *     Note. this layer has been deactivated (as of 2nd Aug 2017)
+ *  but remains present to serve as an example layer
+ * for using an Arcgis WMS.
  *     wmsUrl += '&STYLES=polygonSymbolizer';
  * @return RaisgLayer class (extends WMSLayerClass)
  */

--- a/app/assets/javascripts/map/views/layers/RaisgMiningLayer.js
+++ b/app/assets/javascripts/map/views/layers/RaisgMiningLayer.js
@@ -1,5 +1,8 @@
 /*
  * @return RaisgLayer class (extends WMSLayerClass)
+ *     Note. this layer has been deactivated (as of 2nd Aug 2017)
+ *     but remains present to serve as an example layer
+ *     for using an Arcgis WMS.
  *     wmsUrl += '&STYLES=polygonSymbolizer';
  */
 define([


### PR DESCRIPTION
This PR deactivates RASIG, which has become problematic after they updated their Argis WMS. We are leaving the layers in the codebase for future reference.

We have also set the display of these layers to false in the layerspecs.