### PR TITLE
Use the new proxy endpoint created on the production API

### DIFF
--- a/app/assets/javascripts/views/SourceModalView.js
+++ b/app/assets/javascripts/views/SourceModalView.js
@@ -13,7 +13,7 @@ define([
 
   var SourceModel = Backbone.Model.extend({
 
-    _uriTemplate: window.gfw.config.GFW_API_HOST + '/metadata/{slug}',
+    _uriTemplate: window.gfw.config.GFW_API_HOST_PROD + '/gfw-metadata/{slug}',
 
     initialize: function(options) {
       this.options = _.extend({}, options);


### PR DESCRIPTION
The old endpoint stopped working do to a change on IP. This an endpoint from the old API and will need to be migrated in the future, for now we created a proxy endpoint in the GFW production api.

This needs to be deployed to production today.