### PR TITLE
Use the new proxy endpoint created on the production API

### DIFF
--- a/app/assets/javascripts/views/SourceModalView.js
+++ b/app/assets/javascripts/views/SourceModalView.js
@@ -13,7 +13,7 @@ define([
 
   var SourceModel = Backbone.Model.extend({
 
-    _uriTemplate: window.gfw.config.GFW_API_HOST + '/metadata/{slug}',
+    _uriTemplate: window.gfw.config.GFW_API_HOST_PROD + '/gfw-metadata/{slug}',
 
     initialize: function(options) {
       this.options = _.extend({}, options);


### PR DESCRIPTION
Fixes bug in production of fetching metadata from the map.