### PR TITLE
Include info on places to watch legend

### DIFF
--- a/app/assets/javascripts/map/templates/legend/glad.handlebars
+++ b/app/assets/javascripts/map/templates/legend/glad.handlebars
@@ -5,7 +5,11 @@
 </div>
 <div data-autotoggle="true" data-sublayer="places_to_watch" data-parent="umd_as_it_happens" class="layer-sublayer js-toggle-sublayer">
   <span class="onoffswitch" style="background-color:#f69;"><span></span></span>
-  <div class="sublayer-title">Places to watch</div>
+  <div class="sublayer-title">Places to watch
+    <a href="#" data-source="places_to_watch" class="source source-shape-info js-tooltip" data-description="High-priority alerts from last month">
+      <svg class="icon-info-green -source"><use xlink:href="#shape-info"></use></svg>
+    </a>
+  </div>
   <div class="layer-details layer-details-places-to-watch">
     <p class="canopy">To receive monthly email updates</p>
     <p class="canopy"><a href="http://www.wri.org/global-forest-watch-updates-and-newsletter" target="_blank">Sign up for the PTW newsletter ➤</a></p>


### PR DESCRIPTION
## Overview

This PR include:
- Fix problem with info-modal on places to watch on map legend.
- (https://www.pivotaltracker.com/story/show/151245998)

## Demo

![placestwowatch](https://user-images.githubusercontent.com/8074563/30692653-bebade1c-9ecc-11e7-839a-f2e39529301e.gif)

## Notes

(No notes)

## Testing

- Active glad legend.
- Click info button next to places to watch text.
