### PR TITLE
Date selector for GLAD is picking the wrong start year for the datepicker

### DIFF
--- a/app/assets/javascripts/map/services/GladDateService.js
+++ b/app/assets/javascripts/map/services/GladDateService.js
@@ -50,7 +50,7 @@ define([
 
           var startDay = groupedDates[years[1]];
           var startDate = moment.utc()
-            .year(years[1])
+            .year(years[0])
             .dayOfYear(startDay[0].julian_day);
 
           var endDay = groupedDates[years[years.length - 1]];


### PR DESCRIPTION
When viewing the GLAD layer: http://localhost:3000/map/3/15.00/27.00/ALL/grayscale/umd_as_it_happens,places_to_watch?tab=analysis-tab&begin=2015-01-16&end=2017-09-16&dont_analyze=true the time ranger selector on the timeline was picking the wrong date to start from (2016) instead of 2015. So the users couldn't select any dates inside of 2015.

This PR fixes this and suggests a merge directly to master to make it available in production. If all good this commit should then be merged to develop to ensure it persists.