### PR TITLE
Removes GLAD notification from map

### DIFF
--- a/app/assets/javascripts/map/presenters/GladLayerPresenter.js
+++ b/app/assets/javascripts/map/presenters/GladLayerPresenter.js
@@ -10,7 +10,6 @@ define([
   var GladLayerPresenter = PresenterClass.extend({
 
     init: function(view) {
-      this.publishNotification('notification-glad-data-alert');
       this.view = view;
       this._super();
 
@@ -56,10 +55,6 @@ define([
 
     animationStopped: function() {
       mps.publish('Torque/stopped', []);
-    },
-
-    publishNotification: function(id){
-      mps.publish('Notification/open', [id]);
     },
 
     updateTimelineDate: function(change) {

--- a/app/views/shared/_notifications.html.erb
+++ b/app/views/shared/_notifications.html.erb
@@ -44,16 +44,6 @@
   <div id="notification-over-limit" data-type="error">
     <p>File exceedes feature limit <button class="btn little white source" data-source="drop-shapefile">More info</button></p>
   </div>
-  <div id="notification-glad-data-alert" data-type="warning">
-    <p>
-      GLAD alerts are up-to-date and updating weekly for Peru, Brazil, and
-      Central Africa - alerts in southeast Asia are on hold (as of March 10) as
-      we work to migrate the system to Google Earth Engine and adjust to recent
-      changes made by Landsat. Check out our
-      <a href="https://groups.google.com/forum/#!forum/globalforestwatch" target="_blank" rel="noopener noreferrer">Discussion Forum</a><br>
-      for the latest details or with any questions.
-    </p>
-  </div>
 
 
   <!-- STORIES -->


### PR DESCRIPTION
Previously when users selected the GLAD layer we were showing a banner
with some information about its state. This is no longer necessary.

This commit removes it from the application completely.