### PR TITLE
Removes GLAD notification from map

### DIFF
--- a/app/assets/javascripts/map/presenters/GladLayerPresenter.js
+++ b/app/assets/javascripts/map/presenters/GladLayerPresenter.js
@@ -9,7 +9,6 @@ define([
   var GladLayerPresenter = PresenterClass.extend({
 
     init: function(view) {
-      this.publishNotification('notification-glad-data-alert');
       this.view = view;
       this._super();
 
@@ -55,10 +54,6 @@ define([
 
     animationStopped: function() {
       mps.publish('Torque/stopped', []);
-    },
-
-    publishNotification: function(id){
-      mps.publish('Notification/open', [id]);
     },
 
     updateTimelineDate: function(change) {

--- a/app/assets/javascripts/map/services/GladDateService.js
+++ b/app/assets/javascripts/map/services/GladDateService.js
@@ -8,7 +8,7 @@ define([
   var REQUEST_ID = 'GladDateService:fetchDates';
 
   var API = window.gfw.config.GFW_API_HOST_PROD;
-  var DATASET = 'e663eb09-04de-4f39-b871-35c6c2ed10b5';
+  var DATASET = '393cb17c-be09-4868-914e-b50f7f5ec0b5';
   var QUERY = '/query?sql=SELECT count(*) as alerts FROM {dataset} GROUP BY julian_day, year ORDER BY year, julian_day';
 
   var GladDateService = Class.extend({

--- a/app/views/shared/_notifications.html.erb
+++ b/app/views/shared/_notifications.html.erb
@@ -44,14 +44,6 @@
   <div id="notification-over-limit" data-type="error">
     <p>File exceedes feature limit <button class="btn little white source" data-source="drop-shapefile">More info</button></p>
   </div>
-  <div id="notification-glad-data-alert" data-type="warning">
-    <p>
-      GLAD alerts are currently being updated for Peru only - other areas are on hold (as of March 10) as we work to<br>
-      migrate the system to Google Earth Engine and adjust to recent changes made by Landsat. Check out our
-      <a href="https://groups.google.com/forum/#!forum/globalforestwatch" target="_blank" rel="noopener noreferrer">Discussion Forum</a><br>
-      for the latest details or with any questions.
-    </p>
-  </div>
 
   <!-- STORIES -->
   <div id="notification-limit-exceed" data-type="error">


### PR DESCRIPTION
Previously when users selected the GLAD layer we were showing a banner
with some information about its state. This is no longer necessary.

This commit removes it from the application completely.