### PR TITLE
Returns SAD alerts to application

### DIFF
--- a/app/assets/javascripts/map/templates/layersNav.handlebars
+++ b/app/assets/javascripts/map/templates/layersNav.handlebars
@@ -34,6 +34,11 @@
               <span class="layer-title">Terra-i alerts<a href='#' data-source='terra_i_alerts' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
               <span class="layer-info">(monthly, 250m, tropics, CIAT)</span>
             </li>
+            <li class="layer" data-layer="imazon">
+              <span class="onoffswitch"><span></span></span>
+              <span class="layer-title">SAD alerts<a href='#' data-source='imazon_sad' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
+              <span class="layer-info">(monthly, 250m, Brazilian Amazon, Imazon)</span>
+            </li>
           </div>
           <div class="layer-group">
             <li class="layer" data-layer="viirs_fires_alerts">


### PR DESCRIPTION
## Overview

It seems that in July we removed the SAD alerts from the map navigation in this commit: https://github.com/Vizzuality/gfw/commit/45a48c229071daf5ac093cbf764ac3e5aa307917

But talking with Mikaela it seems that this was not supposed to be like this. So I'm returning it to the production site now.
