### PR TITLE
Divides gain by 12 on the total big figure for country rankings page

### DIFF
--- a/app/assets/javascripts/countries/views/CountryOverviewView.js
+++ b/app/assets/javascripts/countries/views/CountryOverviewView.js
@@ -952,7 +952,9 @@ define([
               url: 'https://wri-01.cartodb.com/api/v2/sql?q=' + query,
               dataType: 'json',
               success: _.bind(function(data) {
-                var gain = data.rows[0].sum;
+                // gain needs to be divided by 12, as each year holds the same
+                // value.
+                var gain = data.rows[0].sum/12;
                 var g_mha, l_mha;
                 g_mha = l_mha = 'Mha';
 


### PR DESCRIPTION
## Overview

Following from this BC thread: https://basecamp.com/3063126/projects/10726176/todos/327458495 

It seems that:

"apparently the current table structure on CARTO requires a value for every cell. Even though the data is not annual, we put in the total value for every year 2001 to 2012. So it does indeed need to be divided by 12 on both the individual country pages and on the country rankings page!"

So we need to divide that value per 12.