### PR TITLE
Fixes issue with filtering data from past 2 days

### DIFF
--- a/app/assets/javascripts/map/views/layers/FormaActivityLayer.js
+++ b/app/assets/javascripts/map/views/layers/FormaActivityLayer.js
@@ -29,7 +29,7 @@ define([
 
       // Default to 48 hours
       var currentDate = options.currentDate ||
-        [moment().subtract(2, 'days').utc(), moment()];
+        [moment().subtract(3, 'days').utc(), moment()];
       this.setCurrentDate(DatesHelper.getRangeForDates(currentDate));
 
       this._super(layer, options, map);

--- a/app/assets/javascripts/map/views/timeline/FormaActivityTimeline.js
+++ b/app/assets/javascripts/map/views/timeline/FormaActivityTimeline.js
@@ -23,9 +23,9 @@ define([
     label: 'past week',
     duration: 168
   }, {
-    start: moment().subtract(2, 'days').utc(),
+    start: moment().subtract(3, 'days').utc(),
     end: moment().utc(),
-    label: 'past 48 hours',
+    label: 'past 2 days',
     duration: 48
   }];
 


### PR DESCRIPTION
## Overview

There was an issue with the filtering of the forma active clearings for the past 48 hours, related to the timing of the alerts what we were hoping to do with the "Past 48 hours". We are now replacing that with "Past 2 days" and making sure that we capture the past two days and a bit more regardless of the time you visit the site.