### PR TITLE
Put sentinel data at the bottom of the image stack

### DIFF
--- a/app/assets/javascripts/map/models/LayerSpecModel.js
+++ b/app/assets/javascripts/map/models/LayerSpecModel.js
@@ -18,6 +18,7 @@ define([
     layerOrder: [
       //high resolution maps
       "highres",
+      "sentinel_tiles",
       //-
       "grump2000",
       "mex_forest_zoning_cat",
@@ -188,7 +189,6 @@ define([
       "places_to_watch",
       'forma_month_3',
       'forma_activity',
-      'sentinel_tiles'
     ],
 
     categoryOrder: [


### PR DESCRIPTION
## Overview

This addresses [BC bug](https://basecamp.com/3063126/projects/10728552/todos/332155798).
Ensures new sentinel image appears below other layers on the map.

