### PR TITLE
Toggling forest change layers preserves Tree cover layer

### DIFF
--- a/app/assets/javascripts/map/services/LayerSpecService.js
+++ b/app/assets/javascripts/map/services/LayerSpecService.js
@@ -89,9 +89,12 @@ define([
         return false;
       } else {
         if (!this._combinationIsValid(layer)) {
-          _.each(this.model.get(layer.category_slug), this._removeLayer);
+          _.each(this.model.get(layer.category_slug), function(l) {
+            if (l.category_name === 'Forest change') {
+              this._removeLayer(l);
+            }
+          }.bind(this));
         }
-
         this._addLayer(layer);
         return layer;
       }


### PR DESCRIPTION
Following [this](https://basecamp.com/3063126/projects/10728552/todos/331321730) basecamp thread, a fix has been implemented so that attempting to toggle on forbidden layer combinations does not remove all previous layers!

Instead, attempting to toggle an invalid combination only removes the conflicting previous layer(s).

e.g. Starting from the default layers (Forest Loss, Forest Gain, Tree Cover) and attempting to toggle on GLAD alerts removes only the Loss/Gain layers, but not Tree Cover.


