### PR TITLE
Changes treecover menu subtitle

### DIFF
--- a/app/assets/javascripts/map/templates/layersNav.handlebars
+++ b/app/assets/javascripts/map/templates/layersNav.handlebars
@@ -80,7 +80,7 @@
           <li class="wrapped-layer" data-color="#B2D26E">
             <span class="onoffswitch"><span></span></span>
             <span class="layer-title">Tree cover<a href='#' data-source='tree_cover' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
-            <span class="layer-info">(2000/2010) Hansen/UMD/Google/USGS/NASA</span>
+            <span class="layer-info">(2000/2010, Hansen/UMD/Google/USGS/NASA)</span>
             <span class="layer-info -hidden">
               <label data-layer="forest2000" class="layer wrapped">
                 <span></span>


### PR DESCRIPTION
Quick fix to change Tree Cover subtitle to (2000/2010, Hansen/UMD/Google/USGS/NASA) as per [this](https://basecamp.com/3063126/projects/10726176/todos/287938139#comment_580061332) Basecamp thread.