### PR TITLE
Fix/tree gain widget update

### DIFF
--- a/app/javascript/pages/country/root/root-component.js
+++ b/app/javascript/pages/country/root/root-component.js
@@ -16,24 +16,24 @@ const WIDGETS = {
   treeCover: {
     gridWidth: 6
   },
+  treeLocated: {
+    gridWidth: 6
+  },
+  treeLoss: {
+    gridWidth: 12
+  },
   treeCoverGain: {
     gridWidth: 6
+  },
+  treeCoverLossAreas: {
+    gridWidth: 6
+  },
+  totalAreaPlantations: {
+    gridWidth: 6
+  },
+  plantationArea: {
+    gridWidth: 6
   }
-  // treeLocated: {
-  //   gridWidth: 6
-  // },
-  // treeLoss: {
-  //   gridWidth: 12
-  // },
-  // treeCoverLossAreas: {
-  //   gridWidth: 6
-  // },
-  // totalAreaPlantations: {
-  //   gridWidth: 6
-  // },
-  // plantationArea: {
-  //   gridWidth: 6
-  // }
 };
 
 class Root extends PureComponent {
@@ -64,7 +64,7 @@ class Root extends PureComponent {
             </div>
           </div>
           <div className={`map-panel ${showMapMobile ? '-open-mobile' : ''}`}>
-            {/* <Sticky
+            <Sticky
               className={`map ${showMapMobile ? '-open-mobile' : ''}`}
               limitElement="c-stories"
             >
@@ -87,7 +87,7 @@ class Root extends PureComponent {
                   zoom: 8
                 }}
               />
-            </Sticky> */}
+            </Sticky>
           </div>
         </div>
         <Stories />

--- a/app/javascript/pages/country/root/root-component.js
+++ b/app/javascript/pages/country/root/root-component.js
@@ -16,24 +16,24 @@ const WIDGETS = {
   treeCover: {
     gridWidth: 6
   },
-  treeLocated: {
-    gridWidth: 6
-  },
-  treeLoss: {
-    gridWidth: 12
-  },
-  treeCoverLossAreas: {
-    gridWidth: 6
-  },
   treeCoverGain: {
     gridWidth: 6
-  },
-  totalAreaPlantations: {
-    gridWidth: 6
-  },
-  plantationArea: {
-    gridWidth: 6
   }
+  // treeLocated: {
+  //   gridWidth: 6
+  // },
+  // treeLoss: {
+  //   gridWidth: 12
+  // },
+  // treeCoverLossAreas: {
+  //   gridWidth: 6
+  // },
+  // totalAreaPlantations: {
+  //   gridWidth: 6
+  // },
+  // plantationArea: {
+  //   gridWidth: 6
+  // }
 };
 
 class Root extends PureComponent {
@@ -64,7 +64,7 @@ class Root extends PureComponent {
             </div>
           </div>
           <div className={`map-panel ${showMapMobile ? '-open-mobile' : ''}`}>
-            <Sticky
+            {/* <Sticky
               className={`map ${showMapMobile ? '-open-mobile' : ''}`}
               limitElement="c-stories"
             >
@@ -87,7 +87,7 @@ class Root extends PureComponent {
                   zoom: 8
                 }}
               />
-            </Sticky>
+            </Sticky> */}
           </div>
         </div>
         <Stories />

--- a/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain-actions.js
+++ b/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain-actions.js
@@ -12,6 +12,7 @@ const setTreeCoverGainSettingsIndicator = createAction(
 const getTreeCoverGain = createThunkAction(
   'getTreeCoverGain',
   (country, region, subRegion, indicator) => dispatch => {
+    dispatch(setTreeCoverGainIsLoading(true));
     axios
       .all([
         getGain(country, region, subRegion, indicator),

--- a/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain-actions.js
+++ b/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain-actions.js
@@ -11,30 +11,28 @@ const setTreeCoverGainSettingsIndicator = createAction(
 );
 const getTreeCoverGain = createThunkAction(
   'getTreeCoverGain',
-  (country, region, subRegion, indicator) => dispatch => {
-    dispatch(setTreeCoverGainIsLoading(true));
-    axios
-      .all([
-        getGain(country, region, subRegion, indicator),
-        getExtent(country, region, subRegion, indicator, 0)
-      ])
-      .then(
-        axios.spread((getTreeGainResponse, getExtentResponse) => {
-          const gain = getTreeGainResponse.data.data[0].value;
-          const treeExtent = getExtentResponse.data.data[0].value;
-
-          dispatch(
-            setTreeCoverGainValues({
-              gain,
-              treeExtent
-            })
-          );
-        })
-      )
-      .catch(error => {
-        console.info(error);
-        dispatch(setTreeCoverGainIsLoading(false));
-      });
+  params => (dispatch, state) => {
+    if (!state().widgetTreeCoverGain.isLoading) {
+      dispatch(setTreeCoverGainIsLoading(true));
+      axios
+        .all([getGain({ ...params }), getExtent({ ...params, threshold: 0 })])
+        .then(
+          axios.spread((getTreeGainResponse, getExtentResponse) => {
+            const gain = getTreeGainResponse.data.data[0].value;
+            const treeExtent = getExtentResponse.data.data[0].value;
+            dispatch(
+              setTreeCoverGainValues({
+                gain,
+                treeExtent
+              })
+            );
+          })
+        )
+        .catch(error => {
+          console.info(error);
+          dispatch(setTreeCoverGainIsLoading(false));
+        });
+    }
   }
 );
 

--- a/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain-component.js
+++ b/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain-component.js
@@ -30,15 +30,18 @@ class WidgetTreeCoverGain extends PureComponent {
             indicators={indicators}
             settings={settings}
             onIndicatorChange={setTreeCoverGainSettingsIndicator}
+            isLoading={isLoading}
           />
         </WidgetHeader>
         {isLoading ? (
-          <Loader />
+          <Loader className="loader-offset" />
         ) : (
-          <div className="c-widget-tree-cover-gain__container">
-            <div className="c-widget-tree-cover-gain__info">
+          <div className="container">
+            <div className="info">
               <p className="title">Hansen - UMD</p>
-              <p dangerouslySetInnerHTML={getSentence()} />
+              <p
+                dangerouslySetInnerHTML={getSentence()} // eslint-disable-line
+              />
             </div>
           </div>
         )}

--- a/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain-reducers.js
+++ b/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain-reducers.js
@@ -1,39 +1,9 @@
 export const initialState = {
-  isLoading: true,
+  isLoading: false,
   gain: 0,
   treeExtent: 0,
-  indicators: [
-    {
-      label: 'All Regions',
-      value: 'gadm28_only'
-    },
-    {
-      label: 'Biodiversity Hotspots',
-      value: 'biodiversity_hot_spots'
-    },
-    {
-      label: 'Protected Areas',
-      value: 'wdpa'
-    },
-    {
-      label: 'Tree Plantations',
-      value: 'gfw_plantations'
-    },
-    {
-      label: 'Managed',
-      value: 'gfw_managed_forests'
-    },
-    {
-      label: 'Intact Forest Landscapes (2000)',
-      value: 'IFL_2000'
-    },
-    {
-      label: 'Intact Forest Landscapes (2013)',
-      value: 'IFL_2013'
-    }
-  ],
   settings: {
-    indicator: 'gadm28_only'
+    indicator: 'gadm28'
   }
 };
 
@@ -45,8 +15,7 @@ const setTreeCoverGainIsLoading = (state, { payload }) => ({
 const setTreeCoverGainValues = (state, { payload }) => ({
   ...state,
   isLoading: false,
-  gain: payload.gain,
-  treeExtent: payload.treeExtent
+  ...payload
 });
 
 const setTreeCoverGainSettingsIndicator = (state, { payload }) => ({

--- a/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain-settings-component.js
+++ b/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain-settings-component.js
@@ -4,7 +4,7 @@ import Dropdown from 'components/dropdown';
 
 class WidgetTreeCoverGainSettings extends PureComponent {
   render() {
-    const { indicators, settings, onIndicatorChange } = this.props;
+    const { indicators, settings, onIndicatorChange, isLoading } = this.props;
     return (
       <div className="c-widget-settings">
         <div className="body">
@@ -14,6 +14,7 @@ class WidgetTreeCoverGainSettings extends PureComponent {
             value={settings.indicator}
             options={indicators}
             onChange={option => onIndicatorChange(option.value)}
+            disabled={isLoading}
           />
         </div>
       </div>
@@ -24,7 +25,8 @@ class WidgetTreeCoverGainSettings extends PureComponent {
 WidgetTreeCoverGainSettings.propTypes = {
   indicators: PropTypes.array.isRequired,
   settings: PropTypes.object.isRequired,
-  onIndicatorChange: PropTypes.func
+  onIndicatorChange: PropTypes.func,
+  isLoading: PropTypes.bool
 };
 
 export default WidgetTreeCoverGainSettings;

--- a/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain-styles.scss
+++ b/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain-styles.scss
@@ -1,16 +1,16 @@
 @import '~styles/settings.scss';
 
 .c-widget-tree-cover-gain {
-  .c-widget-tree-cover-gain__container {
-    .c-widget-tree-cover-gain__info {
-      border-top: 1px solid rgba($slate, .2);
+  .container {
+    .info {
+      border-top: 1px solid rgba($slate, 0.2);
 
       .title {
         display: block;
         margin: rem(10px) 0 rem(18px);
         font-size: 12px;
         line-height: 1.08;
-        color: rgba($slate, .5);
+        color: rgba($slate, 0.5);
         font-weight: 400;
       }
 
@@ -25,5 +25,10 @@
         }
       }
     }
+  }
+
+  .loader-offset {
+    top: rem(50px);
+    height: calc(100% - 50px);
   }
 }

--- a/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain.js
+++ b/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain.js
@@ -15,10 +15,8 @@ const INDICATORS_WHITELIST = [
   'gadm28',
   'biodiversity_hot_spots',
   'wdpa',
-  'gfw_plantations',
-  'gfw_managed_forests',
-  'IFL_2000',
-  'IFL_2013'
+  'primary_forests',
+  'ifl_2013'
 ];
 
 const mapStateToProps = ({ countryData, widgetTreeCoverGain, location }) => {

--- a/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain.js
+++ b/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import numeral from 'numeral';
 import { getAdminsSelected, getIndicators } from 'pages/country/utils/filters';
+import isEqual from 'lodash/isEqual';
 
 import WidgetTreeCoverGainComponent from './widget-tree-cover-gain-component';
 import actions from './widget-tree-cover-gain-actions';
@@ -60,7 +61,10 @@ class WidgetTreeCoverGainContainer extends PureComponent {
   componentWillReceiveProps(nextProps) {
     const { settings, location, getTreeCoverGain } = nextProps;
 
-    if (settings.indicator !== this.props.settings.indicator) {
+    if (
+      !isEqual(nextProps.location, this.props.location) ||
+      !isEqual(settings.indicator !== this.props.settings.indicator)
+    ) {
       getTreeCoverGain({
         ...location,
         indicator: settings.indicator

--- a/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain.js
+++ b/app/javascript/pages/country/widgets/widget-tree-cover-gain/widget-tree-cover-gain.js
@@ -2,6 +2,7 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import numeral from 'numeral';
+import { getAdminsSelected, getIndicators } from 'pages/country/utils/filters';
 
 import WidgetTreeCoverGainComponent from './widget-tree-cover-gain-component';
 import actions from './widget-tree-cover-gain-actions';
@@ -10,38 +11,64 @@ export { initialState } from './widget-tree-cover-gain-reducers';
 export { default as reducers } from './widget-tree-cover-gain-reducers';
 export { default as actions } from './widget-tree-cover-gain-actions';
 
-const mapStateToProps = state => ({
-  location: state.location.payload,
-  isLoading: state.widgetTreeCoverGain.isLoading,
-  gain: state.widgetTreeCoverGain.gain,
-  treeExtent: state.widgetTreeCoverGain.treeExtent,
-  indicators: state.widgetTreeCoverGain.indicators,
-  settings: state.widgetTreeCoverGain.settings
-});
+const INDICATORS_WHITELIST = [
+  'gadm28',
+  'biodiversity_hot_spots',
+  'wdpa',
+  'gfw_plantations',
+  'gfw_managed_forests',
+  'IFL_2000',
+  'IFL_2013'
+];
+
+const mapStateToProps = ({ countryData, widgetTreeCoverGain, location }) => {
+  const {
+    isCountriesLoading,
+    isRegionsLoading,
+    isSubRegionsLoading
+  } = countryData;
+  return {
+    location: location.payload,
+    isLoading:
+      widgetTreeCoverGain.isLoading ||
+      isCountriesLoading ||
+      isRegionsLoading ||
+      isSubRegionsLoading,
+    gain: widgetTreeCoverGain.gain,
+    treeExtent: widgetTreeCoverGain.treeExtent,
+    indicators:
+      getIndicators({
+        whitelist: INDICATORS_WHITELIST,
+        location: location.payload,
+        ...countryData
+      }) || [],
+    settings: widgetTreeCoverGain.settings,
+    locationNames: getAdminsSelected({
+      ...countryData,
+      location: location.payload
+    })
+  };
+};
 
 class WidgetTreeCoverGainContainer extends PureComponent {
-  componentWillUpdate(nextProps) {
-    const { isMetaLoading, settings } = this.props;
-
-    if (JSON.stringify(settings) !== JSON.stringify(nextProps.settings)) {
-      this.updateData(nextProps);
-    }
-
-    if (!nextProps.isMetaLoading && isMetaLoading) {
-      this.setWidgetData(nextProps);
-    }
+  componentWillMount() {
+    const { location, settings, getTreeCoverGain } = this.props;
+    getTreeCoverGain({
+      ...location,
+      indicator: settings.indicator
+    });
   }
 
-  setWidgetData = newProps => {
-    const { location, settings, getTreeCoverGain } = newProps;
+  componentWillReceiveProps(nextProps) {
+    const { settings, location, getTreeCoverGain } = nextProps;
 
-    getTreeCoverGain(
-      location.country,
-      location.region,
-      location.subRegion,
-      settings.indicator
-    );
-  };
+    if (settings.indicator !== this.props.settings.indicator) {
+      getTreeCoverGain({
+        ...location,
+        indicator: settings.indicator
+      });
+    }
+  }
 
   getSentence = () => {
     const {
@@ -56,48 +83,36 @@ class WidgetTreeCoverGainContainer extends PureComponent {
       item => item.value === settings.indicator
     );
     const regionPhrase =
-      settings.indicator === 'gadm28_only'
+      settings.indicator === 'gadm28'
         ? 'region-wide'
         : `in ${indicator[0].label.toLowerCase()}`;
 
     const areaPercent = numeral(100 * treeExtent / gain).format('0,00');
 
     return {
-      __html: `From 2001 to 2012, ${
-        locationNames.current.label
-      } gained <strong>${numeral(gain).format(
+      __html: `From 2001 to 2012, ${locationNames.current &&
+        locationNames.current.label} gained <strong>${numeral(gain).format(
         '0,0'
-      )} ha</strong> of tree cover in ${
-        regionPhrase
-      }, equivalent to a <strong>${
-        areaPercent
-      }%</strong> increase relative to 2010 tree cover extent.`
+      )} ha</strong> of tree cover in ${regionPhrase}, equivalent to a <strong>${areaPercent}%</strong> increase relative to 2010 tree cover extent.`
     };
-  };
-
-  updateData = newProps => {
-    newProps.setTreeCoverGainIsLoading(true);
-    this.setWidgetData(newProps);
   };
 
   render() {
     return createElement(WidgetTreeCoverGainComponent, {
       ...this.props,
-      componentWillUpdate: this.componentWillUpdate,
-      setWidgetData: this.setWidgetData,
-      updateData: this.updateData,
       getSentence: this.getSentence
     });
   }
 }
 
 WidgetTreeCoverGainContainer.propTypes = {
-  isMetaLoading: PropTypes.bool,
-  locationNames: PropTypes.object,
-  gain: PropTypes.number,
-  treeExtent: PropTypes.number,
-  indicators: PropTypes.array,
-  settings: PropTypes.object
+  locationNames: PropTypes.object.isRequired,
+  gain: PropTypes.number.isRequired,
+  treeExtent: PropTypes.number.isRequired,
+  indicators: PropTypes.array.isRequired,
+  settings: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  getTreeCoverGain: PropTypes.func.isRequired
 };
 
 export default connect(mapStateToProps, actions)(WidgetTreeCoverGainContainer);

--- a/app/javascript/pages/country/widgets/widget-tree-cover/widget-tree-cover.js
+++ b/app/javascript/pages/country/widgets/widget-tree-cover/widget-tree-cover.js
@@ -26,10 +26,12 @@ const INDICATORS_WHITELIST = [
 
 const mapStateToProps = ({ widgetTreeCover, countryData, location }) => {
   const { isCountriesLoading, isRegionsLoading } = countryData;
-  const totalArea = widgetTreeCover.totalArea;
-  const totalCover = widgetTreeCover.totalCover;
-  const totalIntactForest = widgetTreeCover.totalIntactForest;
-  const totalNonForest = widgetTreeCover.totalNonForest;
+  const {
+    totalArea,
+    totalCover,
+    totalIntactForest,
+    totalNonForest
+  } = widgetTreeCover.totalArea;
   const data = [
     {
       name: 'Forest',
@@ -83,7 +85,7 @@ class WidgetTreeCoverContainer extends PureComponent {
     });
   }
 
-  componentWillUpdate(nextProps) {
+  componentWillReceiveProps(nextProps) {
     const { settings, getTreeCover, location } = nextProps;
 
     if (


### PR DESCRIPTION
## Overview

Fixes for the Tree Cover Gain widget:
- Spread the data correctly from container to fetch and from state to props
- Correct loading state for fetch from countryData and component data
- Add check for fetch to make sure not already fetching
- Reduce component update logic so use minimal lifecycle methods

