### PR TITLE
Fix: correct modal styles

### DIFF
--- a/app/assets/stylesheets/layouts/_grid.scss
+++ b/app/assets/stylesheets/layouts/_grid.scss
@@ -22,8 +22,4 @@
     width: 95%;
     max-width: 1080px;
   }
-
-  @media (min-width: 1400px){
-    max-width: 83.33333%;
-  }
 }

--- a/app/javascript/components/modal/modal-component.jsx
+++ b/app/javascript/components/modal/modal-component.jsx
@@ -46,23 +46,21 @@ CustomModal.defaultProps = {
   contentLabel: 'Modal content',
   customStyles: {
     overlay: {
-      zIndex: 20,
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
+      zIndex: 1000,
       boxShadow: '0 5px 15px 0 rgba(71, 44, 184, 0.1)',
-      backgroundColor: 'rgba(17, 55, 80, 0.4)'
+      backgroundColor: 'rgba(17, 55, 80, 0.4)',
+      overflow: 'auto',
+      padding: '40px 0'
     },
     content: {
       position: 'relative',
       top: 'auto',
+      margin: 'auto',
       left: 'auto',
       right: 'auto',
       bottom: 'auto',
       width: '1080px',
       padding: '0',
-      maxHeight: '640px',
-      height: 'calc(100vh - 100px)',
       border: 'none',
       borderRadius: 0
     }


### PR DESCRIPTION
## Overview

Feedback from @juancarlosalonso the modal is now a contained box which scrolls inside the overlay in stead of inside itself.

BONUS: remove unwanted grid break point on old pages.

## Demo

![dec-11-2017 10-38-21](https://user-images.githubusercontent.com/20288774/33824668-72675338-de5f-11e7-8a26-1b2ead900016.gif)


