### PR TITLE
make info buttons visible again

### DIFF
--- a/app/assets/stylesheets/modules/map/_module-legend.scss
+++ b/app/assets/stylesheets/modules/map/_module-legend.scss
@@ -214,7 +214,11 @@
     display: inline-block;
     position: absolute;
     top: -2px;
-    right: 17px;
+    right: 50px;
+
+    @media (min-width: $br-mobileMap){
+      right: 17px;
+    }
 
     &.hidden {
       display: none;
@@ -281,8 +285,12 @@
     display: inline-block;
     position: absolute;
     top: -2px;
-    right: 36px;
+    right: 68px;
     background: $white;
+
+    @media (min-width: $br-mobileMap){
+      right: 36px;
+    }
 
     svg {
       width: 14px;
@@ -429,9 +437,6 @@
         &.-alerts {
           .layer-close {
             right: 0;
-          }
-          .source {
-            right: 18px;
           }
         }
       }


### PR DESCRIPTION
You couldn't see the meta buttons on the mobile map layers menu, now you can.

![screen shot 2017-12-20 at 11 12 55](https://user-images.githubusercontent.com/20288774/34204506-c2b10262-e576-11e7-9ff3-c096c59ed810.png)

