### PR TITLE
make info buttons visible again

### DIFF
--- a/app/assets/stylesheets/modules/map/_module-legend.scss
+++ b/app/assets/stylesheets/modules/map/_module-legend.scss
@@ -213,7 +213,11 @@
     display: inline-block;
     position: absolute;
     top: -2px;
-    right: 17px;
+    right: 50px;
+
+    @media (min-width: $br-mobileMap){
+      right: 17px;
+    }
 
     &.hidden {
       display: none;
@@ -280,8 +284,12 @@
     display: inline-block;
     position: absolute;
     top: -2px;
-    right: 36px;
+    right: 68px;
     background: $white;
+
+    @media (min-width: $br-mobileMap){
+      right: 36px;
+    }
 
     svg {
       width: 14px;
@@ -428,9 +436,6 @@
         &.-alerts {
           .layer-close {
             right: 0;
-          }
-          .source {
-            right: 18px;
           }
         }
       }


### PR DESCRIPTION
## Overview

Adding a PR #3168 to Master to fix an issue on Mobile: enables users to select the legend (which was previously un-clickable).

