### PR TITLE
Bugfix/donut chart ha unit missing

### DIFF
--- a/app/javascript/pages/country/widget/components/widget-pie-chart-legend/widget-pie-chart-legend-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-pie-chart-legend/widget-pie-chart-legend-component.jsx
@@ -38,7 +38,7 @@ WidgetPieChartLegend.propTypes = {
 
 WidgetPieChartLegend.defaultProps = {
   config: {
-    unit: '',
+    unit: 'ha',
     key: 'value',
     format: '.3s'
   }


### PR DESCRIPTION
## Overview
Fixes Pivotal Tracker bug #153870292 of missing ha units on donut charts.

#### Before
![screen shot 2017-12-22 at 10 43 24](https://user-images.githubusercontent.com/6503031/34293525-53959a4c-e705-11e7-845f-a6c914c92b8d.png)

#### After
![screen shot 2017-12-22 at 10 43 18](https://user-images.githubusercontent.com/6503031/34293550-660760d4-e705-11e7-851b-a1c7f7a6971c.png)

