### PR TITLE
modified extent widget to show 0ha cover cases where it makes sense t…

### DIFF
--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-component.js
@@ -47,14 +47,12 @@ class WidgetTreeCover extends PureComponent {
             data &&
             data.length === 0 && (
               <NoContent
-                message={`No tree cover for ${locationNames.current &&
+                message={`No data in selection for ${locationNames.current &&
                   locationNames.current.label}`}
-                icon
               />
             )}
           {!isLoading &&
-            data &&
-            data.length > 0 && (
+            data && (
               <div className="pie-chart-container">
                 <WidgetPieChartLegend data={data} settings={settings} />
                 <WidgetPieChart className="cover-pie-chart" data={data} />

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-selectors.js
@@ -10,7 +10,7 @@ const getPlantationsCover = state => state.plantations || null;
 export const getTreeCoverData = createSelector(
   [getTotalCover, getTotalArea, getPlantationsCover],
   (total, cover, plantations) => {
-    if (!total || !cover) return null;
+    if (!total) return null;
     return [
       {
         name: plantations ? 'Natural forest' : 'Tree cover',
@@ -25,7 +25,7 @@ export const getTreeCoverData = createSelector(
         percentage: plantations / total * 100
       },
       {
-        name: 'Non Forest',
+        name: 'Non-Forest',
         value: total - cover,
         color: COLORS.nonForest,
         percentage: (total - cover) / total * 100


### PR DESCRIPTION
## Overview

PT task #153871404

The tree cover extent widget was previously showing a message about No tree cover in cases where tree cover was 0ha; but in reality it should show the widget as normal, it should only show 100% area for non-forest.

* Show widget when area is 0ha
* Changed `Non Forest` legend label to `Non-Forest`
* When data is missing over a selected area (should only happen if a data layer is miss-assigned to a widget), we show a No data available message

![screen shot 2017-12-22 at 11 19 05](https://user-images.githubusercontent.com/6503031/34294836-a8493c1a-e70a-11e7-9498-17dd9f855c44.png)

![screen shot 2017-12-22 at 11 18 57](https://user-images.githubusercontent.com/6503031/34294880-d417cf64-e70a-11e7-9a50-d0b6ee866d90.png)

(examples for [DZA/17](http://staging.globalforestwatch.org/country/DZA/17))
