### PR TITLE
Bugfix on Tree cover extent plantation legend and update widget configs

### DIFF
--- a/app/javascript/pages/country/data/categories.json
+++ b/app/javascript/pages/country/data/categories.json
@@ -1,29 +1,29 @@
 [
-  { 
+  {
     "label": "Summary",
-    "value": "summary" 
+    "value": "summary"
+  },
+  {
+    "label": "Land cover",
+    "value": "land-cover"
   },
   { 
     "label": "Forest change",
-    "value": "forest-change" 
+    "value": "forest-change"
   },
-  { 
-    "label": "Land cover",
-    "value": "land-cover" 
-  },
-  { 
+  {
     "label": "Land use",
-    "value": "land-use" 
+    "value": "land-use"
   },
-  { 
+  {
     "label": "Conservation",
-    "value": "conservation" 
+    "value": "conservation"
   },
-  { 
+  {
     "label": "People",
     "value": "people"
   },
-  { 
+  {
     "label": "Climate",
     "value": "climate"
   }

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -18,7 +18,11 @@
     "anchorLink": "tree-located",
     "gridWidth": 6,
     "config": {
-      "indicators": ["gadm28", "plantations", "ifl_2013", "primary_forest"],
+      "indicators": ["gadm28", "ifl_2013",
+                      "ifl_2013__wdpa", "ifl_2013__mining",
+                      "primary_forest", "primary_forest__landmark",
+                      "plantations", "plantations__mining",
+                      "plantations__wdpa", "plantations__landmark"],
       "categories": ["summary", "land-cover"],
       "admins": ["country", "region", "subRegion"]
     },

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -4,43 +4,13 @@
     "anchorLink": "tree-cover-extent",
     "gridWidth": 6,
     "config": {
-      "indicators": ["gadm28", "wdpa", "primary_forests", "plantations"],
-      "categories": ["summary", "forest-change", "land-cover"],
+      "indicators": ["gadm28", "mining", "landmark", "wdpa", "plantations"],
+      "categories": ["summary", "land-cover"],
       "admins": ["country", "region", "subRegion"]
     },
     "settings": {
       "indicator": "gadm28",
       "threshold": 30
-    }
-  },
-  "treeGain": {
-    "title": "Tree cover gain",
-    "anchorLink": "tree-cover-gain",
-    "gridWidth": 6,
-    "config": {
-      "indicators": ["gadm28", "wdpa", "primary_forests", "plantations", "ifl_2013"],
-      "categories": ["summary", "forest-change", "land-cover"],
-      "admins": ["country", "region", "subRegion"]
-    },
-    "settings": {
-      "indicator": "gadm28",
-      "threshold": "0"
-    }
-  },
-  "treeLoss": {
-    "title": "Tree cover loss",
-    "anchorLink": "tree-cover-loss",
-    "gridWidth": 12,
-    "config": {
-      "indicators": ["gadm28", "gfw_plantations", "gfw_managed_forests", "wdpa", "primary_forests", "ifl_2013", "ifl_2000"],
-      "categories": ["summary", "forest-change", "land-cover"],
-      "admins": ["country", "region", "subRegion"]
-    },
-    "settings": {
-      "indicator": "gadm28",
-      "threshold": 30,
-      "startYear": 2001,
-      "endYear": 2016
     }
   },
   "treeLocated": {
@@ -49,7 +19,7 @@
     "gridWidth": 6,
     "config": {
       "indicators": ["gadm28", "plantations", "ifl_2013", "primary_forest"],
-      "categories": ["summary", "forest-change", "land-cover"],
+      "categories": ["summary", "land-cover"],
       "admins": ["country", "region", "subRegion"]
     },
     "settings": {
@@ -60,12 +30,42 @@
       "page": 0
     }
   },
+  "treeLoss": {
+    "title": "Tree cover loss",
+    "anchorLink": "tree-cover-loss",
+    "gridWidth": 12,
+    "config": {
+      "indicators": ["gadm28", "gfw_plantations", "gfw_managed_forests", "wdpa", "primary_forests", "ifl_2013", "ifl_2000"],
+      "categories": ["summary", "forest-change"],
+      "admins": ["country", "region", "subRegion"]
+    },
+    "settings": {
+      "indicator": "gadm28",
+      "threshold": 30,
+      "startYear": 2001,
+      "endYear": 2016
+    }
+  },
+  "treeGain": {
+    "title": "Tree cover gain",
+    "anchorLink": "tree-cover-gain",
+    "gridWidth": 6,
+    "config": {
+      "indicators": ["gadm28", "wdpa", "primary_forests", "plantations", "ifl_2013"],
+      "categories": ["summary", "forest-change"],
+      "admins": ["country", "region", "subRegion"]
+    },
+    "settings": {
+      "indicator": "gadm28",
+      "threshold": "0"
+    }
+  },
   "faoExtent": {
     "title": "FAO REFORESTATION",
     "anchorLink": "fao-reforestation",
     "gridWidth": 6,
     "config": {
-      "categories": ["summary", "forest-change", "land-cover"],
+      "categories": ["summary","forest-change"],
       "admins": ["country"]
     },
     "settings": {
@@ -77,7 +77,7 @@
     "anchorLink": "fao-forest",
     "gridWidth": 6,
     "config": {
-      "categories": ["summary", "forest-change", "land-cover"],
+      "categories": ["land-cover"],
       "admins": ["country"]
     }
   }

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -18,7 +18,7 @@
     "anchorLink": "tree-located",
     "gridWidth": 6,
     "config": {
-      "indicators": ["gadm28", "ifl_2013",
+      "indicators": ["gadm28", "ifl_2013", "wdpa",
                       "ifl_2013__wdpa", "ifl_2013__mining",
                       "primary_forest", "primary_forest__landmark",
                       "plantations", "plantations__mining",
@@ -39,7 +39,11 @@
     "anchorLink": "tree-cover-loss",
     "gridWidth": 12,
     "config": {
-      "indicators": ["gadm28", "gfw_plantations", "gfw_managed_forests", "wdpa", "primary_forests", "ifl_2013", "ifl_2000"],
+      "indicators": ["gadm28", "wdpa", "ifl_2013",
+                     "ifl_2013__wdpa", "ifl_2013__mining",
+                     "primary_forests","primary_forest__landmark",
+                      "plantations", "plantations__mining",
+                      "plantations__wdpa", "plantations__landmark"],
       "categories": ["summary", "forest-change"],
       "admins": ["country", "region", "subRegion"]
     },

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-selectors.js
@@ -5,15 +5,23 @@ import COLORS from 'pages/country/data/colors.json';
 const getTotalCover = state => state.totalArea || null;
 const getTotalArea = state => state.cover || null;
 const getPlantationsCover = state => state.plantations || null;
+const getIndicator = state => state.indicator || null;
+
+function getNameLabel(indicator, plantations) {
+  if (indicator === 'plantations') {
+    return 'Tree plantations';
+  }
+  return plantations ? 'Natural forest' : 'Tree cover';
+}
 
 // get lists selected
 export const getTreeCoverData = createSelector(
-  [getTotalCover, getTotalArea, getPlantationsCover],
-  (total, cover, plantations) => {
+  [getTotalCover, getTotalArea, getPlantationsCover, getIndicator],
+  (total, cover, plantations, indicator) => {
     if (!total) return null;
     return [
       {
-        name: plantations ? 'Natural forest' : 'Tree cover',
+        name: getNameLabel(indicator, plantations),
         value: cover - plantations,
         color: COLORS.darkGreen,
         percentage: (cover - plantations) / total * 100

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover.js
@@ -19,6 +19,7 @@ export { default as actions } from './widget-tree-cover-actions';
 const mapStateToProps = ({ widgetTreeCover, countryData, location }) => {
   const { isCountriesLoading, isRegionsLoading } = countryData;
   const { totalArea, cover, plantations } = widgetTreeCover.data;
+  const { indicator } = widgetTreeCover.settings;
   const { indicators } = widgetTreeCover.config;
 
   return {
@@ -28,7 +29,7 @@ const mapStateToProps = ({ widgetTreeCover, countryData, location }) => {
       widgetTreeCover.isLoading || isCountriesLoading || isRegionsLoading,
     location: location.payload,
     regions: countryData.regions,
-    data: getTreeCoverData({ totalArea, cover, plantations }) || [],
+    data: getTreeCoverData({ totalArea, cover, plantations, indicator }) || [],
     options:
       {
         indicators:
@@ -76,10 +77,10 @@ class WidgetTreeCoverContainer extends PureComponent {
         t => t.value === settings.threshold
       );
       const indicator = getActiveFilter(settings, indicators, 'indicator');
-      return `Tree  cover for 
-        ${indicator.label} of 
+      return `Tree  cover for
+        ${indicator.label} of
         ${locationNames.current &&
-          locationNames.current.label} with a tree canopy of 
+          locationNames.current.label} with a tree canopy of
         ${activeThreshold.label}`;
     }
     return '';


### PR DESCRIPTION
## Config update and Tree cover Extent modification

* Added more menu options to widgets
* Assigned widgets to different tabs
*  I also changed the order of some of the widgets and the order of the tabs
* Refining by location `plantations` in the Tree cover Extent widget now results in the legend showing `Tree Plantations` as a label rather than `Tree Cover`. (Addressed PT bug #153854716 )

![screen shot 2017-12-22 at 11 56 21](https://user-images.githubusercontent.com/6503031/34297526-e3d74070-e718-11e7-9fdb-2c76e872e0a3.png)

![screen shot 2017-12-22 at 12 38 08](https://user-images.githubusercontent.com/6503031/34297525-e3a236d2-e718-11e7-9cc3-c1854dfc8624.png)

