### PR TITLE
Sync state of widgets with URL (and vice versa)

### DIFF
--- a/app/javascript/components/map/map-actions.js
+++ b/app/javascript/components/map/map-actions.js
@@ -14,7 +14,7 @@ const getLayerSpec = createThunkAction(
       fetchLayerSpec()
         .then(response => {
           const layerSpec = {};
-          response.data.rows.forEach(layer => {
+          (response.data.rows || []).forEach(layer => {
             layerSpec[layer.slug] = layer;
           });
           dispatch(setLayerSpec(layerSpec));

--- a/app/javascript/components/no-content/no-content-styles.scss
+++ b/app/javascript/components/no-content/no-content-styles.scss
@@ -13,11 +13,11 @@
 
 .message {
   opacity: 0.5;
-  margin-right: 10px;
   text-align: center;
 }
 
 .message-icon {
   width: rem(25px);
   height: rem(25px);
+  margin-left: 10px;
 }

--- a/app/javascript/components/no-content/no-content-styles.scss
+++ b/app/javascript/components/no-content/no-content-styles.scss
@@ -14,6 +14,7 @@
 .message {
   opacity: 0.5;
   margin-right: 10px;
+  text-align: center;
 }
 
 .message-icon {

--- a/app/javascript/components/share/share-actions.js
+++ b/app/javascript/components/share/share-actions.js
@@ -3,33 +3,28 @@ import { createThunkAction } from 'utils/redux';
 
 import { getShortenUrl } from 'services/bitly';
 
+const setShareData = createAction('setShareData');
+const setShareSelected = createAction('setShareSelected');
+const setShareOpen = createAction('setShareOpen');
+
 const setShare = createThunkAction('setShare', params => dispatch => {
-  const {
-    isOpen,
-    haveEmbed,
-    selectedType,
-    data: { title, subtitle, embedSettings }
-  } = params;
-  let { data: { url, embedUrl } } = params;
+  const { open, selected, data } = params;
+  const { title, subtitle, embedUrl, embedSettings } = data;
 
-  getShortenUrl(url).then(response => {
+  getShortenUrl(data.shareUrl).then(response => {
+    let shareUrl = '';
     if (response.data.status_code === 200) {
-      url = response.data.data.url;
+      shareUrl = response.data.data.url;
     }
-
-    embedUrl = `<iframe width="${embedSettings.width}" height="${
-      embedSettings.height
-    }" frameborder="0" src="${embedUrl || params.data.url}"></iframe>`;
 
     dispatch(
       setShareData({
-        isOpen,
-        haveEmbed,
-        selectedType,
+        open,
+        selected,
         data: {
           title,
           subtitle,
-          url,
+          shareUrl,
           embedUrl,
           embedSettings
         }
@@ -37,13 +32,10 @@ const setShare = createThunkAction('setShare', params => dispatch => {
     );
   });
 });
-const setShareData = createAction('setShareData');
-const setShareType = createAction('setShareType');
-const setIsOpen = createAction('setIsOpen');
 
 export default {
   setShare,
   setShareData,
-  setShareType,
-  setIsOpen
+  setShareSelected,
+  setShareOpen
 };

--- a/app/javascript/components/share/share-actions.js
+++ b/app/javascript/components/share/share-actions.js
@@ -7,34 +7,28 @@ const setShareData = createAction('setShareData');
 const setShareSelected = createAction('setShareSelected');
 const setShareOpen = createAction('setShareOpen');
 
-const setShare = createThunkAction('setShare', params => dispatch => {
-  const { open, selected, data } = params;
-  const { title, subtitle, embedUrl, embedSettings } = data;
+const setShareModal = createThunkAction('setShare', params => dispatch => {
+  const { title, subtitle, embedUrl, shareUrl, embedSettings } = params;
 
-  getShortenUrl(data.shareUrl).then(response => {
-    let shareUrl = '';
+  getShortenUrl(shareUrl).then(response => {
+    let shortShareUrl = '';
     if (response.data.status_code === 200) {
-      shareUrl = response.data.data.url;
+      shortShareUrl = response.data.data.url;
     }
-
     dispatch(
       setShareData({
-        open,
-        selected,
-        data: {
-          title,
-          subtitle,
-          shareUrl,
-          embedUrl,
-          embedSettings
-        }
+        title,
+        subtitle,
+        shareUrl: shortShareUrl,
+        embedUrl,
+        embedSettings
       })
     );
   });
 });
 
 export default {
-  setShare,
+  setShareModal,
   setShareData,
   setShareSelected,
   setShareOpen

--- a/app/javascript/components/share/share-actions.js
+++ b/app/javascript/components/share/share-actions.js
@@ -4,26 +4,28 @@ import { createThunkAction } from 'utils/redux';
 import { getShortenUrl } from 'services/bitly';
 
 const setShareData = createAction('setShareData');
+const setShareUrl = createAction('setShareUrl');
 const setShareSelected = createAction('setShareSelected');
 const setShareOpen = createAction('setShareOpen');
 
 const setShareModal = createThunkAction('setShare', params => dispatch => {
   const { title, subtitle, embedUrl, shareUrl, embedSettings } = params;
 
+  dispatch(
+    setShareData({
+      title,
+      subtitle,
+      embedUrl,
+      embedSettings
+    })
+  );
+
   getShortenUrl(shareUrl).then(response => {
     let shortShareUrl = '';
     if (response.data.status_code === 200) {
       shortShareUrl = response.data.data.url;
     }
-    dispatch(
-      setShareData({
-        title,
-        subtitle,
-        shareUrl: shortShareUrl,
-        embedUrl,
-        embedSettings
-      })
-    );
+    dispatch(setShareUrl(shortShareUrl));
   });
 });
 
@@ -31,5 +33,6 @@ export default {
   setShareModal,
   setShareData,
   setShareSelected,
-  setShareOpen
+  setShareOpen,
+  setShareUrl
 };

--- a/app/javascript/components/share/share-actions.js
+++ b/app/javascript/components/share/share-actions.js
@@ -7,6 +7,7 @@ const setShareData = createAction('setShareData');
 const setShareUrl = createAction('setShareUrl');
 const setShareSelected = createAction('setShareSelected');
 const setShareOpen = createAction('setShareOpen');
+const setShareCopied = createAction('setShareCopied');
 
 const setShareModal = createThunkAction('setShare', params => dispatch => {
   const { title, subtitle, embedUrl, shareUrl, embedSettings } = params;
@@ -34,5 +35,6 @@ export default {
   setShareData,
   setShareSelected,
   setShareOpen,
-  setShareUrl
+  setShareUrl,
+  setShareCopied
 };

--- a/app/javascript/components/share/share-actions.js
+++ b/app/javascript/components/share/share-actions.js
@@ -8,6 +8,7 @@ const setShareUrl = createAction('setShareUrl');
 const setShareSelected = createAction('setShareSelected');
 const setShareOpen = createAction('setShareOpen');
 const setShareCopied = createAction('setShareCopied');
+const setShareLoading = createAction('setShareLoading');
 
 const setShareModal = createThunkAction('setShare', params => dispatch => {
   const { title, subtitle, embedUrl, shareUrl, embedSettings } = params;
@@ -17,6 +18,7 @@ const setShareModal = createThunkAction('setShare', params => dispatch => {
       title,
       subtitle,
       embedUrl,
+      shareUrl,
       embedSettings
     })
   );
@@ -25,8 +27,10 @@ const setShareModal = createThunkAction('setShare', params => dispatch => {
     let shortShareUrl = '';
     if (response.data.status_code === 200) {
       shortShareUrl = response.data.data.url;
+      dispatch(setShareUrl(shortShareUrl));
+    } else {
+      dispatch(setShareLoading(false));
     }
-    dispatch(setShareUrl(shortShareUrl));
   });
 });
 
@@ -36,5 +40,6 @@ export default {
   setShareSelected,
   setShareOpen,
   setShareUrl,
-  setShareCopied
+  setShareCopied,
+  setShareLoading
 };

--- a/app/javascript/components/share/share-component.jsx
+++ b/app/javascript/components/share/share-component.jsx
@@ -42,7 +42,8 @@ class Share extends PureComponent {
                 ? 'Click and paste HTML to embed in website'
                 : 'Click and paste link in email or IM'}
             </p>
-            {loading && <Loader className="input-loader" />}
+            {loading &&
+              selected !== 'embed' && <Loader className="input-loader" />}
             <input
               ref={input => {
                 this.textInput = input;

--- a/app/javascript/components/share/share-component.jsx
+++ b/app/javascript/components/share/share-component.jsx
@@ -17,6 +17,7 @@ class Share extends PureComponent {
     const {
       selected,
       loading,
+      copied,
       data: { title, subtitle, shareUrl, embedUrl, embedSettings },
       handleFocus,
       setShareSelected,
@@ -56,7 +57,7 @@ class Share extends PureComponent {
               className="input-button"
               onClick={() => handleCopyToClipboard(this.textInput)}
             >
-              COPY
+              {copied ? 'COPIED!' : 'COPY'}
             </button>
           </div>
           {embedUrl ? (
@@ -144,6 +145,7 @@ class Share extends PureComponent {
 Share.propTypes = {
   open: PropTypes.bool,
   selected: PropTypes.string,
+  copied: PropTypes.bool,
   data: PropTypes.object,
   loading: PropTypes.bool,
   setShareOpen: PropTypes.func,

--- a/app/javascript/components/share/share-component.jsx
+++ b/app/javascript/components/share/share-component.jsx
@@ -4,6 +4,7 @@ import Modal from 'components/modal';
 
 import Button from 'components/button';
 import Icon from 'components/icon/icon';
+import Loader from 'components/loader';
 
 import googleplusIcon from 'assets/icons/googleplus.svg';
 import twitterIcon from 'assets/icons/twitter.svg';
@@ -15,6 +16,7 @@ class Share extends PureComponent {
   getContent() {
     const {
       selected,
+      loading,
       data: { title, subtitle, shareUrl, embedUrl, embedSettings },
       handleFocus,
       setShareSelected,
@@ -39,12 +41,13 @@ class Share extends PureComponent {
                 ? 'Click and paste HTML to embed in website'
                 : 'Click and paste link in email or IM'}
             </p>
+            {loading && <Loader className="input-loader" />}
             <input
               ref={input => {
                 this.textInput = input;
               }}
               type="text"
-              value={inputValue}
+              value={!loading ? inputValue : ''}
               readOnly
               onClick={handleFocus}
               className="input"
@@ -142,6 +145,7 @@ Share.propTypes = {
   open: PropTypes.bool,
   selected: PropTypes.string,
   data: PropTypes.object,
+  loading: PropTypes.bool,
   setShareOpen: PropTypes.func,
   setShareSelected: PropTypes.func,
   handleFocus: PropTypes.func,

--- a/app/javascript/components/share/share-component.jsx
+++ b/app/javascript/components/share/share-component.jsx
@@ -14,15 +14,19 @@ import './share-styles.scss';
 class Share extends PureComponent {
   getContent() {
     const {
-      haveEmbed,
-      selectedType,
-      data: { title, subtitle, url, embedUrl },
+      selected,
+      data: { title, subtitle, shareUrl, embedUrl, embedSettings },
       handleFocus,
-      changeType,
-      copyToClipboard
+      setShareSelected,
+      handleCopyToClipboard
     } = this.props;
 
-    const inputValue = selectedType === 'embed' ? embedUrl : url;
+    const inputValue =
+      selected === 'embed'
+        ? `<iframe width="${embedSettings.width}" height="${
+          embedSettings.height
+        }" frameborder="0" src="${embedUrl}"></iframe>`
+        : shareUrl;
 
     return (
       <div className="c-share">
@@ -31,7 +35,7 @@ class Share extends PureComponent {
         <div className="actions">
           <div className="input-container">
             <p className="info">
-              {selectedType === 'embed'
+              {selected === 'embed'
                 ? 'Click and paste HTML to embed in website'
                 : 'Click and paste link in email or IM'}
             </p>
@@ -47,49 +51,49 @@ class Share extends PureComponent {
             />
             <button
               className="input-button"
-              onClick={() => copyToClipboard(this.textInput)}
+              onClick={() => handleCopyToClipboard(this.textInput)}
             >
               COPY
             </button>
           </div>
-          {haveEmbed ? (
+          {embedUrl ? (
             <div className="buttons-container">
               <Button
                 className={`share-button ${
-                  selectedType !== 'embed' ? 'theme-button-light-green' : ''
+                  selected === 'embed' ? 'theme-button-light-green' : ''
                 }`}
-                onClick={() => changeType('embed')}
+                onClick={() => setShareSelected('link')}
               >
-                EMBED
+                LINK
               </Button>
               <Button
                 className={`share-button ${
-                  selectedType === 'embed' ? 'theme-button-light-green' : ''
+                  selected !== 'embed' ? 'theme-button-light-green' : ''
                 }`}
-                onClick={() => changeType('link')}
+                onClick={() => setShareSelected('embed')}
               >
-                LINK
+                EMBED
               </Button>
             </div>
           ) : null}
         </div>
         <div className="social-container">
           <a
-            href={`https://plus.google.com/share?url=${url}`}
+            href={`https://plus.google.com/share?url=${shareUrl}`}
             target="_blank"
             className="social-button -googleplus"
           >
             <Icon icon={googleplusIcon} className="googleplus-icon" />
           </a>
           <a
-            href={`https://twitter.com/share?url=${url}`}
+            href={`https://twitter.com/share?shareUrl=${shareUrl}`}
             target="_blank"
             className="social-button -twitter"
           >
             <Icon icon={twitterIcon} className="twitter-icon" />
           </a>
           <a
-            href={`https://www.facebook.com/sharer.php?u=${url}`}
+            href={`https://www.facebook.com/sharer.php?u=${shareUrl}`}
             target="_blank"
             className="social-button -facebook"
           >
@@ -101,11 +105,11 @@ class Share extends PureComponent {
   }
 
   render() {
-    const { isOpen, handleClose } = this.props;
+    const { open, setShareOpen } = this.props;
     return (
       <Modal
-        isOpen={isOpen}
-        onRequestClose={handleClose}
+        isOpen={open}
+        onRequestClose={() => setShareOpen(false)}
         customStyles={{
           overlay: {
             zIndex: 20,
@@ -135,14 +139,13 @@ class Share extends PureComponent {
 }
 
 Share.propTypes = {
-  isOpen: PropTypes.bool,
-  haveEmbed: PropTypes.bool,
-  selectedType: PropTypes.string,
+  open: PropTypes.bool,
+  selected: PropTypes.string,
   data: PropTypes.object,
-  handleClose: PropTypes.func,
+  setShareOpen: PropTypes.func,
+  setShareSelected: PropTypes.func,
   handleFocus: PropTypes.func,
-  changeType: PropTypes.func,
-  copyToClipboard: PropTypes.func
+  handleCopyToClipboard: PropTypes.func
 };
 
 export default Share;

--- a/app/javascript/components/share/share-reducers.js
+++ b/app/javascript/components/share/share-reducers.js
@@ -34,6 +34,11 @@ const setShareCopied = state => ({
   copied: true
 });
 
+const setShareLoading = (state, { payload }) => ({
+  ...state,
+  loading: payload
+});
+
 const setShareUrl = (state, { payload }) => ({
   ...state,
   loading: false,
@@ -54,5 +59,6 @@ export default {
   setShareSelected,
   setShareOpen,
   setShareUrl,
-  setShareCopied
+  setShareCopied,
+  setShareLoading
 };

--- a/app/javascript/components/share/share-reducers.js
+++ b/app/javascript/components/share/share-reducers.js
@@ -1,11 +1,10 @@
 export const initialState = {
-  isOpen: false,
-  haveEmbed: false,
-  selectedType: 'link',
+  open: false,
+  selected: 'link',
   data: {
     title: '',
     subtitle: '',
-    url: '',
+    shareUrl: '',
     embedUrl: '',
     embedSettings: { width: 0, height: 0 }
   }
@@ -13,23 +12,26 @@ export const initialState = {
 
 const setShareData = (state, { payload }) => ({
   ...state,
-  isOpen: payload.isOpen,
-  haveEmbed: payload.haveEmbed ? payload.haveEmbed : state.haveEmbed,
-  data: payload.data ? payload.data : state.data
+  open: true,
+  selected: 'link',
+  data: {
+    ...state.data,
+    ...payload
+  }
 });
 
-const setShareType = (state, { payload }) => ({
+const setShareSelected = (state, { payload }) => ({
   ...state,
-  selectedType: payload
+  selected: payload
 });
 
-const setIsOpen = (state, { payload }) => ({
+const setShareOpen = (state, { payload }) => ({
   ...state,
-  isOpen: payload
+  open: payload
 });
 
 export default {
   setShareData,
-  setShareType,
-  setIsOpen
+  setShareSelected,
+  setShareOpen
 };

--- a/app/javascript/components/share/share-reducers.js
+++ b/app/javascript/components/share/share-reducers.js
@@ -1,4 +1,5 @@
 export const initialState = {
+  loading: false,
   open: false,
   selected: 'link',
   data: {
@@ -14,6 +15,7 @@ const setShareData = (state, { payload }) => ({
   ...state,
   open: true,
   selected: 'link',
+  loading: true,
   data: {
     ...state.data,
     ...payload
@@ -25,6 +27,15 @@ const setShareSelected = (state, { payload }) => ({
   selected: payload
 });
 
+const setShareUrl = (state, { payload }) => ({
+  ...state,
+  loading: false,
+  data: {
+    ...state.data,
+    shareUrl: payload
+  }
+});
+
 const setShareOpen = (state, { payload }) => ({
   ...state,
   open: payload
@@ -33,5 +44,6 @@ const setShareOpen = (state, { payload }) => ({
 export default {
   setShareData,
   setShareSelected,
-  setShareOpen
+  setShareOpen,
+  setShareUrl
 };

--- a/app/javascript/components/share/share-reducers.js
+++ b/app/javascript/components/share/share-reducers.js
@@ -2,6 +2,7 @@ export const initialState = {
   loading: false,
   open: false,
   selected: 'link',
+  copied: false,
   data: {
     title: '',
     subtitle: '',
@@ -24,7 +25,13 @@ const setShareData = (state, { payload }) => ({
 
 const setShareSelected = (state, { payload }) => ({
   ...state,
-  selected: payload
+  selected: payload,
+  copied: false
+});
+
+const setShareCopied = state => ({
+  ...state,
+  copied: true
 });
 
 const setShareUrl = (state, { payload }) => ({
@@ -38,12 +45,14 @@ const setShareUrl = (state, { payload }) => ({
 
 const setShareOpen = (state, { payload }) => ({
   ...state,
-  open: payload
+  open: payload,
+  copied: false
 });
 
 export default {
   setShareData,
   setShareSelected,
   setShareOpen,
-  setShareUrl
+  setShareUrl,
+  setShareCopied
 };

--- a/app/javascript/components/share/share-styles.scss
+++ b/app/javascript/components/share/share-styles.scss
@@ -32,6 +32,7 @@ $input-button-width: rem(100px);
 
   .input-container {
     width: 100%;
+    position: relative;
 
     .input,
     .input-button {
@@ -67,6 +68,22 @@ $input-button-width: rem(100px);
       &:hover {
         border-color: darken($green-gfw, 10%);
         color: darken($slate, 10%);
+      }
+    }
+
+    .input-loader {
+      position: absolute;
+      left: rem(20px);
+      top: rem(50px);
+      width: rem(20px);
+      height: rem(20px);
+
+      .spinner {
+        &::before {
+          width: rem(20px);
+          height: rem(20px);
+          border-width: 2px;
+        }
       }
     }
   }

--- a/app/javascript/components/share/share.js
+++ b/app/javascript/components/share/share.js
@@ -13,7 +13,8 @@ const mapStateToProps = state => ({
   isOpen: state.share.isOpen,
   haveEmbed: state.share.haveEmbed,
   selectedType: state.share.selectedType,
-  data: state.share.data
+  data: state.share.data,
+  location: state.location
 });
 
 class ShareContainer extends PureComponent {
@@ -52,7 +53,6 @@ class ShareContainer extends PureComponent {
   render() {
     return createElement(ShareComponent, {
       ...this.props,
-      componentWillUpdate: this.componentWillUpdate,
       changeType: this.changeType,
       copyToClipboard: this.copyToClipboard,
       handleFocus: this.handleFocus,

--- a/app/javascript/components/share/share.js
+++ b/app/javascript/components/share/share.js
@@ -1,4 +1,5 @@
 import { createElement, PureComponent } from 'react';
+import { PropTypes } from 'prop-types';
 import { connect } from 'react-redux';
 
 import actions from './share-actions';
@@ -8,6 +9,7 @@ import ShareComponent from './share-component';
 const mapStateToProps = ({ share, location }) => ({
   open: share.open,
   selected: share.selected,
+  copied: share.copied,
   data: share.data,
   loading: share.loading,
   location
@@ -15,10 +17,12 @@ const mapStateToProps = ({ share, location }) => ({
 
 class ShareContainer extends PureComponent {
   handleCopyToClipboard = input => {
+    const { setShareCopied } = this.props;
     input.select();
 
     try {
       document.execCommand('copy');
+      setShareCopied();
     } catch (err) {
       alert('This browser does not support clipboard access');
     }
@@ -36,6 +40,10 @@ class ShareContainer extends PureComponent {
     });
   }
 }
+
+ShareContainer.propTypes = {
+  setShareCopied: PropTypes.func.isRequired
+};
 
 export { actions, reducers, initialState };
 

--- a/app/javascript/components/share/share.js
+++ b/app/javascript/components/share/share.js
@@ -1,37 +1,19 @@
 import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 
-import ShareComponent from './share-component';
 import actions from './share-actions';
+import reducers, { initialState } from './share-reducers';
+import ShareComponent from './share-component';
 
-export { initialState } from './share-reducers';
-export { default as reducers } from './share-reducers';
-export { default as actions } from './share-actions';
-
-const mapStateToProps = state => ({
-  isOpen: state.share.isOpen,
-  haveEmbed: state.share.haveEmbed,
-  selectedType: state.share.selectedType,
-  data: state.share.data,
-  location: state.location
+const mapStateToProps = ({ share, location }) => ({
+  open: share.open,
+  selected: share.selected,
+  data: share.data,
+  location
 });
 
 class ShareContainer extends PureComponent {
-  componentWillUpdate(nextProps) {
-    const { isOpen, setShare } = nextProps;
-
-    if (isOpen && !this.props.isOpen) {
-      setShare(nextProps);
-    }
-  }
-
-  changeType = type => {
-    const { setShareType } = this.props;
-    setShareType(type);
-  };
-
-  copyToClipboard = input => {
+  handleCopyToClipboard = input => {
     input.select();
 
     try {
@@ -45,26 +27,15 @@ class ShareContainer extends PureComponent {
     event.target.select();
   };
 
-  handleClose = () => {
-    const { setIsOpen } = this.props;
-    setIsOpen(false);
-  };
-
   render() {
     return createElement(ShareComponent, {
       ...this.props,
-      changeType: this.changeType,
-      copyToClipboard: this.copyToClipboard,
-      handleFocus: this.handleFocus,
-      handleClose: this.handleClose
+      handleCopyToClipboard: this.handleCopyToClipboard,
+      handleFocus: this.handleFocus
     });
   }
 }
 
-ShareContainer.propTypes = {
-  isOpen: PropTypes.bool,
-  setShareType: PropTypes.func,
-  setIsOpen: PropTypes.func
-};
+export { actions, reducers, initialState };
 
 export default connect(mapStateToProps, actions)(ShareContainer);

--- a/app/javascript/components/share/share.js
+++ b/app/javascript/components/share/share.js
@@ -24,7 +24,7 @@ class ShareContainer extends PureComponent {
       document.execCommand('copy');
       setShareCopied();
     } catch (err) {
-      alert('This browser does not support clipboard access');
+      alert('This browser does not support clipboard access'); // eslint-disable-line
     }
   };
 

--- a/app/javascript/components/share/share.js
+++ b/app/javascript/components/share/share.js
@@ -9,6 +9,7 @@ const mapStateToProps = ({ share, location }) => ({
   open: share.open,
   selected: share.selected,
   data: share.data,
+  loading: share.loading,
   location
 });
 

--- a/app/javascript/components/subnav-menu/subnav-menu-component.jsx
+++ b/app/javascript/components/subnav-menu/subnav-menu-component.jsx
@@ -9,7 +9,8 @@ import 'styles/themes/subnav/subnav-dark.scss'; // eslint-disable-line
 class SubNavMenu extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
   render() {
-    const { links, className, theme, handleClick, activeLink } = this.props;
+    const { links, className, theme, checkActive } = this.props;
+
     return (
       <div className={`c-subnav-menu ${theme || ''} ${className || ''}`}>
         <div className="row">
@@ -31,25 +32,14 @@ class SubNavMenu extends PureComponent {
                         {link.label}
                       </AnchorLink>
                     );
-                  } else if (link.value) {
-                    LinkComponent = (
-                      <button
-                        key={link.value}
-                        className={`text -paragraph-5 -color-8 ${
-                          activeLink === link.value ? 'active' : ''
-                        }`}
-                        onClick={() => handleClick(link.value)}
-                      >
-                        {link.label}
-                      </button>
-                    );
                   } else {
                     LinkComponent = (
                       <NavLink
-                        exact
-                        to={link.path}
                         className="text -paragraph-5 -color-8"
+                        to={link.path}
                         activeClassName="active"
+                        exact
+                        isActive={checkActive ? () => link.active : null}
                       >
                         {link.label}
                       </NavLink>
@@ -75,8 +65,7 @@ SubNavMenu.propTypes = {
   ),
   className: PropTypes.string,
   theme: PropTypes.string,
-  handleClick: PropTypes.func,
-  activeLink: PropTypes.string
+  checkActive: PropTypes.bool
 };
 
 export default SubNavMenu;

--- a/app/javascript/components/subnav-menu/subnav-menu-styles.scss
+++ b/app/javascript/components/subnav-menu/subnav-menu-styles.scss
@@ -10,6 +10,7 @@ $subnav-height: rem(60px);
     flex-direction: row;
     justify-content: space-between;
     height: $subnav-height;
+    overflow-x: scroll;
 
     @media screen and (min-width: $screen-m) {
       justify-content: flex-start;
@@ -24,8 +25,7 @@ $subnav-height: rem(60px);
         max-width: rem(180px);
       }
 
-      > a,
-      button {
+      > a {
         position: relative;
         display: flex;
         justify-content: center;
@@ -34,6 +34,7 @@ $subnav-height: rem(60px);
         width: 100%;
         text-align: center;
         cursor: pointer;
+        white-space: nowrap;
 
         &.active {
           background-color: $white;

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -1,12 +1,12 @@
 {
   "treeCover": {
     "title": "Tree cover extent",
-    "anchorLink": "tree-cover-extent",
     "gridWidth": 6,
     "config": {
       "indicators": ["gadm28", "mining", "landmark", "wdpa", "plantations"],
       "categories": ["summary", "land-cover"],
-      "admins": ["country", "region", "subRegion"]
+      "admins": ["country", "region", "subRegion"],
+      "selectors": ["indicators", "thresholds"]
     },
     "settings": {
       "indicator": "gadm28",
@@ -16,7 +16,6 @@
   },
   "treeLocated": {
     "title": "WHERE ARE THE FOREST LOCATED",
-    "anchorLink": "tree-located",
     "gridWidth": 6,
     "config": {
       "indicators": ["gadm28", "ifl_2013", "wdpa",
@@ -25,7 +24,8 @@
                       "plantations", "plantations__mining",
                       "plantations__wdpa", "plantations__landmark"],
       "categories": ["summary", "land-cover"],
-      "admins": ["country", "region"]
+      "admins": ["country", "region"],
+      "selectors": ["indicators", "thresholds", "units"]      
     },
     "settings": {
       "indicator": "gadm28",
@@ -38,7 +38,6 @@
   },
   "treeLoss": {
     "title": "Tree cover loss",
-    "anchorLink": "tree-cover-loss",
     "gridWidth": 12,
     "config": {
       "indicators": ["gadm28", "wdpa", "ifl_2013",
@@ -47,7 +46,8 @@
                       "plantations", "plantations__mining",
                       "plantations__wdpa", "plantations__landmark"],
       "categories": ["summary", "forest-change"],
-      "admins": ["country", "region", "subRegion"]
+      "admins": ["country", "region", "subRegion"],
+      "selectors": ["indicators", "startYears", "endYears", "thresholds"]
     },
     "settings": {
       "indicator": "gadm28",
@@ -59,12 +59,12 @@
   },
   "treeGain": {
     "title": "Tree cover gain",
-    "anchorLink": "tree-cover-gain",
     "gridWidth": 6,
     "config": {
       "indicators": ["gadm28", "wdpa", "primary_forests", "plantations", "ifl_2013"],
       "categories": ["summary", "forest-change"],
-      "admins": ["country", "region", "subRegion"]
+      "admins": ["country", "region", "subRegion"],
+      "selectors": ["indicators", "thresholds"]
     },
     "settings": {
       "indicator": "gadm28",
@@ -74,11 +74,11 @@
   },
   "faoReforestation": {
     "title": "FAO reforestation",
-    "anchorLink": "fao-reforestation",
     "gridWidth": 6,
     "config": {
       "categories": ["summary","forest-change"],
-      "admins": ["country"]
+      "admins": ["country"],
+      "selectors": ["periods"]
     },
     "settings": {
       "period": 1990
@@ -87,7 +87,6 @@
   },
   "faoCover": {
     "title": "Forest cover",
-    "anchorLink": "fao-cover",
     "gridWidth": 6,
     "config": {
       "categories": ["land-cover"],

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -12,7 +12,7 @@
       "indicator": "gadm28",
       "threshold": 30
     },
-    "active": false
+    "active": true
   },
   "treeLocated": {
     "title": "WHERE ARE THE FOREST LOCATED",
@@ -55,7 +55,7 @@
       "startYear": 2001,
       "endYear": 2016
     },
-    "active": true
+    "active": false
   },
   "treeGain": {
     "title": "Tree cover gain",

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -15,7 +15,7 @@
     "active": true
   },
   "treeLocated": {
-    "title": "WHERE ARE THE FOREST LOCATED",
+    "title": "Where are the forests located",
     "config": {
       "gridWidth": 6,
       "indicators": ["gadm28", "ifl_2013", "wdpa",

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -1,8 +1,8 @@
 {
   "treeCover": {
     "title": "Tree cover extent",
-    "gridWidth": 6,
     "config": {
+      "gridWidth": 6,
       "indicators": ["gadm28", "mining", "landmark", "wdpa", "plantations"],
       "categories": ["summary", "land-cover"],
       "admins": ["country", "region", "subRegion"],
@@ -16,8 +16,8 @@
   },
   "treeLocated": {
     "title": "WHERE ARE THE FOREST LOCATED",
-    "gridWidth": 6,
     "config": {
+      "gridWidth": 6,
       "indicators": ["gadm28", "ifl_2013", "wdpa",
                       "ifl_2013__wdpa", "ifl_2013__mining",
                       "primary_forest", "primary_forest__landmark",
@@ -38,8 +38,8 @@
   },
   "treeLoss": {
     "title": "Tree cover loss",
-    "gridWidth": 12,
     "config": {
+      "gridWidth": 12,
       "indicators": ["gadm28", "wdpa", "ifl_2013",
                      "ifl_2013__wdpa", "ifl_2013__mining",
                      "primary_forests","primary_forest__landmark",
@@ -59,8 +59,8 @@
   },
   "treeGain": {
     "title": "Tree cover gain",
-    "gridWidth": 6,
     "config": {
+      "gridWidth": 6,
       "indicators": ["gadm28", "wdpa", "primary_forests", "plantations", "ifl_2013"],
       "categories": ["summary", "forest-change"],
       "admins": ["country", "region", "subRegion"],
@@ -74,8 +74,8 @@
   },
   "FAOReforestation": {
     "title": "FAO reforestation",
-    "gridWidth": 6,
     "config": {
+      "gridWidth": 6,
       "categories": ["summary","forest-change"],
       "admins": ["country"],
       "selectors": ["periods"]
@@ -87,8 +87,8 @@
   },
   "FAOCover": {
     "title": "Forest cover",
-    "gridWidth": 6,
     "config": {
+      "gridWidth": 6,
       "categories": ["land-cover"],
       "admins": ["country"]
     },

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -83,15 +83,15 @@
     "settings": {
       "period": 1990
     },
-    "active": true
+    "active": false
   },
-  "faoCover": {
+  "FAOCover": {
     "title": "Forest cover",
     "gridWidth": 6,
     "config": {
       "categories": ["land-cover"],
       "admins": ["country"]
     },
-    "active": false
+    "active": true
   }
 }

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -12,7 +12,7 @@
       "indicator": "gadm28",
       "threshold": 30
     },
-    "active": true
+    "active": false
   },
   "treeLocated": {
     "title": "WHERE ARE THE FOREST LOCATED",
@@ -34,7 +34,7 @@
       "pageSize": 10,
       "page": 0
     },
-    "active": false
+    "active": true
   },
   "treeLoss": {
     "title": "Tree cover loss",

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -70,9 +70,9 @@
       "indicator": "gadm28",
       "threshold": "0"
     },
-    "active": true
+    "active": false
   },
-  "faoReforestation": {
+  "FAOReforestation": {
     "title": "FAO reforestation",
     "gridWidth": 6,
     "config": {
@@ -83,7 +83,7 @@
     "settings": {
       "period": 1990
     },
-    "active": false
+    "active": true
   },
   "faoCover": {
     "title": "Forest cover",

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -12,7 +12,7 @@
       "indicator": "gadm28",
       "threshold": 30
     },
-    "active": false
+    "active": true
   },
   "treeLocated": {
     "title": "WHERE ARE THE FOREST LOCATED",
@@ -34,7 +34,7 @@
       "pageSize": 10,
       "page": 0
     },
-    "active": false
+    "active": true
   },
   "treeLoss": {
     "title": "Tree cover loss",
@@ -55,7 +55,7 @@
       "startYear": 2001,
       "endYear": 2016
     },
-    "active": false
+    "active": true
   },
   "treeGain": {
     "title": "Tree cover gain",
@@ -70,7 +70,7 @@
       "indicator": "gadm28",
       "threshold": "0"
     },
-    "active": false
+    "active": true
   },
   "FAOReforestation": {
     "title": "FAO reforestation",
@@ -83,7 +83,7 @@
     "settings": {
       "period": 1990
     },
-    "active": false
+    "active": true
   },
   "FAOCover": {
     "title": "Forest cover",

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -11,7 +11,8 @@
     "settings": {
       "indicator": "gadm28",
       "threshold": 30
-    }
+    },
+    "active": false
   },
   "treeLocated": {
     "title": "WHERE ARE THE FOREST LOCATED",
@@ -32,7 +33,8 @@
       "unit": "ha",
       "pageSize": 10,
       "page": 0
-    }
+    },
+    "active": false
   },
   "treeLoss": {
     "title": "Tree cover loss",
@@ -52,7 +54,8 @@
       "threshold": 30,
       "startYear": 2001,
       "endYear": 2016
-    }
+    },
+    "active": true
   },
   "treeGain": {
     "title": "Tree cover gain",
@@ -66,7 +69,8 @@
     "settings": {
       "indicator": "gadm28",
       "threshold": "0"
-    }
+    },
+    "active": false
   },
   "faoReforestation": {
     "title": "FAO reforestation",
@@ -78,7 +82,8 @@
     },
     "settings": {
       "period": 1990
-    }
+    },
+    "active": false
   },
   "faoCover": {
     "title": "Forest cover",
@@ -87,6 +92,7 @@
     "config": {
       "categories": ["land-cover"],
       "admins": ["country"]
-    }
+    },
+    "active": false
   }
 }

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -34,7 +34,7 @@
       "pageSize": 10,
       "page": 0
     },
-    "active": true
+    "active": false
   },
   "treeLoss": {
     "title": "Tree cover loss",
@@ -70,7 +70,7 @@
       "indicator": "gadm28",
       "threshold": "0"
     },
-    "active": false
+    "active": true
   },
   "faoReforestation": {
     "title": "FAO reforestation",

--- a/app/javascript/pages/country/embed/embed-component.js
+++ b/app/javascript/pages/country/embed/embed-component.js
@@ -14,7 +14,7 @@ class Embed extends PureComponent {
     return (
       <div className="c-embed">
         <div className="widget-wrapper">
-          <Widget widget={widgetKey} />
+          <Widget widget={widgetKey} embed />
         </div>
         <Share />
         <CountryDataProvider />

--- a/app/javascript/pages/country/header/header-actions.js
+++ b/app/javascript/pages/country/header/header-actions.js
@@ -21,13 +21,15 @@ export const getTotalExtent = createThunkAction(
       dispatch(setExtentLoading(true));
       getExtent(params)
         .then(response => {
-          const data = response.data.data;
-          dispatch(
-            setTotalExtent({
-              totalArea: (data[0] && data[0].total_area) || 0,
-              extent: (data[0] && data[0].value) || 0
-            })
-          );
+          const { data } = response.data;
+          if (data && data.length > 0) {
+            dispatch(
+              setTotalExtent({
+                totalArea: (data[0] && data[0].total_area) || 0,
+                extent: (data[0] && data[0].value) || 0
+              })
+            );
+          }
         })
         .catch(error => {
           dispatch(setExtentLoading(false));
@@ -44,10 +46,12 @@ export const getTotalLoss = createThunkAction(
       dispatch(setTotalLoss(true));
       getLoss(params)
         .then(response => {
-          const data = response.data.data.length
-            ? reverse(sortBy(response.data.data, 'year'))[0]
-            : {};
-          dispatch(setTotalLoss(data));
+          const { data } = response.data;
+          const dataParsed =
+            data && data.length
+              ? reverse(sortBy(response.data.data, 'year'))[0]
+              : {};
+          dispatch(setTotalLoss(dataParsed));
         })
         .catch(error => {
           dispatch(setTotalLoss(false));
@@ -64,10 +68,10 @@ export const getPlantationsLoss = createThunkAction(
       dispatch(setPlantationsLossLoading(true));
       getLoss(params)
         .then(response => {
-          const data = response.data.data.length
-            ? reverse(sortBy(response.data.data, 'year'))[0]
-            : {};
-          dispatch(setPlantationsLoss(data));
+          const { data } = response.data;
+          const dataParsed =
+            data && data.length ? reverse(sortBy(data, 'year'))[0] : {};
+          dispatch(setPlantationsLoss(dataParsed));
         })
         .catch(error => {
           dispatch(setPlantationsLossLoading(false));

--- a/app/javascript/pages/country/header/header.js
+++ b/app/javascript/pages/country/header/header.js
@@ -45,6 +45,7 @@ const mapStateToProps = ({ countryData, location, header }) => {
     }),
     settings: header.settings,
     location: location.payload,
+    query: location.query,
     locationNames: getAdminsSelected({
       ...adminData,
       location: location.payload
@@ -54,16 +55,18 @@ const mapStateToProps = ({ countryData, location, header }) => {
   };
 };
 
-const mapDispatchToProps = dispatch =>
+const mapDispatchToProps = (dispatch, ownProps) =>
   bindActionCreators(
     {
       handleCountryChange: country => ({
         type: COUNTRY,
-        payload: { country: country.value }
+        payload: { country: country.value },
+        query: ownProps.location.query
       }),
       handleRegionChange: (country, region) => ({
         type: COUNTRY,
-        payload: { country: country.value, region: region.value }
+        payload: { country: country.value, region: region.value },
+        query: ownProps.location.query
       }),
       handleSubRegionChange: (country, region, subRegion) => ({
         type: COUNTRY,
@@ -71,7 +74,8 @@ const mapDispatchToProps = dispatch =>
           country: country.value,
           region: region.value,
           subRegion: subRegion.value
-        }
+        },
+        query: ownProps.location.query
       }),
       ...actions
     },

--- a/app/javascript/pages/country/providers/country-data-provider/country-data-provider-reducers.js
+++ b/app/javascript/pages/country/providers/country-data-provider/country-data-provider-reducers.js
@@ -34,17 +34,17 @@ const setGeostoreLoading = (state, { payload }) => ({
 
 const setCountries = (state, { payload }) => ({
   ...state,
-  countries: payload.map(d => ({ label: d.name, value: d.iso }))
+  countries: (payload || []).map(d => ({ label: d.name, value: d.iso }))
 });
 
 const setRegions = (state, { payload }) => ({
   ...state,
-  regions: payload.map(d => ({ label: d.name, value: d.id }))
+  regions: (payload || []).map(d => ({ label: d.name, value: d.id }))
 });
 
 const setSubRegions = (state, { payload }) => ({
   ...state,
-  subRegions: payload.map(d => ({ label: d.name, value: d.id }))
+  subRegions: (payload || []).map(d => ({ label: d.name, value: d.id }))
 });
 
 const setGeostore = (state, { payload }) => ({

--- a/app/javascript/pages/country/reducers.js
+++ b/app/javascript/pages/country/reducers.js
@@ -21,7 +21,7 @@ import * as widgetAreasMostCoverGainComponent from 'pages/country/widget/widgets
 import * as widgetPlantationAreaComponent from 'pages/country/widget/widgets/widget-plantation-area';
 import * as widgetTotalAreaPlantationsComponent from 'pages/country/widget/widgets/widget-total-area-plantations';
 import * as widgetTreeCoverComponent from 'pages/country/widget/widgets/widget-tree-cover';
-import * as widgetTreeCoverGainComponent from 'pages/country/widget/widgets/widget-tree-gain';
+import * as widgetTreeGainComponent from 'pages/country/widget/widgets/widget-tree-gain';
 import * as widgetTreeCoverLossAreasComponent from 'pages/country/widget/widgets/widget-tree-cover-loss-areas';
 import * as widgetTreeLocatedComponent from 'pages/country/widget/widgets/widget-tree-located';
 import * as widgetTreeLossComponent from 'pages/country/widget/widgets/widget-tree-loss';
@@ -42,7 +42,7 @@ const componentsReducers = {
     widgetTotalAreaPlantationsComponent
   ),
   widgetTreeCover: handleActions(widgetTreeCoverComponent),
-  widgetTreeCoverGain: handleActions(widgetTreeCoverGainComponent),
+  widgetTreeGain: handleActions(widgetTreeGainComponent),
   widgetTreeCoverLossAreas: handleActions(widgetTreeCoverLossAreasComponent),
   widgetTreeLocated: handleActions(widgetTreeLocatedComponent),
   widgetTreeLoss: handleActions(widgetTreeLossComponent),

--- a/app/javascript/pages/country/root/root-actions.js
+++ b/app/javascript/pages/country/root/root-actions.js
@@ -3,11 +3,9 @@ import { createAction } from 'redux-actions';
 const setFixedMapStatus = createAction('setFixedMapStatus');
 const setMapTop = createAction('setMapTop');
 const setShowMapMobile = createAction('setShowMapMobile');
-const setCategory = createAction('setCategory');
 
 export default {
   setFixedMapStatus,
   setMapTop,
-  setShowMapMobile,
-  setCategory
+  setShowMapMobile
 };

--- a/app/javascript/pages/country/root/root-component.js
+++ b/app/javascript/pages/country/root/root-component.js
@@ -22,9 +22,7 @@ class Root extends PureComponent {
       handleShowMapMobile,
       links,
       isGeostoreLoading,
-      setCategory,
-      widgets,
-      category
+      widgets
     } = this.props;
 
     return (
@@ -37,10 +35,9 @@ class Root extends PureComponent {
             <Header className="header" />
             <SubNavMenu
               links={links}
-              activeLink={category}
               className="subnav-tabs"
               theme="theme-subnav-dark"
-              handleClick={setCategory}
+              checkActive
             />
             <div className="widgets">
               <div className="row">
@@ -106,8 +103,6 @@ Root.propTypes = {
   handleShowMapMobile: PropTypes.func.isRequired,
   links: PropTypes.array.isRequired,
   isGeostoreLoading: PropTypes.bool,
-  setCategory: PropTypes.func,
-  category: PropTypes.string,
   widgets: PropTypes.array
 };
 

--- a/app/javascript/pages/country/root/root-component.js
+++ b/app/javascript/pages/country/root/root-component.js
@@ -22,7 +22,8 @@ class Root extends PureComponent {
       handleShowMapMobile,
       links,
       isGeostoreLoading,
-      widgets
+      widgets,
+      location
     } = this.props;
 
     return (
@@ -32,7 +33,7 @@ class Root extends PureComponent {
         </button>
         <div className="panels">
           <div className="data-panel">
-            <Header className="header" />
+            <Header className="header" location={location} />
             <SubNavMenu
               links={links}
               className="subnav-tabs"
@@ -103,7 +104,8 @@ Root.propTypes = {
   handleShowMapMobile: PropTypes.func.isRequired,
   links: PropTypes.array.isRequired,
   isGeostoreLoading: PropTypes.bool,
-  widgets: PropTypes.array
+  widgets: PropTypes.array,
+  location: PropTypes.object
 };
 
 export default Root;

--- a/app/javascript/pages/country/root/root-component.js
+++ b/app/javascript/pages/country/root/root-component.js
@@ -49,7 +49,7 @@ class Root extends PureComponent {
                     <div
                       key={widget.name}
                       className={`columns large-${
-                        widget.gridWidth
+                        widget.config.gridWidth
                       } small-12 widget`}
                     >
                       <Widget widget={widget.name} />

--- a/app/javascript/pages/country/root/root-reducers.js
+++ b/app/javascript/pages/country/root/root-reducers.js
@@ -1,7 +1,6 @@
 export const initialState = {
   gfwHeaderHeight: 58,
-  showMapMobile: false,
-  category: 'summary'
+  showMapMobile: false
 };
 
 const setFixedMapStatus = (state, { payload }) => ({
@@ -14,13 +13,7 @@ const setShowMapMobile = (state, { payload }) => ({
   showMapMobile: payload
 });
 
-const setCategory = (state, { payload }) => ({
-  ...state,
-  category: payload
-});
-
 export default {
   setFixedMapStatus,
-  setShowMapMobile,
-  setCategory
+  setShowMapMobile
 };

--- a/app/javascript/pages/country/root/root-selectors.js
+++ b/app/javascript/pages/country/root/root-selectors.js
@@ -1,10 +1,14 @@
 import { createSelector } from 'reselect';
+import compact from 'lodash/compact';
+import qs from 'query-string';
 
 import WIDGETS from 'pages/country/data/widgets-config.json';
 
 // get list data
+const getCategories = state => state.categories || null;
 const getCategory = state => state.category || null;
 const getAdminLevel = state => state.adminLevel || null;
+const getLocation = state => state.location || null;
 
 // get lists selected
 export const getWidgets = createSelector(
@@ -23,4 +27,23 @@ export const getWidgets = createSelector(
           widget.active
       );
   }
+);
+
+export const getLinks = createSelector(
+  [getCategories, getCategory, getLocation],
+  (categories, activeCategory, location) =>
+    categories.map(category => {
+      const locationUrl = compact(
+        Object.keys(location.payload).map(key => location.payload[key])
+      ).join('/');
+      const newQuery = {
+        ...location.query,
+        category: category.value
+      };
+      return {
+        label: category.label,
+        path: `/country/${locationUrl}?${qs.stringify(newQuery)}`,
+        active: activeCategory === category.value
+      };
+    })
 );

--- a/app/javascript/pages/country/root/root-selectors.js
+++ b/app/javascript/pages/country/root/root-selectors.js
@@ -19,7 +19,8 @@ export const getWidgets = createSelector(
       .filter(
         widget =>
           widget.config.categories.indexOf(category) > -1 &&
-          widget.config.admins.indexOf(adminLevel) > -1
+          widget.config.admins.indexOf(adminLevel) > -1 &&
+          widget.active
       );
   }
 );

--- a/app/javascript/pages/country/root/root.js
+++ b/app/javascript/pages/country/root/root.js
@@ -6,24 +6,27 @@ import { getActiveAdmin } from 'pages/country/widget/widget-selectors';
 import CATEGORIES from 'pages/country/data/categories.json';
 import RootComponent from './root-component';
 import actions from './root-actions';
-import { getWidgets } from './root-selectors';
+import { getWidgets, getLinks } from './root-selectors';
 
 export { initialState } from './root-reducers';
 export { default as reducers } from './root-reducers';
 export { default as actions } from './root-actions';
 
-const mapStateToProps = ({ root, countryData, location }) => ({
-  gfwHeaderHeight: root.gfwHeaderHeight,
-  isMapFixed: root.isMapFixed,
-  showMapMobile: root.showMapMobile,
-  links: CATEGORIES,
-  isGeostoreLoading: countryData.isGeostoreLoading,
-  category: root.category,
-  widgets: getWidgets({
-    category: root.category,
-    adminLevel: getActiveAdmin(location.payload)
-  })
-});
+const mapStateToProps = ({ root, countryData, location }) => {
+  const category = (location.query && location.query.category) || 'summary';
+  return {
+    gfwHeaderHeight: root.gfwHeaderHeight,
+    isMapFixed: root.isMapFixed,
+    showMapMobile: root.showMapMobile,
+    links: getLinks({ categories: CATEGORIES, location, category }),
+    isGeostoreLoading: countryData.isGeostoreLoading,
+    category,
+    widgets: getWidgets({
+      category,
+      adminLevel: getActiveAdmin(location.payload)
+    })
+  };
+};
 
 class RootContainer extends PureComponent {
   handleShowMapMobile = () => {

--- a/app/javascript/pages/country/root/root.js
+++ b/app/javascript/pages/country/root/root.js
@@ -21,6 +21,7 @@ const mapStateToProps = ({ root, countryData, location }) => {
     links: getLinks({ categories: CATEGORIES, location, category }),
     isGeostoreLoading: countryData.isGeostoreLoading,
     category,
+    location,
     widgets: getWidgets({
       category,
       adminLevel: getActiveAdmin(location.payload)

--- a/app/javascript/pages/country/router.js
+++ b/app/javascript/pages/country/router.js
@@ -1,18 +1,27 @@
 import { connectRoutes } from 'redux-first-router';
 import createHistory from 'history/createBrowserHistory';
 import queryString from 'query-string';
+import actions from 'pages/country/widget/widget-actions';
 
 const history = createHistory();
 
 export const COUNTRY = 'location/COUNTRY';
 export const EMBED = 'location/EMBED';
 
+const countryThunk = (dispatch, getState) => {
+  const { query } = getState().location;
+  if (query) {
+    dispatch(actions.setWidgetConfigStore(query));
+  }
+};
+
 export const routes = {
   [EMBED]: {
     path: '/country/embed/:widget/:country/:region?/:subRegion?'
   },
   [COUNTRY]: {
-    path: '/country/:country/:region?/:subRegion?'
+    path: '/country/:country/:region?/:subRegion?',
+    thunk: countryThunk
   }
 };
 

--- a/app/javascript/pages/country/router.js
+++ b/app/javascript/pages/country/router.js
@@ -1,17 +1,17 @@
 import { connectRoutes } from 'redux-first-router';
 import createHistory from 'history/createBrowserHistory';
 import queryString from 'query-string';
-import actions from 'pages/country/widget/widget-actions';
+import { setWidgetSettingsStore } from 'pages/country/widget/widget-actions';
 
 const history = createHistory();
 
 export const COUNTRY = 'location/COUNTRY';
 export const EMBED = 'location/EMBED';
 
-const countryThunk = (dispatch, getState) => {
+const syncWidgetSettings = (dispatch, getState) => {
   const { query } = getState().location;
   if (query) {
-    dispatch(actions.setWidgetConfigStore(query));
+    dispatch(setWidgetSettingsStore(query));
   }
 };
 
@@ -21,7 +21,7 @@ export const routes = {
   },
   [COUNTRY]: {
     path: '/country/:country/:region?/:subRegion?',
-    thunk: countryThunk
+    thunk: syncWidgetSettings
   }
 };
 

--- a/app/javascript/pages/country/router.js
+++ b/app/javascript/pages/country/router.js
@@ -17,7 +17,8 @@ const syncWidgetSettings = (dispatch, getState) => {
 
 export const routes = {
   [EMBED]: {
-    path: '/country/embed/:widget/:country/:region?/:subRegion?'
+    path: '/country/embed/:widget/:country/:region?/:subRegion?',
+    thunk: syncWidgetSettings
   },
   [COUNTRY]: {
     path: '/country/:country/:region?/:subRegion?',

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header-actions.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header-actions.js
@@ -1,7 +1,0 @@
-import { createAction } from 'redux-actions';
-
-export const setShareData = createAction('setShareData');
-
-export default {
-  setShareData
-};

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
@@ -18,7 +18,8 @@ class WidgetHeader extends PureComponent {
       openShare,
       settingsConfig,
       locationNames,
-      widget
+      widget,
+      embed
     } = this.props;
 
     return (
@@ -31,7 +32,8 @@ class WidgetHeader extends PureComponent {
             <Button className="theme-button-small square" disabled>
               <Icon icon={infoIcon} />
             </Button>
-            {settingsConfig &&
+            {!embed &&
+              settingsConfig &&
               !isEmpty(settingsConfig.options) && (
                 <Tooltip
                   theme="light"
@@ -73,7 +75,8 @@ WidgetHeader.propTypes = {
   shareAnchor: PropTypes.string,
   widget: PropTypes.string,
   settingsConfig: PropTypes.object,
-  locationNames: PropTypes.object
+  locationNames: PropTypes.object,
+  embed: PropTypes.bool
 };
 
 export default WidgetHeader;

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
@@ -15,14 +15,13 @@ class WidgetHeader extends PureComponent {
     const {
       title,
       openShare,
-      shareAnchor,
       settingsConfig,
       locationNames,
       widget
     } = this.props;
 
     return (
-      <div className="c-widget-header" id={shareAnchor}>
+      <div className="c-widget-header" id={`#${widget}`}>
         <div className="title">{`${title} in ${
           locationNames.current ? locationNames.current.label : ''
         }`}</div>

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
@@ -20,7 +20,7 @@ class WidgetHeader extends PureComponent {
       widget,
       embed,
       shareData,
-      setShareData
+      setShareModal
     } = this.props;
 
     return (
@@ -59,7 +59,7 @@ class WidgetHeader extends PureComponent {
               )}
             <Button
               className="theme-button-small theme-button-light square"
-              onClick={() => setShareData(shareData)}
+              onClick={() => setShareModal(shareData)}
             >
               <Icon icon={shareIcon} />
             </Button>
@@ -76,7 +76,7 @@ WidgetHeader.propTypes = {
   settingsConfig: PropTypes.object,
   locationNames: PropTypes.object,
   embed: PropTypes.bool,
-  setShareData: PropTypes.func.isRequired,
+  setShareModal: PropTypes.func.isRequired,
   shareData: PropTypes.object.isRequired
 };
 

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
@@ -23,7 +23,7 @@ class WidgetHeader extends PureComponent {
     } = this.props;
 
     return (
-      <div className="c-widget-header" id={`#${widget}`}>
+      <div className="c-widget-header">
         <div className="title">{`${title} in ${
           locationNames.current ? locationNames.current.label : ''
         }`}</div>

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Tooltip } from 'react-tippy';
 import Button from 'components/button';
 import Icon from 'components/icon';
+import isEmpty from 'lodash/isEmpty';
 
 import WidgetSettings from 'pages/country/widget/components/widget-settings';
 import settingsIcon from 'assets/icons/settings.svg';
@@ -31,7 +32,7 @@ class WidgetHeader extends PureComponent {
               <Icon icon={infoIcon} />
             </Button>
             {settingsConfig &&
-              settingsConfig.options && (
+              !isEmpty(settingsConfig.options) && (
                 <Tooltip
                   theme="light"
                   position="bottom-right"

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
@@ -15,11 +15,12 @@ class WidgetHeader extends PureComponent {
   render() {
     const {
       title,
-      openShare,
       settingsConfig,
       locationNames,
       widget,
-      embed
+      embed,
+      shareData,
+      setShareData
     } = this.props;
 
     return (
@@ -58,7 +59,7 @@ class WidgetHeader extends PureComponent {
               )}
             <Button
               className="theme-button-small theme-button-light square"
-              onClick={openShare}
+              onClick={() => setShareData(shareData)}
             >
               <Icon icon={shareIcon} />
             </Button>
@@ -70,13 +71,13 @@ class WidgetHeader extends PureComponent {
 }
 
 WidgetHeader.propTypes = {
-  title: PropTypes.string.isRequired,
-  openShare: PropTypes.func.isRequired,
-  shareAnchor: PropTypes.string,
   widget: PropTypes.string,
+  title: PropTypes.string.isRequired,
   settingsConfig: PropTypes.object,
   locationNames: PropTypes.object,
-  embed: PropTypes.bool
+  embed: PropTypes.bool,
+  setShareData: PropTypes.func.isRequired,
+  shareData: PropTypes.object.isRequired
 };
 
 export default WidgetHeader;

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
@@ -17,7 +17,8 @@ class WidgetHeader extends PureComponent {
       openShare,
       shareAnchor,
       settingsConfig,
-      locationNames
+      locationNames,
+      widget
     } = this.props;
 
     return (
@@ -43,6 +44,7 @@ class WidgetHeader extends PureComponent {
                   html={
                     <WidgetSettings
                       {...settingsConfig}
+                      widget={widget}
                       locationNames={locationNames}
                     />
                   }
@@ -69,6 +71,7 @@ WidgetHeader.propTypes = {
   title: PropTypes.string.isRequired,
   openShare: PropTypes.func.isRequired,
   shareAnchor: PropTypes.string,
+  widget: PropTypes.string,
   settingsConfig: PropTypes.object,
   locationNames: PropTypes.object
 };

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header-reducers.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header-reducers.js
@@ -1,3 +1,0 @@
-export const initialState = {};
-
-export default {};

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header.js
@@ -30,7 +30,7 @@ class WidgetHeaderContainer extends PureComponent {
         subtitle: `${title} in ${
           locationNames.current ? locationNames.current.label : ''
         }`,
-        url: window.location.href,
+        url: `${window.location.href}#${widget}`,
         embedUrl: EMBED_URL.replace('{widget}', widget).replace(
           '{location}',
           `${location.payload.country}${
@@ -38,7 +38,9 @@ class WidgetHeaderContainer extends PureComponent {
           }${
             location.payload.subRegion ? `/${location.payload.subRegion}` : ''
           }${
-            location.query[widget] ? `?${widget}=${location.query[widget]}` : ''
+            location.query && location.query[widget]
+              ? `?${widget}=${location.query[widget]}`
+              : ''
           }`
         ),
         embedSettings:

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header.js
@@ -1,70 +1,37 @@
-import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
+import compact from 'lodash/compact';
 
-import WIDGETS_CONFIG from 'pages/country/data/widgets-config.json';
-
+import shareActions from 'components/share/share-actions';
 import WidgetHeaderComponent from './widget-header-component';
-import actions from './widget-header-actions';
 
-export { initialState } from './widget-header-reducers';
-export { default as reducers } from './widget-header-reducers';
-export { default as actions } from './widget-header-actions';
+const mapStateToProps = ({ location }, ownProps) => {
+  const { locationNames, widget, title, settingsConfig } = ownProps;
+  const locationUrl = compact(
+    Object.keys(location.payload).map(key => location.payload[key])
+  ).join('/');
+  const embedUrl = `${
+    window.location.origin
+  }/country/embed/${widget}/${locationUrl}${
+    location.query && location.query[widget]
+      ? `?${widget}=${location.query[widget]}`
+      : ''
+  }`;
 
-const EMBED_URL = `${process.env.GFW_URL}/country/embed/{widget}/{location}`;
-
-const mapStateToProps = (state, widgetHeader) => ({
-  location: state.location,
-  widget: widgetHeader.widget
-});
-
-class WidgetHeaderContainer extends PureComponent {
-  openShare = () => {
-    const { location, widget, setShareData, title, locationNames } = this.props;
-
-    setShareData({
-      isOpen: true,
-      haveEmbed: true,
-      data: {
-        title: 'Share this widget',
-        subtitle: `${title} in ${
-          locationNames.current ? locationNames.current.label : ''
-        }`,
-        url: `${window.location.href}#${widget}`,
-        embedUrl: EMBED_URL.replace('{widget}', widget).replace(
-          '{location}',
-          `${location.payload.country}${
-            location.payload.region ? `/${location.payload.region}` : ''
-          }${
-            location.payload.subRegion ? `/${location.payload.subRegion}` : ''
-          }${
-            location.query && location.query[widget]
-              ? `?${widget}=${location.query[widget]}`
-              : ''
-          }`
-        ),
-        embedSettings:
-          WIDGETS_CONFIG[widget].gridWidth === 6
-            ? { width: 315, height: 460 }
-            : { width: 670, height: 490 }
-      }
-    });
+  return {
+    location,
+    shareData: {
+      title: 'Share this widget',
+      subtitle: `${title} in ${
+        locationNames.current ? locationNames.current.label : ''
+      }`,
+      shareUrl: `${window.location.href}#${widget}`,
+      embedUrl,
+      embedSettings:
+        settingsConfig.config.gridWidth === 6
+          ? { width: 315, height: 460 }
+          : { width: 670, height: 490 }
+    }
   };
-
-  render() {
-    return createElement(WidgetHeaderComponent, {
-      ...this.props,
-      openShare: this.openShare
-    });
-  }
-}
-
-WidgetHeaderContainer.propTypes = {
-  location: PropTypes.object.isRequired,
-  widget: PropTypes.string.isRequired,
-  setShareData: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired,
-  locationNames: PropTypes.object.isRequired
 };
 
-export default connect(mapStateToProps, actions)(WidgetHeaderContainer);
+export default connect(mapStateToProps, shareActions)(WidgetHeaderComponent);

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header.js
@@ -14,7 +14,7 @@ export { default as actions } from './widget-header-actions';
 const EMBED_URL = `${process.env.GFW_URL}/country/embed/{widget}/{location}`;
 
 const mapStateToProps = (state, widgetHeader) => ({
-  location: state.location.payload,
+  location: state.location,
   widget: widgetHeader.widget
 });
 
@@ -33,8 +33,12 @@ class WidgetHeaderContainer extends PureComponent {
         url: window.location.href,
         embedUrl: EMBED_URL.replace('{widget}', widget).replace(
           '{location}',
-          `${location.country}${location.region ? `/${location.region}` : ''}${
-            location.subRegion ? `/${location.subRegion}` : ''
+          `${location.payload.country}${
+            location.payload.region ? `/${location.payload.region}` : ''
+          }${
+            location.payload.subRegion ? `/${location.payload.subRegion}` : ''
+          }${
+            location.query[widget] ? `?${widget}=${location.query[widget]}` : ''
           }`
         ),
         embedSettings:

--- a/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-component.jsx
@@ -15,7 +15,8 @@ class WidgetNumberedList extends PureComponent {
       data,
       settings,
       handlePageChange,
-      colorRange
+      colorRange,
+      linksDisabled
     } = this.props;
     const { page, pageSize, unit } = settings;
     const pageData = data.slice(page * pageSize, (page + 1) * pageSize);
@@ -27,7 +28,10 @@ class WidgetNumberedList extends PureComponent {
           {data.length > 0 &&
             pageData.map((item, index) => (
               <li key={item.label}>
-                <Link className="list-item" to={item.path}>
+                <Link
+                  className={`list-item ${linksDisabled ? 'disabled' : ''}`}
+                  to={item.path}
+                >
                   <div className="item-label">
                     <div
                       className="item-bubble"
@@ -62,7 +66,8 @@ WidgetNumberedList.propTypes = {
   settings: PropTypes.object.isRequired,
   handlePageChange: PropTypes.func.isRequired,
   colorRange: PropTypes.array.isRequired,
-  className: PropTypes.string
+  className: PropTypes.string,
+  linksDisabled: PropTypes.bool
 };
 
 export default WidgetNumberedList;

--- a/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-styles.scss
+++ b/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-styles.scss
@@ -20,6 +20,15 @@
     }
   }
 
+  .disabled {
+    pointer-events: none;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
   .item-label {
     display: flex;
     flex-direction: row;

--- a/app/javascript/pages/country/widget/components/widget-settings/widget-settings-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-settings/widget-settings-component.jsx
@@ -75,7 +75,7 @@ class WidgetSettings extends PureComponent {
             value={settings.period}
             options={periods}
             onChange={option =>
-              onSettingsChange({ value: { preiod: option.value }, widget })
+              onSettingsChange({ value: { period: option.value }, widget })
             }
           />
         )}

--- a/app/javascript/pages/country/widget/components/widget-settings/widget-settings-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-settings/widget-settings-component.jsx
@@ -26,7 +26,7 @@ class WidgetSettings extends PureComponent {
       onThresholdChange,
       onIndicatorChange
     } = this.props.actions;
-
+    
     return (
       <div className="c-widget-settings">
         {indicators &&
@@ -37,7 +37,7 @@ class WidgetSettings extends PureComponent {
                 locationNames.current.label.toUpperCase()}`}
               value={settings.indicator}
               options={indicators}
-              onChange={option => onIndicatorChange(option.value)}
+              onChange={option => onIndicatorChange({ value: { indicator: option.value }, widget: 'TreeLoss' })}
               disabled={isLoading}
               optionRenderer={(option, selectedOptions) => (
                 <div
@@ -65,7 +65,7 @@ class WidgetSettings extends PureComponent {
               label="UNIT"
               value={settings.unit}
               options={units}
-              onChange={option => onUnitChange(option.value)}
+              onChange={option => onUnitChange({ value: { unit: option.value }, widget: 'TreeLoss' })}
             />
           )}
         {periods &&
@@ -110,7 +110,7 @@ class WidgetSettings extends PureComponent {
               label="CANOPY DENSITY"
               value={settings.threshold}
               options={thresholds}
-              onChange={option => onThresholdChange(option.value)}
+              onChange={option => onThresholdChange({ value: { threshold: option.value }, widget: 'TreeLoss' })}
               disabled={isLoading}
               infoAction={() => console.info('open modal')}
             />

--- a/app/javascript/pages/country/widget/components/widget-settings/widget-settings-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-settings/widget-settings-component.jsx
@@ -9,7 +9,13 @@ import './widget-settings-styles.scss';
 
 class WidgetSettings extends PureComponent {
   render() {
-    const { settings, isLoading, locationNames } = this.props;
+    const {
+      settings,
+      loading,
+      locationNames,
+      onSettingsChange,
+      widget
+    } = this.props;
     const {
       units,
       indicators,
@@ -18,70 +24,63 @@ class WidgetSettings extends PureComponent {
       startYears,
       endYears
     } = this.props.options;
-    const {
-      onStartYearChange,
-      onEndYearChange,
-      onUnitChange,
-      onPeriodChange,
-      onThresholdChange,
-      onIndicatorChange
-    } = this.props.actions;
-    
+
     return (
       <div className="c-widget-settings">
-        {indicators &&
-          onIndicatorChange && (
-            <Dropdown
-              theme="theme-select-light"
-              label={`REFINE LOCATION WITHIN ${locationNames.current &&
-                locationNames.current.label.toUpperCase()}`}
-              value={settings.indicator}
-              options={indicators}
-              onChange={option => onIndicatorChange({ value: { indicator: option.value }, widget: 'TreeLoss' })}
-              disabled={isLoading}
-              optionRenderer={(option, selectedOptions) => (
-                <div
-                  className={`dd__option ${
-                    selectedOptions[0].value === option.value
-                      ? 'dd__selectedOption'
-                      : ''
-                  }`}
+        {indicators && (
+          <Dropdown
+            theme="theme-select-light"
+            label={`REFINE LOCATION WITHIN ${locationNames.current &&
+              locationNames.current.label.toUpperCase()}`}
+            value={settings.indicator}
+            options={indicators}
+            onChange={option =>
+              onSettingsChange({ value: { indicator: option.value }, widget })
+            }
+            disabled={loading}
+            optionRenderer={(option, selectedOptions) => (
+              <div
+                className={`dd__option ${
+                  selectedOptions[0].value === option.value
+                    ? 'dd__selectedOption'
+                    : ''
+                }`}
+              >
+                {option.label}
+                <Button
+                  disabled
+                  className="theme-button-small square info-button"
                 >
-                  {option.label}
-                  <Button
-                    disabled
-                    className="theme-button-small square info-button"
-                  >
-                    <Icon icon={infoIcon} className="info-icon" />
-                  </Button>
-                </div>
-              )}
-            />
-          )}
-        {units &&
-          onUnitChange && (
-            <Dropdown
-              theme="theme-select-light"
-              label="UNIT"
-              value={settings.unit}
-              options={units}
-              onChange={option => onUnitChange({ value: { unit: option.value }, widget: 'TreeLoss' })}
-            />
-          )}
-        {periods &&
-          onPeriodChange && (
-            <Dropdown
-              theme="theme-select-light"
-              label="PERIOD"
-              value={settings.period}
-              options={periods}
-              onChange={option => onPeriodChange(option.value)}
-            />
-          )}
+                  <Icon icon={infoIcon} className="info-icon" />
+                </Button>
+              </div>
+            )}
+          />
+        )}
+        {units && (
+          <Dropdown
+            theme="theme-select-light"
+            label="UNIT"
+            value={settings.unit}
+            options={units}
+            onChange={option =>
+              onSettingsChange({ value: { unit: option.value }, widget })
+            }
+          />
+        )}
+        {periods && (
+          <Dropdown
+            theme="theme-select-light"
+            label="PERIOD"
+            value={settings.period}
+            options={periods}
+            onChange={option =>
+              onSettingsChange({ value: { preiod: option.value }, widget })
+            }
+          />
+        )}
         {startYears &&
-          endYears &&
-          onStartYearChange &&
-          onEndYearChange && (
+          endYears && (
             <div className="years-select">
               <span className="label">YEARS</span>
               <div className="select-container">
@@ -89,32 +88,43 @@ class WidgetSettings extends PureComponent {
                   theme="theme-select-button -transparent"
                   value={settings.startYear}
                   options={startYears}
-                  onChange={option => onStartYearChange(option.value)}
-                  disabled={isLoading}
+                  onChange={option =>
+                    onSettingsChange({
+                      value: { startYear: option.value },
+                      widget
+                    })
+                  }
+                  disabled={loading}
                 />
                 <span className="text-date">to</span>
                 <Dropdown
                   theme="theme-select-button -transparent"
                   value={settings.endYear}
                   options={endYears}
-                  onChange={option => onEndYearChange(option.value)}
-                  disabled={isLoading}
+                  onChange={option =>
+                    onSettingsChange({
+                      value: { endYear: option.value },
+                      widget
+                    })
+                  }
+                  disabled={loading}
                 />
               </div>
             </div>
           )}
-        {thresholds &&
-          onThresholdChange && (
-            <Dropdown
-              theme="theme-select-button canopy-select"
-              label="CANOPY DENSITY"
-              value={settings.threshold}
-              options={thresholds}
-              onChange={option => onThresholdChange({ value: { threshold: option.value }, widget: 'TreeLoss' })}
-              disabled={isLoading}
-              infoAction={() => console.info('open modal')}
-            />
-          )}
+        {thresholds && (
+          <Dropdown
+            theme="theme-select-button canopy-select"
+            label="CANOPY DENSITY"
+            value={settings.threshold}
+            options={thresholds}
+            onChange={option =>
+              onSettingsChange({ value: { threshold: option.value }, widget })
+            }
+            disabled={loading}
+            infoAction={() => console.info('open modal')}
+          />
+        )}
       </div>
     );
   }
@@ -128,16 +138,11 @@ WidgetSettings.propTypes = {
   settings: PropTypes.object,
   startYears: PropTypes.array,
   endYears: PropTypes.array,
-  onIndicatorChange: PropTypes.func,
-  onThresholdChange: PropTypes.func,
-  onUnitChange: PropTypes.func,
-  onPeriodChange: PropTypes.func,
-  onStartYearChange: PropTypes.func,
-  onEndYearChange: PropTypes.func,
-  isLoading: PropTypes.bool,
+  loading: PropTypes.bool,
   locationNames: PropTypes.object,
   options: PropTypes.object,
-  actions: PropTypes.object
+  onSettingsChange: PropTypes.func,
+  widget: PropTypes.string
 };
 
 export default WidgetSettings;

--- a/app/javascript/pages/country/widget/widget-actions.js
+++ b/app/javascript/pages/country/widget/widget-actions.js
@@ -1,42 +1,37 @@
 import { createThunkAction } from 'utils/redux';
-import { actions as treeLossActions } from 'pages/country/widget/widgets/widget-tree-loss';
+import * as treeLossActions from 'pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions';
+import upperFirst from 'lodash/upperFirst';
+import { encodeStateForUrl, decodeUrlForState } from 'utils/stateToUrl';
 
-const actions = { ...treeLossActions };
+const widgetActions = { ...treeLossActions.default };
 
-const setWidgetConfigUrl = createThunkAction(
-  'setWidgetConfigUrl',
-  ({ value, widget }) => (dispatch, getState) => {
-    const { location } = getState();
+export const setWidgetSettingsUrl = createThunkAction(
+  'setWidgetSettingsUrl',
+  ({ value, widget }) => (dispatch, state) => {
+    const { location } = state();
     let params = value;
     if (location.query && location.query[widget]) {
       params = {
-        ...location.query[widget],
+        ...decodeUrlForState(location.query[widget]),
         ...value
       };
     }
     dispatch({
       type: 'location/COUNTRY',
       payload: location.payload,
-      query: { [widget]: JSON.stringify(params) }
+      query: { [widget]: encodeStateForUrl(params) }
     });
   }
 );
 
-
-const setWidgetConfigStore = createThunkAction(
-  'setWidgetConfigStore',
-  (query) => (dispatch) => {
-    Object.keys(query).forEach((widgetKey) => {
-      const actionFunc = actions[`set${widgetKey}Settings`];
+export const setWidgetSettingsStore = createThunkAction(
+  'setWidgetSettingsStore',
+  query => dispatch => {
+    Object.keys(query).forEach(widgetKey => {
+      const actionFunc = widgetActions[`set${upperFirst(widgetKey)}Settings`];
       if (actionFunc) {
-        dispatch(actionFunc(JSON.parse(query[widgetKey])));
+        dispatch(actionFunc(decodeUrlForState(query[widgetKey])));
       }
     });
   }
 );
-
-
-export default {
-  setWidgetConfigUrl,
-  setWidgetConfigStore
-};

--- a/app/javascript/pages/country/widget/widget-actions.js
+++ b/app/javascript/pages/country/widget/widget-actions.js
@@ -1,9 +1,13 @@
 import { createThunkAction } from 'utils/redux';
 import * as treeLossActions from 'pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions';
+import * as treeCoverActions from 'pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-actions';
 import upperFirst from 'lodash/upperFirst';
 import { encodeStateForUrl, decodeUrlForState } from 'utils/stateToUrl';
 
-const widgetActions = { ...treeLossActions.default };
+const widgetActions = {
+  ...treeLossActions.default,
+  ...treeCoverActions.default
+};
 
 export const setWidgetSettingsUrl = createThunkAction(
   'setWidgetSettingsUrl',

--- a/app/javascript/pages/country/widget/widget-actions.js
+++ b/app/javascript/pages/country/widget/widget-actions.js
@@ -7,13 +7,15 @@ import * as treeCoverActions from 'pages/country/widget/widgets/widget-tree-cove
 import * as treeLocatedActions from 'pages/country/widget/widgets/widget-tree-located/widget-tree-located-actions';
 import * as treeGainActions from 'pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions';
 import * as FAOReforestationActions from 'pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-actions';
+import * as FAOCoverActions from 'pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-actions';
 
 const widgetActions = {
   ...treeLossActions.default,
   ...treeCoverActions.default,
   ...treeLocatedActions.default,
   ...treeGainActions.default,
-  ...FAOReforestationActions.default
+  ...FAOReforestationActions.default,
+  ...FAOCoverActions.default
 };
 
 export const setWidgetSettingsUrl = createThunkAction(

--- a/app/javascript/pages/country/widget/widget-actions.js
+++ b/app/javascript/pages/country/widget/widget-actions.js
@@ -6,12 +6,14 @@ import * as treeLossActions from 'pages/country/widget/widgets/widget-tree-loss/
 import * as treeCoverActions from 'pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-actions';
 import * as treeLocatedActions from 'pages/country/widget/widgets/widget-tree-located/widget-tree-located-actions';
 import * as treeGainActions from 'pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions';
+import * as FAOReforestationActions from 'pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-actions';
 
 const widgetActions = {
   ...treeLossActions.default,
   ...treeCoverActions.default,
   ...treeLocatedActions.default,
-  ...treeGainActions.default
+  ...treeGainActions.default,
+  ...FAOReforestationActions.default
 };
 
 export const setWidgetSettingsUrl = createThunkAction(

--- a/app/javascript/pages/country/widget/widget-actions.js
+++ b/app/javascript/pages/country/widget/widget-actions.js
@@ -32,7 +32,10 @@ export const setWidgetSettingsUrl = createThunkAction(
     dispatch({
       type: 'location/COUNTRY',
       payload: location.payload,
-      query: { [widget]: encodeStateForUrl(params) }
+      query: {
+        ...location.query,
+        [widget]: encodeStateForUrl(params)
+      }
     });
   }
 );

--- a/app/javascript/pages/country/widget/widget-actions.js
+++ b/app/javascript/pages/country/widget/widget-actions.js
@@ -5,11 +5,13 @@ import { encodeStateForUrl, decodeUrlForState } from 'utils/stateToUrl';
 import * as treeLossActions from 'pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions';
 import * as treeCoverActions from 'pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-actions';
 import * as treeLocatedActions from 'pages/country/widget/widgets/widget-tree-located/widget-tree-located-actions';
+import * as treeGainActions from 'pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions';
 
 const widgetActions = {
   ...treeLossActions.default,
   ...treeCoverActions.default,
-  ...treeLocatedActions.default
+  ...treeLocatedActions.default,
+  ...treeGainActions.default
 };
 
 export const setWidgetSettingsUrl = createThunkAction(

--- a/app/javascript/pages/country/widget/widget-actions.js
+++ b/app/javascript/pages/country/widget/widget-actions.js
@@ -1,0 +1,42 @@
+import { createThunkAction } from 'utils/redux';
+import { actions as treeLossActions } from 'pages/country/widget/widgets/widget-tree-loss';
+
+const actions = { ...treeLossActions };
+
+const setWidgetConfigUrl = createThunkAction(
+  'setWidgetConfigUrl',
+  ({ value, widget }) => (dispatch, getState) => {
+    const { location } = getState();
+    let params = value;
+    if (location.query && location.query[widget]) {
+      params = {
+        ...location.query[widget],
+        ...value
+      };
+    }
+    dispatch({
+      type: 'location/COUNTRY',
+      payload: location.payload,
+      query: { [widget]: JSON.stringify(params) }
+    });
+  }
+);
+
+
+const setWidgetConfigStore = createThunkAction(
+  'setWidgetConfigStore',
+  (query) => (dispatch) => {
+    Object.keys(query).forEach((widgetKey) => {
+      const actionFunc = actions[`set${widgetKey}Settings`];
+      if (actionFunc) {
+        dispatch(actionFunc(JSON.parse(query[widgetKey])));
+      }
+    });
+  }
+);
+
+
+export default {
+  setWidgetConfigUrl,
+  setWidgetConfigStore
+};

--- a/app/javascript/pages/country/widget/widget-actions.js
+++ b/app/javascript/pages/country/widget/widget-actions.js
@@ -35,3 +35,8 @@ export const setWidgetSettingsStore = createThunkAction(
     });
   }
 );
+
+export default {
+  setWidgetSettingsUrl,
+  setWidgetSettingsStore
+};

--- a/app/javascript/pages/country/widget/widget-actions.js
+++ b/app/javascript/pages/country/widget/widget-actions.js
@@ -1,12 +1,15 @@
 import { createThunkAction } from 'utils/redux';
-import * as treeLossActions from 'pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions';
-import * as treeCoverActions from 'pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-actions';
 import upperFirst from 'lodash/upperFirst';
 import { encodeStateForUrl, decodeUrlForState } from 'utils/stateToUrl';
 
+import * as treeLossActions from 'pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions';
+import * as treeCoverActions from 'pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-actions';
+import * as treeLocatedActions from 'pages/country/widget/widgets/widget-tree-located/widget-tree-located-actions';
+
 const widgetActions = {
   ...treeLossActions.default,
-  ...treeCoverActions.default
+  ...treeCoverActions.default,
+  ...treeLocatedActions.default
 };
 
 export const setWidgetSettingsUrl = createThunkAction(

--- a/app/javascript/pages/country/widget/widget-actions.js
+++ b/app/javascript/pages/country/widget/widget-actions.js
@@ -1,5 +1,7 @@
 import { createThunkAction } from 'utils/redux';
 import upperFirst from 'lodash/upperFirst';
+import isEqual from 'lodash/isEqual';
+import pick from 'lodash/pick';
 import { encodeStateForUrl, decodeUrlForState } from 'utils/stateToUrl';
 
 import * as treeLossActions from 'pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions';
@@ -40,13 +42,23 @@ export const setWidgetSettingsUrl = createThunkAction(
   }
 );
 
+function isObjectContained(contained, container) {
+  return isEqual(pick(container, Object.keys(contained)), contained);
+}
+
 export const setWidgetSettingsStore = createThunkAction(
   'setWidgetSettingsStore',
-  query => dispatch => {
+  query => (dispatch, getState) => {
     Object.keys(query).forEach(widgetKey => {
-      const actionFunc = widgetActions[`set${upperFirst(widgetKey)}Settings`];
-      if (actionFunc) {
-        dispatch(actionFunc(decodeUrlForState(query[widgetKey])));
+      const widgetConfig = decodeUrlForState(query[widgetKey]);
+      const { settings } = getState()[`widget${upperFirst(widgetKey)}`];
+      // Check if the state needs and update checking the values of the new config
+      // with the existing in the url to avoid dispatch actions without changes
+      if (!isObjectContained(widgetConfig, settings)) {
+        const actionFunc = widgetActions[`set${upperFirst(widgetKey)}Settings`];
+        if (actionFunc) {
+          dispatch(actionFunc(widgetConfig));
+        }
       }
     });
   }

--- a/app/javascript/pages/country/widget/widget-component.jsx
+++ b/app/javascript/pages/country/widget/widget-component.jsx
@@ -35,7 +35,8 @@ class Widget extends PureComponent {
       locationNames,
       title,
       settingsConfig,
-      setWidgetSettingsUrl
+      setWidgetSettingsUrl,
+      embed
     } = this.props;
     const WidgetComponent = widgets[`Widget${upperFirst(camelCase(widget))}`];
     return (
@@ -48,6 +49,7 @@ class Widget extends PureComponent {
             ...settingsConfig,
             onSettingsChange: setWidgetSettingsUrl
           }}
+          embed={embed}
         />
         <div className="container">
           <WidgetComponent {...this.props} {...settingsConfig} />
@@ -62,7 +64,8 @@ Widget.propTypes = {
   title: PropTypes.string.isRequired,
   setWidgetSettingsUrl: PropTypes.func.isRequired,
   settingsConfig: PropTypes.object,
-  locationNames: PropTypes.object
+  locationNames: PropTypes.object,
+  embed: PropTypes.bool
 };
 
 export default Widget;

--- a/app/javascript/pages/country/widget/widget-component.jsx
+++ b/app/javascript/pages/country/widget/widget-component.jsx
@@ -40,7 +40,7 @@ class Widget extends PureComponent {
     } = this.props;
     const WidgetComponent = widgets[`Widget${upperFirst(camelCase(widget))}`];
     return (
-      <div className="c-widget">
+      <div className="c-widget" id={widget}>
         <WidgetHeader
           widget={widget}
           title={title}

--- a/app/javascript/pages/country/widget/widget-component.jsx
+++ b/app/javascript/pages/country/widget/widget-component.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import upperFirst from 'lodash/upperFirst';
 import camelCase from 'lodash/camelCase';
 
+import WidgetHeader from 'pages/country/widget/components/widget-header';
+
 import WidgetTreeCover from 'pages/country/widget/widgets/widget-tree-cover';
 import WidgetTreeLocated from 'pages/country/widget/widgets/widget-tree-located';
 import WidgetTreeLoss from 'pages/country/widget/widgets/widget-tree-loss';
@@ -28,14 +30,38 @@ const widgets = {
 
 class Widget extends PureComponent {
   render() {
-    const { widget } = this.props;
+    const {
+      widget,
+      locationNames,
+      title,
+      settingsConfig,
+      setWidgetSettingsUrl
+    } = this.props;
     const WidgetComponent = widgets[`Widget${upperFirst(camelCase(widget))}`];
-    return <WidgetComponent {...this.props} />;
+    return (
+      <div className="c-widget">
+        <WidgetHeader
+          widget={widget}
+          title={title}
+          locationNames={locationNames}
+          settingsConfig={{
+            ...settingsConfig,
+            onSettingsChange: setWidgetSettingsUrl
+          }}
+        />
+        <div className="container">
+          <WidgetComponent {...this.props} {...settingsConfig} />
+        </div>
+      </div>
+    );
   }
 }
 
 Widget.propTypes = {
   widget: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  setWidgetSettingsUrl: PropTypes.func.isRequired,
+  settingsConfig: PropTypes.object,
   locationNames: PropTypes.object
 };
 

--- a/app/javascript/pages/country/widget/widget.js
+++ b/app/javascript/pages/country/widget/widget.js
@@ -13,8 +13,7 @@ const mapStateToProps = (state, ownProps) => {
   const {
     isCountriesLoading,
     isRegionsLoading,
-    isSubRegionsLoading,
-    isGeostoreLoading
+    isSubRegionsLoading
   } = countryData;
   const adminData = {
     location: location.payload,
@@ -53,10 +52,7 @@ const mapStateToProps = (state, ownProps) => {
   }
   return {
     isMetaLoading:
-      isCountriesLoading ||
-      isRegionsLoading ||
-      isSubRegionsLoading ||
-      isGeostoreLoading,
+      isCountriesLoading || isRegionsLoading || isSubRegionsLoading,
     locationNames: widgetSelectors.getAdminsSelected(adminData),
     activeLocation: widgetSelectors.getActiveAdmin({
       location: location.payload

--- a/app/javascript/pages/country/widget/widget.js
+++ b/app/javascript/pages/country/widget/widget.js
@@ -50,6 +50,7 @@ const mapStateToProps = (state, ownProps) => {
       }
     });
   }
+
   return {
     isMetaLoading:
       isCountriesLoading || isRegionsLoading || isSubRegionsLoading,

--- a/app/javascript/pages/country/widget/widget.js
+++ b/app/javascript/pages/country/widget/widget.js
@@ -1,13 +1,15 @@
 import { connect } from 'react-redux';
-import {
-  getAdminsSelected,
-  getActiveAdmin
-} from 'pages/country/widget/widget-selectors';
-import Component from './widget-component';
+import upperFirst from 'lodash/upperFirst';
 
+import * as widgetSelectors from 'pages/country/widget/widget-selectors';
+import Component from './widget-component';
 import actions from './widget-actions';
 
-const mapStateToProps = ({ location, countryData }) => {
+const mapStateToProps = (state, ownProps) => {
+  const { location, countryData } = state;
+  const { title, config, settings, loading, data } = state[
+    `widget${upperFirst(ownProps.widget)}`
+  ];
   const {
     isCountriesLoading,
     isRegionsLoading,
@@ -20,14 +22,53 @@ const mapStateToProps = ({ location, countryData }) => {
     regions: countryData.regions,
     subRegions: countryData.subRegions
   };
+  const options = {};
+  if (config.selectors) {
+    config.selectors.forEach(selector => {
+      const selectorFunc = widgetSelectors[`get${upperFirst(selector)}`];
+      switch (selector) {
+        case 'indicators':
+          options[selector] = selectorFunc({
+            whitelist: config.indicators,
+            location: location.payload,
+            ...countryData
+          });
+          break;
+        case 'startYears':
+          options[selector] = selectorFunc({
+            data: data.loss,
+            ...settings
+          });
+          break;
+        case 'endYears':
+          options[selector] = selectorFunc({
+            data: data.loss,
+            ...settings
+          });
+          break;
+        default:
+          options[selector] = selectorFunc();
+      }
+    });
+  }
   return {
     isMetaLoading:
       isCountriesLoading ||
       isRegionsLoading ||
       isSubRegionsLoading ||
       isGeostoreLoading,
-    locationNames: getAdminsSelected(adminData),
-    activeLocation: getActiveAdmin({ location: location.payload })
+    locationNames: widgetSelectors.getAdminsSelected(adminData),
+    activeLocation: widgetSelectors.getActiveAdmin({
+      location: location.payload
+    }),
+    location: location.payload,
+    title,
+    settingsConfig: {
+      config,
+      settings,
+      options,
+      loading
+    }
   };
 };
 

--- a/app/javascript/pages/country/widget/widget.js
+++ b/app/javascript/pages/country/widget/widget.js
@@ -5,6 +5,8 @@ import {
 } from 'pages/country/widget/widget-selectors';
 import Component from './widget-component';
 
+import actions from './widget-actions';
+
 const mapStateToProps = ({ location, countryData }) => {
   const {
     isCountriesLoading,
@@ -29,4 +31,4 @@ const mapStateToProps = ({ location, countryData }) => {
   };
 };
 
-export default connect(mapStateToProps, null)(Component);
+export default connect(mapStateToProps, actions)(Component);

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-actions.js
@@ -5,13 +5,14 @@ import axios from 'axios';
 import { getFAO } from 'services/forest-data';
 import { getRanking } from 'services/country';
 
-const setFAOCoverIsLoading = createAction('setFAOIsLoading');
-const setFAOCoverData = createAction('setFAOData');
+const setFAOCoverLoading = createAction('setFAOCoverLoading');
+const setFAOCoverData = createAction('setFAOCoverData');
+
 const getFAOCover = createThunkAction(
   'getFAOCover',
   params => (dispatch, state) => {
-    if (!state().widgetFAOCover.isLoading) {
-      dispatch(setFAOCoverIsLoading(true));
+    if (!state().widgetFAOCover.loading) {
+      dispatch(setFAOCoverLoading(true));
       axios
         .all([getFAO({ ...params }), getRanking({ ...params })])
         .then(
@@ -31,14 +32,14 @@ const getFAOCover = createThunkAction(
         )
         .catch(error => {
           console.info(error);
-          dispatch(setFAOCoverIsLoading(false));
+          dispatch(setFAOCoverLoading(false));
         });
     }
   }
 );
 
 export default {
-  setFAOCoverIsLoading,
+  setFAOCoverLoading,
   setFAOCoverData,
   getFAOCover
 };

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-component.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import Loader from 'components/loader/loader';
-import WidgetHeader from 'pages/country/widget/components/widget-header';
 import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
 import WidgetPieChart from 'pages/country/widget/components/widget-pie-chart';
 import WidgetPieChartLegend from 'pages/country/widget/components/widget-pie-chart-legend';
@@ -11,55 +10,39 @@ import './widget-fao-cover-styles.scss';
 
 class WidgetFAOCover extends PureComponent {
   render() {
-    const {
-      locationNames,
-      isLoading,
-      data,
-      getSentence,
-      title,
-      anchorLink,
-      widget
-    } = this.props;
+    const { locationNames, loading, data, getSentence } = this.props;
 
     return (
-      <div className="c-widget c-widget-fao-cover">
-        <WidgetHeader
-          widget={widget}
-          title={title}
-          anchorLink={anchorLink}
-          locationNames={locationNames}
-        />
-        <div className="container">
-          {isLoading && <Loader />}
-          {!isLoading &&
-            data &&
-            data.length === 0 && (
-              <NoContent
-                message={`No forest cover for ${locationNames.current &&
-                  locationNames.current.label}`}
-                icon
-              />
-            )}
-          {!isLoading &&
-            data &&
-            data.length > 0 && (
-              <div>
-                <WidgetDynamicSentence sentence={getSentence()} />
-                <div className="pie-chart-container">
-                  <WidgetPieChartLegend
-                    className="pie-chart-legend"
-                    data={data}
-                    settings={{
-                      unit: '%',
-                      format: '.1f',
-                      key: 'percentage'
-                    }}
-                  />
-                  <WidgetPieChart className="cover-pie-chart" data={data} />
-                </div>
+      <div className="c-widget-fao-cover">
+        {loading && <Loader />}
+        {!loading &&
+          data &&
+          data.length === 0 && (
+            <NoContent
+              message={`No forest cover for ${locationNames.current &&
+                locationNames.current.label}`}
+              icon
+            />
+          )}
+        {!loading &&
+          data &&
+          data.length > 0 && (
+            <div>
+              <WidgetDynamicSentence sentence={getSentence()} />
+              <div className="pie-chart-container">
+                <WidgetPieChartLegend
+                  className="pie-chart-legend"
+                  data={data}
+                  settings={{
+                    unit: '%',
+                    format: '.1f',
+                    key: 'percentage'
+                  }}
+                />
+                <WidgetPieChart className="cover-pie-chart" data={data} />
               </div>
-            )}
-        </div>
+            </div>
+          )}
       </div>
     );
   }
@@ -67,12 +50,9 @@ class WidgetFAOCover extends PureComponent {
 
 WidgetFAOCover.propTypes = {
   locationNames: PropTypes.object.isRequired,
-  isLoading: PropTypes.bool.isRequired,
+  loading: PropTypes.bool.isRequired,
   data: PropTypes.array.isRequired,
-  getSentence: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired,
-  anchorLink: PropTypes.string.isRequired,
-  widget: PropTypes.string.isRequired
+  getSentence: PropTypes.func.isRequired
 };
 
 export default WidgetFAOCover;

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-reducers.js
@@ -1,28 +1,28 @@
 import WIDGETS_CONFIG from 'pages/country/data/widgets-config.json';
 
 export const initialState = {
-  isLoading: false,
+  loading: false,
   data: {
     fao: {},
     rank: 0
   },
-  ...WIDGETS_CONFIG.faoCover
+  ...WIDGETS_CONFIG.FAOCover
 };
 
-const setFAOCoverIsLoading = (state, { payload }) => ({
+const setFAOCoverLoading = (state, { payload }) => ({
   ...state,
-  isLoading: payload
+  loading: payload
 });
 
 const setFAOCoverData = (state, { payload }) => ({
   ...state,
-  isLoading: false,
+  loading: false,
   data: {
     ...payload
   }
 });
 
 export default {
-  setFAOCoverIsLoading,
+  setFAOCoverLoading,
   setFAOCoverData
 };

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover.js
@@ -4,41 +4,20 @@ import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 import { format } from 'd3-format';
 
-import { getAdminsSelected } from 'pages/country/widget/widget-selectors';
-import { getFAOCoverData } from './widget-fao-cover-selectors';
-
-import WidgetFAOCoverComponent from './widget-fao-cover-component';
 import actions from './widget-fao-cover-actions';
+import reducers, { initialState } from './widget-fao-cover-reducers';
+import { getFAOCoverData } from './widget-fao-cover-selectors';
+import WidgetFAOCoverComponent from './widget-fao-cover-component';
 
-export { initialState } from './widget-fao-cover-reducers';
-export { default as reducers } from './widget-fao-cover-reducers';
-export { default as actions } from './widget-fao-cover-actions';
-
-const mapStateToProps = ({ countryData, widgetFAOCover, location }) => {
-  const {
-    isCountriesLoading,
-    isRegionsLoading,
-    isSubRegionsLoading
-  } = countryData;
+const mapStateToProps = ({ widgetFAOCover }, ownProps) => {
   const { fao, rank } = widgetFAOCover.data;
-  const locationNames = getAdminsSelected({
-    ...countryData,
-    location: location.payload,
-    config: widgetFAOCover.config
-  });
-
   return {
-    title: widgetFAOCover.title,
-    anchorLink: widgetFAOCover.anchorLink,
-    location: location.payload,
-    isLoading:
-      widgetFAOCover.isLoading ||
-      isCountriesLoading ||
-      isRegionsLoading ||
-      isSubRegionsLoading,
+    loading: widgetFAOCover.loading || ownProps.isMetaLoading,
     fao,
     rank,
-    data: getFAOCoverData({ fao, rank, locationNames }) || {}
+    data:
+      getFAOCoverData({ fao, rank, locationNames: ownProps.locationNames }) ||
+      {}
   };
 };
 
@@ -105,5 +84,7 @@ WidgetFAOCoverContainer.propTypes = {
   rank: PropTypes.number.isRequired,
   getFAOCover: PropTypes.func.isRequired
 };
+
+export { actions, reducers, initialState };
 
 export default connect(mapStateToProps, actions)(WidgetFAOCoverContainer);

--- a/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-actions.js
@@ -17,8 +17,8 @@ const getFAOReforestationData = createThunkAction(
           const data = response.data.rows;
           dispatch(
             setFAOReforestationData({
-              name: (data.length && data[0].name) || '',
-              rate: (data.length && data[0].rate) || 0
+              name: (data && data.length > 0 && data[0].name) || '',
+              rate: (data && data.length > 0 && data[0].rate) || 0
             })
           );
         })

--- a/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-actions.js
@@ -3,18 +3,15 @@ import { createThunkAction } from 'utils/redux';
 
 import { getFAOExtent } from 'services/forest-data';
 
-const setFAOReforestationIsLoading = createAction(
-  'setFAOReforestationIsLoading'
-);
+const setFAOReforestationLoading = createAction('setFAOReforestationLoading');
 const setFAOReforestationData = createAction('setFAOReforestationData');
-const setFAOReforestationSettingsPeriod = createAction(
-  'setFAOReforestationSettingsPeriod'
-);
+const setFAOReforestationSettings = createAction('setFAOReforestationSettings');
+
 const getFAOReforestationData = createThunkAction(
   'getFAOReforestation',
   params => (dispatch, state) => {
-    if (!state().widgetFAOReforestation.isLoading) {
-      dispatch(setFAOReforestationIsLoading(true));
+    if (!state().widgetFAOReforestation.loading) {
+      dispatch(setFAOReforestationLoading(true));
       getFAOExtent({ ...params })
         .then(response => {
           const data = response.data.rows;
@@ -27,15 +24,15 @@ const getFAOReforestationData = createThunkAction(
         })
         .catch(error => {
           console.info(error);
-          dispatch(setFAOReforestationIsLoading(false));
+          dispatch(setFAOReforestationLoading(false));
         });
     }
   }
 );
 
 export default {
-  setFAOReforestationIsLoading,
+  setFAOReforestationLoading,
   setFAOReforestationData,
-  setFAOReforestationSettingsPeriod,
+  setFAOReforestationSettings,
   getFAOReforestationData
 };

--- a/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-component.js
@@ -2,48 +2,19 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import Loader from 'components/loader/loader';
-import WidgetHeader from 'pages/country/widget/components/widget-header';
 import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
 import './widget-fao-reforestation-styles.scss';
 
 class WidgetFAOReforestation extends PureComponent {
   render() {
-    const {
-      locationNames,
-      isLoading,
-      options,
-      config,
-      settings,
-      getSentence,
-      setFAOReforestationSettingsPeriod,
-      title,
-      anchorLink,
-      widget
-    } = this.props;
+    const { loading, getSentence } = this.props;
 
     return (
-      <div className="c-widget c-widget-fao-reforestation">
-        <WidgetHeader
-          widget={widget}
-          title={title}
-          anchorLink={anchorLink}
-          locationNames={locationNames}
-          settingsConfig={{
-            isLoading,
-            config,
-            settings,
-            options,
-            actions: {
-              onPeriodChange: setFAOReforestationSettingsPeriod
-            }
-          }}
-        />
-        {isLoading ? (
+      <div className="c-widget-fao-reforestation">
+        {loading ? (
           <Loader />
         ) : (
-          <div className="container">
-            <WidgetDynamicSentence sentence={getSentence()} />
-          </div>
+          <WidgetDynamicSentence sentence={getSentence()} />
         )}
       </div>
     );
@@ -51,16 +22,8 @@ class WidgetFAOReforestation extends PureComponent {
 }
 
 WidgetFAOReforestation.propTypes = {
-  locationNames: PropTypes.object.isRequired,
-  isLoading: PropTypes.bool.isRequired,
-  options: PropTypes.object.isRequired,
-  settings: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired,
-  getSentence: PropTypes.func.isRequired,
-  setFAOReforestationSettingsPeriod: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired,
-  anchorLink: PropTypes.string.isRequired,
-  widget: PropTypes.string.isRequired
+  loading: PropTypes.bool.isRequired,
+  getSentence: PropTypes.func.isRequired
 };
 
 export default WidgetFAOReforestation;

--- a/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-reducers.js
@@ -1,34 +1,34 @@
 import WIDGETS_CONFIG from 'pages/country/data/widgets-config.json';
 
 export const initialState = {
-  isLoading: false,
+  loading: false,
   data: {},
-  ...WIDGETS_CONFIG.faoReforestation
+  ...WIDGETS_CONFIG.FAOReforestation
 };
 
-const setFAOReforestationIsLoading = (state, { payload }) => ({
+const setFAOReforestationLoading = (state, { payload }) => ({
   ...state,
-  isLoading: payload
+  loading: payload
 });
 
 const setFAOReforestationData = (state, { payload }) => ({
   ...state,
-  isLoading: false,
+  loading: false,
   data: {
     ...payload
   }
 });
 
-const setFAOReforestationSettingsPeriod = (state, { payload }) => ({
+const setFAOReforestationSettings = (state, { payload }) => ({
   ...state,
   settings: {
     ...state.settings,
-    period: payload
+    ...payload
   }
 });
 
 export default {
-  setFAOReforestationIsLoading,
+  setFAOReforestationLoading,
   setFAOReforestationData,
-  setFAOReforestationSettingsPeriod
+  setFAOReforestationSettings
 };

--- a/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-styles.scss
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-styles.scss
@@ -1,7 +1,5 @@
 @import '~styles/settings.scss';
 
 .c-widget-fao-reforestation {
-  .container {
-    padding-top: rem(20px);
-  }
+  padding-top: rem(20px);
 }

--- a/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation.js
@@ -3,41 +3,16 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 import { format } from 'd3-format';
-import {
-  getPeriods,
-  getActiveFilter
-} from 'pages/country/widget/widget-selectors';
+import { getActiveFilter } from 'pages/country/widget/widget-selectors';
 
-import WidgetFAOReforestationComponent from './widget-fao-reforestation-component';
 import actions from './widget-fao-reforestation-actions';
+import reducers, { initialState } from './widget-fao-reforestation-reducers';
+import WidgetFAOReforestationComponent from './widget-fao-reforestation-component';
 
-export { initialState } from './widget-fao-reforestation-reducers';
-export { default as reducers } from './widget-fao-reforestation-reducers';
-export { default as actions } from './widget-fao-reforestation-actions';
-
-const mapStateToProps = ({ countryData, widgetFAOReforestation, location }) => {
-  const {
-    isCountriesLoading,
-    isRegionsLoading,
-    isSubRegionsLoading
-  } = countryData;
-  return {
-    title: widgetFAOReforestation.title,
-    anchorLink: widgetFAOReforestation.anchorLink,
-    location: location.payload,
-    isLoading:
-      widgetFAOReforestation.isLoading ||
-      isCountriesLoading ||
-      isRegionsLoading ||
-      isSubRegionsLoading,
-    data: widgetFAOReforestation.data,
-    options: {
-      periods: getPeriods() || []
-    },
-    settings: widgetFAOReforestation.settings,
-    config: widgetFAOReforestation.config
-  };
-};
+const mapStateToProps = ({ widgetFAOReforestation }, ownProps) => ({
+  loading: widgetFAOReforestation.loading || ownProps.isMetaLoading,
+  data: widgetFAOReforestation.data
+});
 
 class WidgetFAOReforestationContainer extends PureComponent {
   componentWillMount() {
@@ -88,6 +63,8 @@ WidgetFAOReforestationContainer.propTypes = {
   settings: PropTypes.object.isRequired,
   getFAOReforestationData: PropTypes.func.isRequired
 };
+
+export { actions, reducers, initialState };
 
 export default connect(mapStateToProps, actions)(
   WidgetFAOReforestationContainer

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-actions.js
@@ -4,12 +4,7 @@ import { getExtent } from 'services/forest-data';
 
 const setTreeCoverLoading = createAction('setTreeCoverLoading');
 const setTreeCoverData = createAction('setTreeCoverData');
-const setTreeCoverSettingsIndicator = createAction(
-  'setTreeCoverSettingsIndicator'
-);
-const setTreeCoverSettingsThreshold = createAction(
-  'setTreeCoverSettingsThreshold'
-);
+const setTreeCoverSettings = createAction('setTreeCoverSettings');
 
 export const getTreeCover = createThunkAction(
   'getTreeCover',
@@ -55,6 +50,5 @@ export default {
   setTreeCoverLoading,
   setTreeCoverData,
   getTreeCover,
-  setTreeCoverSettingsIndicator,
-  setTreeCoverSettingsThreshold
+  setTreeCoverSettings
 };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-actions.js
@@ -13,8 +13,12 @@ export const getTreeCover = createThunkAction(
       dispatch(setTreeCoverLoading(true));
       getExtent(params)
         .then(response => {
-          const totalArea = response.data.data[0].total_area;
-          const cover = response.data.data[0].value;
+          const totalArea =
+            response.data &&
+            response.data.data &&
+            response.data.data[0].total_area;
+          const cover =
+            response.data && response.data.data && response.data.data[0].value;
           if (params.indicator !== 'gadm28') {
             dispatch(
               setTreeCoverData({
@@ -26,7 +30,10 @@ export const getTreeCover = createThunkAction(
           } else {
             getExtent({ ...params, indicator: 'plantations' }).then(
               plantationsResponse => {
-                const plantations = plantationsResponse.data.data[0].value;
+                const { data } = plantationsResponse.data;
+                const plantations =
+                  data && data.length > 0 ? data[0].value : '';
+
                 dispatch(
                   setTreeCoverData({
                     totalArea,

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-actions.js
@@ -9,7 +9,7 @@ const setTreeCoverSettings = createAction('setTreeCoverSettings');
 export const getTreeCover = createThunkAction(
   'getTreeCover',
   params => (dispatch, state) => {
-    if (!state().widgetTreeCover.isLoading) {
+    if (!state().widgetTreeCover.loading) {
       dispatch(setTreeCoverLoading(true));
       getExtent(params)
         .then(response => {

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-component.js
@@ -4,88 +4,50 @@ import PropTypes from 'prop-types';
 import WidgetPieChart from 'pages/country/widget/components/widget-pie-chart';
 import WidgetPieChartLegend from 'pages/country/widget/components/widget-pie-chart-legend';
 import Loader from 'components/loader/loader';
-import WidgetHeader from 'pages/country/widget/components/widget-header';
 import NoContent from 'components/no-content';
 
 import './widget-tree-cover-styles.scss';
 
 class WidgetTreeCover extends PureComponent {
   render() {
-    const {
-      isLoading,
-      data,
-      settings,
-      options,
-      config,
-      setTreeCoverSettingsIndicator,
-      setTreeCoverSettingsThreshold,
-      locationNames,
-      title,
-      anchorLink,
-      widget
-    } = this.props;
+    const { loading, data, settings, locationNames } = this.props;
 
     return (
-      <div className="c-widget c-widget-tree-cover">
-        <WidgetHeader
-          widget={widget}
-          title={title}
-          anchorLink={anchorLink}
-          locationNames={locationNames}
-          settingsConfig={{
-            isLoading,
-            config,
-            settings,
-            options,
-            actions: {
-              onIndicatorChange: setTreeCoverSettingsIndicator,
-              onThresholdChange: setTreeCoverSettingsThreshold
-            }
-          }}
-        />
-        <div className="container">
-          {isLoading && <Loader />}
-          {!isLoading &&
-            data &&
-            data.length === 0 && (
-              <NoContent
-                message={`No data in selection for ${locationNames.current &&
-                  locationNames.current.label}`}
+      <div className="c-widget-tree-cover">
+        {loading && <Loader />}
+        {!loading &&
+          data &&
+          data.length === 0 && (
+            <NoContent
+              message={`No data in selection for ${locationNames.current &&
+                locationNames.current.label}`}
+            />
+          )}
+        {!loading &&
+          data && (
+            <div className="pie-chart-container">
+              <WidgetPieChartLegend
+                data={data}
+                config={{
+                  ...settings,
+                  format: '.3s',
+                  unit: 'ha',
+                  key: 'value'
+                }}
               />
-            )}
-          {!isLoading &&
-            data && (
-              <div className="pie-chart-container">
-                <WidgetPieChartLegend
-                  data={data}
-                  config={{
-                    ...settings,
-                    format: '.3s',
-                    unit: 'ha',
-                    key: 'value'
-                  }}
-                />
-                <WidgetPieChart className="cover-pie-chart" data={data} />
-              </div>
-            )}
-        </div>
+              <WidgetPieChart className="cover-pie-chart" data={data} />
+            </div>
+          )}
       </div>
     );
   }
 }
 
 WidgetTreeCover.propTypes = {
-  isLoading: PropTypes.bool.isRequired,
+  loading: PropTypes.bool.isRequired,
   locationNames: PropTypes.object.isRequired,
   data: PropTypes.array.isRequired,
-  settings: PropTypes.object.isRequired,
-  config: PropTypes.object,
-  options: PropTypes.object,
-  setTreeCoverSettingsIndicator: PropTypes.func.isRequired,
-  setTreeCoverSettingsThreshold: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired,
-  anchorLink: PropTypes.string.isRequired,
-  widget: PropTypes.string.isRequired
+  settings: PropTypes.object.isRequired
 };
 
 export default WidgetTreeCover;

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-reducers.js
@@ -1,7 +1,7 @@
 import WIDGETS_CONFIG from 'pages/country/data/widgets-config.json';
 
 export const initialState = {
-  isLoading: false,
+  loading: false,
   data: {
     totalArea: 0,
     cover: 0,
@@ -12,36 +12,27 @@ export const initialState = {
 
 const setTreeCoverLoading = (state, { payload }) => ({
   ...state,
-  isLoading: payload
+  loading: payload
 });
 
 const setTreeCoverData = (state, { payload }) => ({
   ...state,
-  isLoading: false,
+  loading: false,
   data: {
     ...payload
   }
 });
 
-const setTreeCoverSettingsIndicator = (state, { payload }) => ({
+const setTreeCoverSettings = (state, { payload }) => ({
   ...state,
   settings: {
     ...state.settings,
-    indicator: payload
-  }
-});
-
-const setTreeCoverSettingsThreshold = (state, { payload }) => ({
-  ...state,
-  settings: {
-    ...state.settings,
-    threshold: payload
+    ...payload
   }
 });
 
 export default {
   setTreeCoverLoading,
   setTreeCoverData,
-  setTreeCoverSettingsIndicator,
-  setTreeCoverSettingsThreshold
+  setTreeCoverSettings
 };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover.js
@@ -52,7 +52,8 @@ class WidgetTreeCoverContainer extends PureComponent {
       const activeThreshold = thresholds.find(
         t => t.value === settings.threshold
       );
-      const indicator = getActiveFilter(settings, indicators, 'indicator');
+      const indicator =
+        indicators && getActiveFilter(settings, indicators, 'indicator');
       return `Tree  cover for
         ${indicator.label} of
         ${locationNames.current &&

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover.js
@@ -2,46 +2,22 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
-import {
-  getIndicators,
-  getThresholds,
-  getActiveFilter
-} from 'pages/country/widget/widget-selectors';
-import { getTreeCoverData } from './widget-tree-cover-selectors';
+import { getActiveFilter } from 'pages/country/widget/widget-selectors';
 
-import WidgetTreeCoverComponent from './widget-tree-cover-component';
 import actions from './widget-tree-cover-actions';
+import reducers, { initialState } from './widget-tree-cover-reducers';
+import { getTreeCoverData } from './widget-tree-cover-selectors';
+import WidgetTreeCoverComponent from './widget-tree-cover-component';
 
-export { initialState } from './widget-tree-cover-reducers';
-export { default as reducers } from './widget-tree-cover-reducers';
-export { default as actions } from './widget-tree-cover-actions';
-
-const mapStateToProps = ({ widgetTreeCover, countryData, location }) => {
+const mapStateToProps = ({ widgetTreeCover, countryData }) => {
   const { isCountriesLoading, isRegionsLoading } = countryData;
   const { totalArea, cover, plantations } = widgetTreeCover.data;
   const { indicator } = widgetTreeCover.settings;
-  const { indicators } = widgetTreeCover.config;
 
   return {
-    title: widgetTreeCover.title,
-    anchorLink: widgetTreeCover.anchorLink,
-    isLoading:
-      widgetTreeCover.isLoading || isCountriesLoading || isRegionsLoading,
-    location: location.payload,
+    loading: widgetTreeCover.loading || isCountriesLoading || isRegionsLoading,
     regions: countryData.regions,
-    data: getTreeCoverData({ totalArea, cover, plantations, indicator }) || [],
-    options:
-      {
-        indicators:
-          getIndicators({
-            whitelist: indicators,
-            location: location.payload,
-            ...countryData
-          }) || [],
-        thresholds: getThresholds()
-      } || {},
-    settings: widgetTreeCover.settings,
-    config: widgetTreeCover.config
+    data: getTreeCoverData({ totalArea, cover, plantations, indicator }) || []
   };
 };
 
@@ -101,5 +77,7 @@ WidgetTreeCoverContainer.propTypes = {
   getTreeCover: PropTypes.func.isRequired,
   options: PropTypes.object.isRequired
 };
+
+export { actions, reducers, initialState };
 
 export default connect(mapStateToProps, actions)(WidgetTreeCoverContainer);

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions.js
@@ -4,20 +4,15 @@ import axios from 'axios';
 
 import { getGain, getExtent } from 'services/forest-data';
 
-const setTreeCoverGainIsLoading = createAction('setTreeCoverGainIsLoading');
-const setTreeCoverGainData = createAction('setTreeCoverGainData');
-const setTreeCoverGainSettingsIndicator = createAction(
-  'setTreeCoverGainSettingsIndicator'
-);
-const setTreeCoverGainSettingsThreshold = createAction(
-  'setTreeCoverGainSettingsThreshold'
-);
+const setTreeGainLoading = createAction('setTreeGainLoading');
+const setTreeGainData = createAction('setTreeGainData');
+const setTreeGainSettings = createAction('setTreeGainSettings');
 
-const getTreeCoverGain = createThunkAction(
-  'getTreeCoverGain',
+const getTreeGain = createThunkAction(
+  'getTreeGain',
   params => (dispatch, state) => {
-    if (!state().widgetTreeCoverGain.isLoading) {
-      dispatch(setTreeCoverGainIsLoading(true));
+    if (!state().widgetTreeGain.loading) {
+      dispatch(setTreeGainLoading(true));
       axios
         .all([getGain({ ...params }), getExtent({ ...params })])
         .then(
@@ -25,7 +20,7 @@ const getTreeCoverGain = createThunkAction(
             const gain = gainResponse.data.data;
             const extent = extentResponse.data.data;
             dispatch(
-              setTreeCoverGainData({
+              setTreeGainData({
                 gain: (gain.length && gain[0].value) || 0,
                 extent: (extent.length && extent[0].value) || 0
               })
@@ -34,16 +29,15 @@ const getTreeCoverGain = createThunkAction(
         )
         .catch(error => {
           console.info(error);
-          dispatch(setTreeCoverGainIsLoading(false));
+          dispatch(setTreeGainLoading(false));
         });
     }
   }
 );
 
 export default {
-  setTreeCoverGainIsLoading,
-  setTreeCoverGainData,
-  setTreeCoverGainSettingsIndicator,
-  setTreeCoverGainSettingsThreshold,
-  getTreeCoverGain
+  setTreeGainLoading,
+  setTreeGainData,
+  setTreeGainSettings,
+  getTreeGain
 };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions.js
@@ -21,8 +21,8 @@ const getTreeGain = createThunkAction(
             const extent = extentResponse.data.data;
             dispatch(
               setTreeGainData({
-                gain: (gain.length && gain[0].value) || 0,
-                extent: (extent.length && extent[0].value) || 0
+                gain: (gain && gain.length > 0 && gain[0].value) || 0,
+                extent: (gain && extent.length > 0 && extent[0].value) || 0
               })
             );
           })

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-component.js
@@ -2,71 +2,31 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import Loader from 'components/loader';
-import WidgetHeader from 'pages/country/widget/components/widget-header';
 import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
 
 import './widget-tree-gain-styles.scss';
 
 class WidgetTreeCoverGain extends PureComponent {
   render() {
-    const {
-      locationNames,
-      isLoading,
-      options,
-      config,
-      settings,
-      getSentence,
-      setTreeCoverGainSettingsIndicator,
-      setTreeCoverGainSettingsThreshold,
-      title,
-      anchorLink,
-      widget
-    } = this.props;
+    const { loading, getSentence } = this.props;
 
     return (
-      <div className="c-widget c-widget-tree-cover-gain">
-        <WidgetHeader
-          widget={widget}
-          title={title}
-          anchorLink={anchorLink}
-          locationNames={locationNames}
-          settingsConfig={{
-            isLoading,
-            config,
-            settings,
-            options,
-            actions: {
-              onIndicatorChange: setTreeCoverGainSettingsIndicator,
-              onThresholdChange: setTreeCoverGainSettingsThreshold
-            }
-          }}
-        />
-        <div className="container">
-          {isLoading ? (
-            <Loader />
-          ) : (
-            <div className="gain-data">
-              <WidgetDynamicSentence sentence={getSentence()} />
-            </div>
-          )}
-        </div>
+      <div className="c-widget-tree-cover-gain">
+        {loading ? (
+          <Loader />
+        ) : (
+          <div className="gain-data">
+            <WidgetDynamicSentence sentence={getSentence()} />
+          </div>
+        )}
       </div>
     );
   }
 }
 
 WidgetTreeCoverGain.propTypes = {
-  locationNames: PropTypes.object.isRequired,
-  isLoading: PropTypes.bool.isRequired,
-  options: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired,
-  settings: PropTypes.object.isRequired,
-  getSentence: PropTypes.func.isRequired,
-  setTreeCoverGainSettingsIndicator: PropTypes.func.isRequired,
-  setTreeCoverGainSettingsThreshold: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired,
-  anchorLink: PropTypes.string.isRequired,
-  widget: PropTypes.string.isRequired
+  loading: PropTypes.bool.isRequired,
+  getSentence: PropTypes.func.isRequired
 };
 
 export default WidgetTreeCoverGain;

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-reducers.js
@@ -1,7 +1,7 @@
 import WIDGETS_CONFIG from 'pages/country/data/widgets-config.json';
 
 export const initialState = {
-  isLoading: false,
+  loading: false,
   data: {
     gain: 0,
     extent: 0
@@ -9,38 +9,29 @@ export const initialState = {
   ...WIDGETS_CONFIG.treeGain
 };
 
-const setTreeCoverGainIsLoading = (state, { payload }) => ({
+const setTreeGainLoading = (state, { payload }) => ({
   ...state,
-  isLoading: payload
+  loading: payload
 });
 
-const setTreeCoverGainData = (state, { payload }) => ({
+const setTreeGainData = (state, { payload }) => ({
   ...state,
-  isLoading: false,
+  loading: false,
   data: {
     ...payload
   }
 });
 
-const setTreeCoverGainSettingsIndicator = (state, { payload }) => ({
+const setTreeGainSettings = (state, { payload }) => ({
   ...state,
   settings: {
     ...state.settings,
-    indicator: payload
-  }
-});
-
-const setTreeCoverGainSettingsThreshold = (state, { payload }) => ({
-  ...state,
-  settings: {
-    ...state.settings,
-    threshold: payload
+    ...payload
   }
 });
 
 export default {
-  setTreeCoverGainIsLoading,
-  setTreeCoverGainData,
-  setTreeCoverGainSettingsIndicator,
-  setTreeCoverGainSettingsThreshold
+  setTreeGainLoading,
+  setTreeGainData,
+  setTreeGainSettings
 };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
@@ -2,69 +2,37 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { format } from 'd3-format';
-import {
-  getIndicators,
-  getActiveFilter,
-  getThresholds
-} from 'pages/country/widget/widget-selectors';
 import isEqual from 'lodash/isEqual';
 
-import WidgetTreeCoverGainComponent from './widget-tree-gain-component';
+import { getActiveFilter } from 'pages/country/widget/widget-selectors';
+
 import actions from './widget-tree-gain-actions';
+import reducers, { initialState } from './widget-tree-gain-reducers';
+import WidgetTreeGainComponent from './widget-tree-gain-component';
 
-export { initialState } from './widget-tree-gain-reducers';
-export { default as reducers } from './widget-tree-gain-reducers';
-export { default as actions } from './widget-tree-gain-actions';
+const mapStateToProps = ({ widgetTreeGain }, ownProps) => ({
+  loading: widgetTreeGain.loading || ownProps.isMetaLoading,
+  gain: widgetTreeGain.data.gain,
+  extent: widgetTreeGain.data.extent
+});
 
-const mapStateToProps = ({ countryData, widgetTreeCoverGain, location }) => {
-  const {
-    isCountriesLoading,
-    isRegionsLoading,
-    isSubRegionsLoading
-  } = countryData;
-  const { indicators } = widgetTreeCoverGain.config;
-  return {
-    title: widgetTreeCoverGain.title,
-    anchorLink: widgetTreeCoverGain.anchorLink,
-    location: location.payload,
-    isLoading:
-      widgetTreeCoverGain.isLoading ||
-      isCountriesLoading ||
-      isRegionsLoading ||
-      isSubRegionsLoading,
-    gain: widgetTreeCoverGain.data.gain,
-    extent: widgetTreeCoverGain.data.extent,
-    options: {
-      indicators:
-        getIndicators({
-          whitelist: indicators,
-          location: location.payload,
-          ...countryData
-        }) || [],
-      thresholds: getThresholds()
-    },
-    settings: widgetTreeCoverGain.settings,
-    config: widgetTreeCoverGain.config
-  };
-};
-
-class WidgetTreeCoverGainContainer extends PureComponent {
+class WidgetTreeGainContainer extends PureComponent {
   componentWillMount() {
-    const { location, settings, getTreeCoverGain } = this.props;
-    getTreeCoverGain({
+    const { location, settings, getTreeGain } = this.props;
+    getTreeGain({
       ...location,
       ...settings
     });
   }
 
   componentWillReceiveProps(nextProps) {
-    const { settings, location, getTreeCoverGain } = nextProps;
+    const { settings, location, getTreeGain } = nextProps;
 
     if (
       !isEqual(location, this.props.location) ||
       !isEqual(settings, this.props.settings)
     ) {
-      getTreeCoverGain({
+      getTreeGain({
         ...location,
         ...settings
       });
@@ -74,8 +42,8 @@ class WidgetTreeCoverGainContainer extends PureComponent {
   getSentence = () => {
     const { locationNames, gain, extent, settings } = this.props;
     const { indicators } = this.props.options;
-
-    const indicator = getActiveFilter(settings, indicators, 'indicator');
+    const indicator =
+      indicators && getActiveFilter(settings, indicators, 'indicator');
     const regionPhrase =
       settings.indicator === 'gadm28'
         ? '<span>region-wide</span>'
@@ -94,21 +62,23 @@ class WidgetTreeCoverGainContainer extends PureComponent {
   };
 
   render() {
-    return createElement(WidgetTreeCoverGainComponent, {
+    return createElement(WidgetTreeGainComponent, {
       ...this.props,
       getSentence: this.getSentence
     });
   }
 }
 
-WidgetTreeCoverGainContainer.propTypes = {
+WidgetTreeGainContainer.propTypes = {
   locationNames: PropTypes.object.isRequired,
   gain: PropTypes.number.isRequired,
   extent: PropTypes.number.isRequired,
   options: PropTypes.object.isRequired,
   settings: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
-  getTreeCoverGain: PropTypes.func.isRequired
+  getTreeGain: PropTypes.func.isRequired
 };
 
-export default connect(mapStateToProps, actions)(WidgetTreeCoverGainContainer);
+export { actions, reducers, initialState };
+
+export default connect(mapStateToProps, actions)(WidgetTreeGainContainer);

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
@@ -47,7 +47,7 @@ class WidgetTreeGainContainer extends PureComponent {
     const regionPhrase =
       settings.indicator === 'gadm28'
         ? '<span>region-wide</span>'
-        : `in <span>${indicator.label.toLowerCase()}</span>`;
+        : `in <span>${indicator && indicator.label.toLowerCase()}</span>`;
 
     const areaPercent = format('.1f')(100 * gain / extent);
     const firstSentence = `From 2001 to 2012, <span>${locationNames.current &&

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-actions.js
@@ -5,20 +5,14 @@ import { getLocations } from 'services/forest-data';
 
 const setTreeLocatedData = createAction('setTreeLocatedData');
 const setTreeLocatedPage = createAction('setTreeLocatedPage');
-const setTreeLocatedSettingsIndicator = createAction(
-  'setTreeLocatedSettingsIndicator'
-);
-const setTreeLocatedSettingsUnit = createAction('setTreeLocatedSettingsUnit');
-const setTreeLocatedSettingsThreshold = createAction(
-  'setTreeLocatedSettingsThreshold'
-);
-const setTreeLocatedIsLoading = createAction('setTreeLocatedIsLoading');
+const setTreeLocatedSettings = createAction('setTreeLocatedSettings');
+const setTreeLocatedLoading = createAction('setTreeLocatedLoading');
 
 const getTreeLocated = createThunkAction(
   'getTreeLocated',
   params => (dispatch, state) => {
-    if (!state().widgetTreeLocated.isLoading) {
-      dispatch(setTreeLocatedIsLoading(true));
+    if (!state().widgetTreeLocated.loading) {
+      dispatch(setTreeLocatedLoading(true));
       getLocations(params)
         .then(response => {
           if (response.data.data.length) {
@@ -35,7 +29,7 @@ const getTreeLocated = createThunkAction(
         })
         .catch(error => {
           console.info(error);
-          dispatch(setTreeLocatedIsLoading(false));
+          dispatch(setTreeLocatedLoading(false));
         });
     }
   }
@@ -44,9 +38,7 @@ const getTreeLocated = createThunkAction(
 export default {
   setTreeLocatedData,
   setTreeLocatedPage,
-  setTreeLocatedSettingsIndicator,
-  setTreeLocatedSettingsUnit,
-  setTreeLocatedSettingsThreshold,
-  setTreeLocatedIsLoading,
+  setTreeLocatedSettings,
+  setTreeLocatedLoading,
   getTreeLocated
 };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-actions.js
@@ -15,10 +15,11 @@ const getTreeLocated = createThunkAction(
       dispatch(setTreeLocatedLoading(true));
       getLocations(params)
         .then(response => {
-          if (response.data.data.length) {
+          const { data } = response.data;
+          if (data && data.length) {
             dispatch(
               setTreeLocatedData(
-                response.data.data.map(d => ({
+                data.map(d => ({
                   id: d[params.region ? 'adm2' : 'adm1'],
                   area: d.value || 0,
                   percentage: d.value / d.total_area * 100

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-component.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import Loader from 'components/loader/loader';
-import WidgetHeader from 'pages/country/widget/components/widget-header';
 import WidgetNumberedList from 'pages/country/widget/components/widget-numbered-list';
 import NoContent from 'components/no-content';
 import COLORS from 'pages/country/data/colors.json';
@@ -13,80 +12,45 @@ class WidgetTreeLocated extends PureComponent {
   render() {
     const {
       locationNames,
-      isLoading,
+      loading,
       data,
-      options,
       settings,
-      config,
-      handlePageChange,
-      setTreeLocatedSettingsIndicator,
-      setTreeLocatedSettingsUnit,
-      setTreeLocatedSettingsThreshold,
-      title,
-      anchorLink,
-      widget
+      handlePageChange
     } = this.props;
     return (
-      <div className="c-widget c-widget-tree-located">
-        <WidgetHeader
-          widget={widget}
-          title={title}
-          anchorLink={anchorLink}
-          locationNames={locationNames}
-          settingsConfig={{
-            isLoading,
-            config,
-            settings,
-            options,
-            actions: {
-              onIndicatorChange: setTreeLocatedSettingsIndicator,
-              onUnitChange: setTreeLocatedSettingsUnit,
-              onThresholdChange: setTreeLocatedSettingsThreshold
-            }
-          }}
-        />
-        <div className="container">
-          {isLoading && <Loader />}
-          {!isLoading &&
-            data &&
-            data.length === 0 && (
-              <NoContent
-                message={`No regions for ${locationNames.current &&
-                  locationNames.current.label}`}
-                icon
-              />
-            )}
-          {!isLoading &&
-            data &&
-            data.length > 0 && (
-              <WidgetNumberedList
-                className="locations-list"
-                data={data}
-                settings={settings}
-                handlePageChange={handlePageChange}
-                colorRange={[COLORS.darkGreen, COLORS.nonForest]}
-              />
-            )}
-        </div>
+      <div className="c-widget-tree-located">
+        {loading && <Loader />}
+        {!loading &&
+          data &&
+          data.length === 0 && (
+            <NoContent
+              message={`No regions for ${locationNames.current &&
+                locationNames.current.label}`}
+              icon
+            />
+          )}
+        {!loading &&
+          data &&
+          data.length > 0 && (
+            <WidgetNumberedList
+              className="locations-list"
+              data={data}
+              settings={settings}
+              handlePageChange={handlePageChange}
+              colorRange={[COLORS.darkGreen, COLORS.nonForest]}
+            />
+          )}
       </div>
     );
   }
 }
 
 WidgetTreeLocated.propTypes = {
-  isLoading: PropTypes.bool.isRequired,
+  loading: PropTypes.bool.isRequired,
   locationNames: PropTypes.object,
   data: PropTypes.array.isRequired,
-  options: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired,
   settings: PropTypes.object.isRequired,
-  handlePageChange: PropTypes.func.isRequired,
-  setTreeLocatedSettingsIndicator: PropTypes.func.isRequired,
-  setTreeLocatedSettingsUnit: PropTypes.func.isRequired,
-  setTreeLocatedSettingsThreshold: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired,
-  anchorLink: PropTypes.string.isRequired,
-  widget: PropTypes.string.isRequired
+  handlePageChange: PropTypes.func.isRequired
 };
 
 export default WidgetTreeLocated;

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-component.js
@@ -15,7 +15,8 @@ class WidgetTreeLocated extends PureComponent {
       loading,
       data,
       settings,
-      handlePageChange
+      handlePageChange,
+      embed
     } = this.props;
     return (
       <div className="c-widget-tree-located">
@@ -38,6 +39,7 @@ class WidgetTreeLocated extends PureComponent {
               settings={settings}
               handlePageChange={handlePageChange}
               colorRange={[COLORS.darkGreen, COLORS.nonForest]}
+              linksDisabled={embed}
             />
           )}
       </div>
@@ -50,7 +52,8 @@ WidgetTreeLocated.propTypes = {
   locationNames: PropTypes.object,
   data: PropTypes.array.isRequired,
   settings: PropTypes.object.isRequired,
-  handlePageChange: PropTypes.func.isRequired
+  handlePageChange: PropTypes.func.isRequired,
+  embed: PropTypes.bool
 };
 
 export default WidgetTreeLocated;

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-reducers.js
@@ -1,7 +1,7 @@
 import WIDGETS_CONFIG from 'pages/country/data/widgets-config.json';
 
 export const initialState = {
-  isLoading: false,
+  loading: false,
   data: {
     regions: []
   },
@@ -10,7 +10,7 @@ export const initialState = {
 
 const setTreeLocatedData = (state, { payload }) => ({
   ...state,
-  isLoading: false,
+  loading: false,
   data: {
     regions: payload
   },
@@ -28,40 +28,22 @@ const setTreeLocatedPage = (state, { payload }) => ({
   }
 });
 
-const setTreeLocatedSettingsIndicator = (state, { payload }) => ({
+const setTreeLocatedSettings = (state, { payload }) => ({
   ...state,
   settings: {
     ...state.settings,
-    indicator: payload
+    ...payload
   }
 });
 
-const setTreeLocatedSettingsUnit = (state, { payload }) => ({
+const setTreeLocatedLoading = (state, { payload }) => ({
   ...state,
-  settings: {
-    ...state.settings,
-    unit: payload
-  }
-});
-
-const setTreeLocatedSettingsThreshold = (state, { payload }) => ({
-  ...state,
-  settings: {
-    ...state.settings,
-    threshold: payload
-  }
-});
-
-const setTreeLocatedIsLoading = (state, { payload }) => ({
-  ...state,
-  isLoading: payload
+  loading: payload
 });
 
 export default {
   setTreeLocatedData,
   setTreeLocatedPage,
-  setTreeLocatedSettingsIndicator,
-  setTreeLocatedSettingsUnit,
-  setTreeLocatedSettingsThreshold,
-  setTreeLocatedIsLoading
+  setTreeLocatedSettings,
+  setTreeLocatedLoading
 };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located.js
@@ -3,23 +3,13 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 
-import {
-  getThresholds,
-  getUnits,
-  getIndicators
-} from 'pages/country/widget/widget-selectors';
-import { getSortedData } from './widget-tree-located-selectors';
-
-import WidgetTreeLocatedComponent from './widget-tree-located-component';
 import actions from './widget-tree-located-actions';
-
-export { initialState } from './widget-tree-located-reducers';
-export { default as reducers } from './widget-tree-located-reducers';
-export { default as actions } from './widget-tree-located-actions';
+import reducers, { initialState } from './widget-tree-located-reducers';
+import { getSortedData } from './widget-tree-located-selectors';
+import WidgetTreeLocatedComponent from './widget-tree-located-component';
 
 const mapStateToProps = ({ location, widgetTreeLocated, countryData }) => {
   const { isCountriesLoading, isRegionsLoading } = countryData;
-  const { indicators } = widgetTreeLocated.config;
   const data = {
     data: widgetTreeLocated.data.regions,
     unit: widgetTreeLocated.settings.unit,
@@ -27,25 +17,10 @@ const mapStateToProps = ({ location, widgetTreeLocated, countryData }) => {
     location: location.payload
   };
   return {
-    title: widgetTreeLocated.title,
-    anchorLink: widgetTreeLocated.anchorLink,
-    location: location.payload,
     regions: countryData.regions,
-    isLoading:
-      widgetTreeLocated.isLoading || isCountriesLoading || isRegionsLoading,
-    data: getSortedData(data) || [],
-    options: {
-      indicators:
-        getIndicators({
-          whitelist: indicators,
-          location: location.payload,
-          ...countryData
-        }) || [],
-      units: getUnits(),
-      thresholds: getThresholds()
-    },
-    settings: widgetTreeLocated.settings,
-    config: widgetTreeLocated.config
+    loading:
+      widgetTreeLocated.loading || isCountriesLoading || isRegionsLoading,
+    data: getSortedData(data) || []
   };
 };
 
@@ -93,5 +68,7 @@ WidgetTreeLocatedContainer.propTypes = {
   location: PropTypes.object.isRequired,
   getTreeLocated: PropTypes.func.isRequired
 };
+
+export { actions, reducers, initialState };
 
 export default connect(mapStateToProps, actions)(WidgetTreeLocatedContainer);

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions.js
@@ -11,7 +11,7 @@ const setTreeLossSettings = createAction('setTreeLossSettings');
 const getTreeLoss = createThunkAction(
   'getTreeLoss',
   params => (dispatch, state) => {
-    if (!state().widgetTreeLoss.isLoading) {
+    if (!state().widgetTreeLoss.loading) {
       dispatch(setTreeLossLoading(true));
       axios
         .all([getLoss(params), getExtent(params)])

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions.js
@@ -17,11 +17,11 @@ const getTreeLoss = createThunkAction(
         .all([getLoss(params), getExtent(params)])
         .then(
           axios.spread((loss, extent) => {
-            if (loss && extent) {
+            if (loss && loss.data && extent && extent.data) {
               dispatch(
                 setTreeLossData({
                   loss: loss.data.data,
-                  extent: extent.data.data[0].value
+                  extent: (loss.data.data && extent.data.data[0].value) || 0
                 })
               );
             } else {

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions.js
@@ -1,8 +1,6 @@
 import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 import axios from 'axios';
-import minBy from 'lodash/minBy';
-import maxBy from 'lodash/maxBy';
 
 import { getExtent, getLoss } from 'services/forest-data';
 
@@ -23,8 +21,6 @@ const getTreeLoss = createThunkAction(
               dispatch(
                 setTreeLossData({
                   loss: loss.data.data,
-                  startYear: minBy(loss.data.data, 'year').year,
-                  endYear: maxBy(loss.data.data, 'year').year,
                   extent: extent.data.data[0].value
                 })
               );

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions.js
@@ -6,33 +6,22 @@ import maxBy from 'lodash/maxBy';
 
 import { getExtent, getLoss } from 'services/forest-data';
 
-const setTreeLossIsLoading = createAction('setTreeLossIsLoading');
-
-const setTreeLossValues = createAction('setTreeLossValues');
-const setTreeLossSettings = createAction(
-  'setTreeLossSettings'
-);
-const setTreeLossSettingsThreshold = createAction(
-  'setTreeLossSettingsThreshold'
-);
-const setTreeLossSettingsStartYear = createAction(
-  'setTreeLossSettingsStartYear'
-);
-const setTreeLossSettingsEndYear = createAction('setTreeLossSettingsEndYear');
-const setLayers = createAction('setLayers');
+const setTreeLossLoading = createAction('setTreeLossLoading');
+const setTreeLossData = createAction('setTreeLossData');
+const setTreeLossSettings = createAction('setTreeLossSettings');
 
 const getTreeLoss = createThunkAction(
   'getTreeLoss',
   params => (dispatch, state) => {
     if (!state().widgetTreeLoss.isLoading) {
-      dispatch(setTreeLossIsLoading(true));
+      dispatch(setTreeLossLoading(true));
       axios
         .all([getLoss(params), getExtent(params)])
         .then(
           axios.spread((loss, extent) => {
             if (loss && extent) {
               dispatch(
-                setTreeLossValues({
+                setTreeLossData({
                   loss: loss.data.data,
                   startYear: minBy(loss.data.data, 'year').year,
                   endYear: maxBy(loss.data.data, 'year').year,
@@ -40,12 +29,12 @@ const getTreeLoss = createThunkAction(
                 })
               );
             } else {
-              dispatch(setTreeLossIsLoading(false));
+              dispatch(setTreeLossLoading(false));
             }
           })
         )
         .catch(error => {
-          dispatch(setTreeLossIsLoading(false));
+          dispatch(setTreeLossLoading(false));
           console.info(error);
         });
     }
@@ -53,13 +42,8 @@ const getTreeLoss = createThunkAction(
 );
 
 export default {
-  setWidgetConfigUrl,
-  setTreeLossValues,
+  setTreeLossData,
   setTreeLossSettings,
-  setTreeLossSettingsThreshold,
-  setTreeLossIsLoading,
-  setTreeLossSettingsStartYear,
-  setTreeLossSettingsEndYear,
-  setLayers,
+  setTreeLossLoading,
   getTreeLoss
 };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions.js
@@ -9,8 +9,8 @@ import { getExtent, getLoss } from 'services/forest-data';
 const setTreeLossIsLoading = createAction('setTreeLossIsLoading');
 
 const setTreeLossValues = createAction('setTreeLossValues');
-const setTreeLossSettingsIndicator = createAction(
-  'setTreeLossSettingsIndicator'
+const setTreeLossSettings = createAction(
+  'setTreeLossSettings'
 );
 const setTreeLossSettingsThreshold = createAction(
   'setTreeLossSettingsThreshold'
@@ -53,8 +53,9 @@ const getTreeLoss = createThunkAction(
 );
 
 export default {
+  setWidgetConfigUrl,
   setTreeLossValues,
-  setTreeLossSettingsIndicator,
+  setTreeLossSettings,
   setTreeLossSettingsThreshold,
   setTreeLossIsLoading,
   setTreeLossSettingsStartYear,

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-component.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import Loader from 'components/loader/loader';
 import NoContent from 'components/no-content';
-import WidgetHeader from 'pages/country/widget/components/widget-header';
 import WidgetBarChart from 'pages/country/widget/components/widget-bar-chart';
 import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
 
@@ -11,76 +10,49 @@ import './widget-tree-loss-styles.scss';
 
 class WidgetTreeLoss extends PureComponent {
   render() {
-    const {
-      loading,
-      data,
-      options,
-      settings,
-      config,
-      setWidgetSettingsUrl,
-      getSentence,
-      locationNames,
-      title,
-      anchorLink,
-      widget
-    } = this.props;
+    const { loading, data, getSentence, locationNames } = this.props;
 
     return (
-      <div className="c-widget c-widget-tree-loss">
-        <WidgetHeader
-          widget={widget}
-          title={title}
-          anchorLink={anchorLink}
-          locationNames={locationNames}
-          settingsConfig={{
-            loading,
-            config,
-            settings,
-            options,
-            onSettingsChange: setWidgetSettingsUrl
-          }}
-        />
-        <div className="container">
-          {loading && <Loader />}
-          {!loading &&
-            data &&
-            data.length === 0 && (
-              <NoContent
-                message={`No loss data for ${locationNames.current &&
-                  locationNames.current.label}`}
-                icon
+      <div className="c-widget-tree-loss">
+        {loading && <Loader />}
+        {!loading &&
+          data &&
+          data.length === 0 && (
+            <NoContent
+              message={`No loss data for ${locationNames.current &&
+                locationNames.current.label}`}
+              icon
+            />
+          )}
+        {data &&
+          data.length > 0 && (
+            <div className="data-container">
+              <WidgetDynamicSentence sentence={getSentence()} />
+              <WidgetBarChart
+                className="loss-chart"
+                data={data}
+                xKey="year"
+                yKey="area"
+                config={{
+                  color: '#fe6598',
+                  tooltip: [
+                    {
+                      key: 'year',
+                      unit: null
+                    },
+                    {
+                      key: 'area',
+                      unit: 'ha'
+                    },
+                    {
+                      key: 'percentage',
+                      unit: '%'
+                    }
+                  ]
+                }}
               />
-            )}
-          {data &&
-            data.length > 0 && (
-              <div className="data-container">
-                <WidgetDynamicSentence sentence={getSentence()} />
-                <WidgetBarChart
-                  className="loss-chart"
-                  data={data}
-                  xKey="year"
-                  yKey="area"
-                  config={{
-                    color: '#fe6598',
-                    tooltip: [
-                      {
-                        key: 'year',
-                        unit: null
-                      },
-                      {
-                        key: 'area',
-                        unit: 'ha'
-                      },
-                      {
-                        key: 'percentage',
-                        unit: '%'
-                      }
-                    ]
-                  }}
-                />
-              </div>
-            )}
-        </div>
+            </div>
+          )}
       </div>
     );
   }
@@ -89,15 +61,8 @@ class WidgetTreeLoss extends PureComponent {
 WidgetTreeLoss.propTypes = {
   loading: PropTypes.bool.isRequired,
   data: PropTypes.array.isRequired,
-  settings: PropTypes.object.isRequired,
-  options: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired,
   getSentence: PropTypes.func.isRequired,
-  locationNames: PropTypes.object,
-  title: PropTypes.string.isRequired,
-  anchorLink: PropTypes.string.isRequired,
-  widget: PropTypes.string.isRequired,
-  setWidgetSettingsUrl: PropTypes.func.isRequired
+  locationNames: PropTypes.object
 };
 
 export default WidgetTreeLoss;

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-component.js
@@ -12,22 +12,19 @@ import './widget-tree-loss-styles.scss';
 class WidgetTreeLoss extends PureComponent {
   render() {
     const {
-      isLoading,
+      loading,
       data,
       options,
       settings,
       config,
-      setWidgetConfigUrl,
-      setTreeLossSettingsThreshold,
-      setTreeLossSettingsStartYear,
-      setTreeLossSettingsEndYear,
+      setWidgetSettingsUrl,
       getSentence,
       locationNames,
       title,
       anchorLink,
       widget
     } = this.props;
-    
+
     return (
       <div className="c-widget c-widget-tree-loss">
         <WidgetHeader
@@ -36,21 +33,16 @@ class WidgetTreeLoss extends PureComponent {
           anchorLink={anchorLink}
           locationNames={locationNames}
           settingsConfig={{
-            isLoading,
+            loading,
             config,
             settings,
             options,
-            actions: {
-              onIndicatorChange: setWidgetConfigUrl,
-              onThresholdChange: setWidgetConfigUrl,
-              onStartYearChange: setTreeLossSettingsStartYear,
-              onEndYearChange: setTreeLossSettingsEndYear
-            }
+            onSettingsChange: setWidgetSettingsUrl
           }}
         />
         <div className="container">
-          {isLoading && <Loader />}
-          {!isLoading &&
+          {loading && <Loader />}
+          {!loading &&
             data &&
             data.length === 0 && (
               <NoContent
@@ -95,19 +87,17 @@ class WidgetTreeLoss extends PureComponent {
 }
 
 WidgetTreeLoss.propTypes = {
-  isLoading: PropTypes.bool.isRequired,
+  loading: PropTypes.bool.isRequired,
   data: PropTypes.array.isRequired,
   settings: PropTypes.object.isRequired,
   options: PropTypes.object.isRequired,
   config: PropTypes.object.isRequired,
-  setTreeLossSettingsThreshold: PropTypes.func.isRequired,
-  setTreeLossSettingsStartYear: PropTypes.func.isRequired,
-  setTreeLossSettingsEndYear: PropTypes.func.isRequired,
   getSentence: PropTypes.func.isRequired,
   locationNames: PropTypes.object,
   title: PropTypes.string.isRequired,
   anchorLink: PropTypes.string.isRequired,
-  widget: PropTypes.string.isRequired
+  widget: PropTypes.string.isRequired,
+  setWidgetSettingsUrl: PropTypes.func.isRequired
 };
 
 export default WidgetTreeLoss;

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-component.js
@@ -17,7 +17,7 @@ class WidgetTreeLoss extends PureComponent {
       options,
       settings,
       config,
-      setTreeLossSettingsIndicator,
+      setWidgetConfigUrl,
       setTreeLossSettingsThreshold,
       setTreeLossSettingsStartYear,
       setTreeLossSettingsEndYear,
@@ -27,7 +27,7 @@ class WidgetTreeLoss extends PureComponent {
       anchorLink,
       widget
     } = this.props;
-
+    
     return (
       <div className="c-widget c-widget-tree-loss">
         <WidgetHeader
@@ -41,8 +41,8 @@ class WidgetTreeLoss extends PureComponent {
             settings,
             options,
             actions: {
-              onIndicatorChange: setTreeLossSettingsIndicator,
-              onThresholdChange: setTreeLossSettingsThreshold,
+              onIndicatorChange: setWidgetConfigUrl,
+              onThresholdChange: setWidgetConfigUrl,
               onStartYearChange: setTreeLossSettingsStartYear,
               onEndYearChange: setTreeLossSettingsEndYear
             }
@@ -100,7 +100,6 @@ WidgetTreeLoss.propTypes = {
   settings: PropTypes.object.isRequired,
   options: PropTypes.object.isRequired,
   config: PropTypes.object.isRequired,
-  setTreeLossSettingsIndicator: PropTypes.func.isRequired,
   setTreeLossSettingsThreshold: PropTypes.func.isRequired,
   setTreeLossSettingsStartYear: PropTypes.func.isRequired,
   setTreeLossSettingsEndYear: PropTypes.func.isRequired,

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-reducers.js
@@ -9,7 +9,7 @@ export const initialState = {
   ...WIDGETS_CONFIG.treeLoss
 };
 
-const setTreeLossData = (state, { payload }) => ({
+export const setTreeLossData = (state, { payload }) => ({
   ...state,
   loading: false,
   data: {
@@ -23,7 +23,7 @@ const setTreeLossData = (state, { payload }) => ({
   }
 });
 
-const setTreeLossSettings = (state, { payload }) => ({
+export const setTreeLossSettings = (state, { payload }) => ({
   ...state,
   settings: {
     ...state.settings,
@@ -31,7 +31,7 @@ const setTreeLossSettings = (state, { payload }) => ({
   }
 });
 
-const setTreeLossLoading = (state, { payload }) => ({
+export const setTreeLossLoading = (state, { payload }) => ({
   ...state,
   loading: payload
 });

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-reducers.js
@@ -1,7 +1,7 @@
 import WIDGETS_CONFIG from 'pages/country/data/widgets-config.json';
 
 export const initialState = {
-  isLoading: false,
+  loading: false,
   data: {
     loss: [],
     extent: 0
@@ -9,9 +9,9 @@ export const initialState = {
   ...WIDGETS_CONFIG.treeLoss
 };
 
-const setTreeLossValues = (state, { payload }) => ({
+const setTreeLossData = (state, { payload }) => ({
   ...state,
-  isLoading: false,
+  loading: false,
   data: {
     loss: payload.loss,
     extent: payload.extent
@@ -31,40 +31,13 @@ const setTreeLossSettings = (state, { payload }) => ({
   }
 });
 
-const setTreeLossSettingsThreshold = (state, { payload }) => ({
+const setTreeLossLoading = (state, { payload }) => ({
   ...state,
-  settings: {
-    ...state.settings,
-    threshold: payload
-  }
-});
-
-const setTreeLossIsLoading = (state, { payload }) => ({
-  ...state,
-  isLoading: payload
-});
-
-const setTreeLossSettingsStartYear = (state, { payload }) => ({
-  ...state,
-  settings: {
-    ...state.settings,
-    startYear: payload
-  }
-});
-
-const setTreeLossSettingsEndYear = (state, { payload }) => ({
-  ...state,
-  settings: {
-    ...state.settings,
-    endYear: payload
-  }
+  loading: payload
 });
 
 export default {
-  setTreeLossValues,
+  setTreeLossData,
   setTreeLossSettings,
-  setTreeLossSettingsThreshold,
-  setTreeLossIsLoading,
-  setTreeLossSettingsStartYear,
-  setTreeLossSettingsEndYear
+  setTreeLossLoading
 };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-reducers.js
@@ -15,11 +15,6 @@ export const setTreeLossData = (state, { payload }) => ({
   data: {
     loss: payload.loss,
     extent: payload.extent
-  },
-  settings: {
-    ...state.settings,
-    startYear: payload.startYear,
-    endYear: payload.endYear
   }
 });
 

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-reducers.js
@@ -23,11 +23,11 @@ const setTreeLossValues = (state, { payload }) => ({
   }
 });
 
-const setTreeLossSettingsIndicator = (state, { payload }) => ({
+const setTreeLossSettings = (state, { payload }) => ({
   ...state,
   settings: {
     ...state.settings,
-    indicator: payload
+    ...payload
   }
 });
 
@@ -62,7 +62,7 @@ const setTreeLossSettingsEndYear = (state, { payload }) => ({
 
 export default {
   setTreeLossValues,
-  setTreeLossSettingsIndicator,
+  setTreeLossSettings,
   setTreeLossSettingsThreshold,
   setTreeLossIsLoading,
   setTreeLossSettingsStartYear,

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss.js
@@ -43,7 +43,8 @@ class WidgetTreeLossContainer extends PureComponent {
   getSentence = () => {
     const { locationNames, settings, data, extent } = this.props;
     const { indicators } = this.props.options;
-    const indicator = getActiveFilter(settings, indicators, 'indicator');
+    const indicator =
+      indicators && getActiveFilter(settings, indicators, 'indicator');
     const totalLoss = (data && data.length && sumBy(data, 'area')) || 0;
     const totalEmissions =
       (data && data.length && sumBy(data, 'emissions')) || 0;

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss.js
@@ -13,6 +13,7 @@ import { filterData } from './widget-tree-loss-selectors';
 import WidgetTreeLossComponent from './widget-tree-loss-component';
 
 const mapStateToProps = ({ widgetTreeLoss }) => ({
+  loading: widgetTreeLoss.loading,
   data:
     filterData({
       data: widgetTreeLoss.data,

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { format } from 'd3-format';
 import isEqual from 'lodash/isEqual';
 import sumBy from 'lodash/sumBy';
-import { setWidgetSettingsUrl } from 'pages/country/widget/widget-actions';
 
 import {
   getThresholds,
@@ -14,16 +13,11 @@ import {
   getAdminsSelected,
   getActiveFilter
 } from 'pages/country/widget/widget-selectors';
+
+import actions from './widget-tree-loss-actions';
+import reducers, { initialState } from './widget-tree-loss-reducers';
 import { filterData } from './widget-tree-loss-selectors';
-
 import WidgetTreeLossComponent from './widget-tree-loss-component';
-import ownActions from './widget-tree-loss-actions';
-
-const actions = { setWidgetSettingsUrl, ...ownActions };
-
-export { initialState } from './widget-tree-loss-reducers';
-export { default as reducers } from './widget-tree-loss-reducers';
-export { default as actions } from './widget-tree-loss-actions';
 
 const mapStateToProps = ({ widgetTreeLoss, location, countryData }) => ({
   title: widgetTreeLoss.title,
@@ -131,5 +125,7 @@ WidgetTreeLossContainer.propTypes = {
   data: PropTypes.array.isRequired,
   extent: PropTypes.number.isRequired
 };
+
+export { actions, reducers, initialState };
 
 export default connect(mapStateToProps, actions)(WidgetTreeLossContainer);

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss.js
@@ -5,56 +5,20 @@ import { format } from 'd3-format';
 import isEqual from 'lodash/isEqual';
 import sumBy from 'lodash/sumBy';
 
-import {
-  getThresholds,
-  getIndicators,
-  getStartYears,
-  getEndYears,
-  getAdminsSelected,
-  getActiveFilter
-} from 'pages/country/widget/widget-selectors';
+import { getActiveFilter } from 'pages/country/widget/widget-selectors';
 
 import actions from './widget-tree-loss-actions';
 import reducers, { initialState } from './widget-tree-loss-reducers';
 import { filterData } from './widget-tree-loss-selectors';
 import WidgetTreeLossComponent from './widget-tree-loss-component';
 
-const mapStateToProps = ({ widgetTreeLoss, location, countryData }) => ({
-  title: widgetTreeLoss.title,
-  anchorLink: widgetTreeLoss.anchorLink,
-  loading: widgetTreeLoss.loading,
-  location: location.payload,
+const mapStateToProps = ({ widgetTreeLoss }) => ({
   data:
     filterData({
       data: widgetTreeLoss.data,
       ...widgetTreeLoss.settings
     }) || [],
-  extent: widgetTreeLoss.data.extent,
-  options: {
-    startYears:
-      getStartYears({
-        data: widgetTreeLoss.data.loss,
-        ...widgetTreeLoss.settings
-      }) || [],
-    endYears:
-      getEndYears({
-        data: widgetTreeLoss.data.loss,
-        ...widgetTreeLoss.settings
-      }) || [],
-    indicators:
-      getIndicators({
-        whitelist: widgetTreeLoss.config.indicators,
-        location: location.payload,
-        ...countryData
-      }) || [],
-    thresholds: getThresholds()
-  },
-  settings: widgetTreeLoss.settings,
-  config: widgetTreeLoss.config,
-  locationNames: getAdminsSelected({
-    ...countryData,
-    location: location.payload
-  })
+  extent: widgetTreeLoss.data.extent
 });
 
 class WidgetTreeLossContainer extends PureComponent {

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { format } from 'd3-format';
 import isEqual from 'lodash/isEqual';
 import sumBy from 'lodash/sumBy';
+import widgetActions from 'pages/country/widget/widget-actions';
+console.log(widgetActions)
 
 import {
   getThresholds,
@@ -16,7 +18,9 @@ import {
 import { filterData } from './widget-tree-loss-selectors';
 
 import WidgetTreeLossComponent from './widget-tree-loss-component';
-import actions from './widget-tree-loss-actions';
+import ownActions from './widget-tree-loss-actions';
+
+const actions = { ...widgetActions, ...ownActions };
 
 export { initialState } from './widget-tree-loss-reducers';
 export { default as reducers } from './widget-tree-loss-reducers';

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss.js
@@ -4,8 +4,7 @@ import PropTypes from 'prop-types';
 import { format } from 'd3-format';
 import isEqual from 'lodash/isEqual';
 import sumBy from 'lodash/sumBy';
-import widgetActions from 'pages/country/widget/widget-actions';
-console.log(widgetActions)
+import { setWidgetSettingsUrl } from 'pages/country/widget/widget-actions';
 
 import {
   getThresholds,
@@ -20,7 +19,7 @@ import { filterData } from './widget-tree-loss-selectors';
 import WidgetTreeLossComponent from './widget-tree-loss-component';
 import ownActions from './widget-tree-loss-actions';
 
-const actions = { ...widgetActions, ...ownActions };
+const actions = { setWidgetSettingsUrl, ...ownActions };
 
 export { initialState } from './widget-tree-loss-reducers';
 export { default as reducers } from './widget-tree-loss-reducers';
@@ -29,7 +28,7 @@ export { default as actions } from './widget-tree-loss-actions';
 const mapStateToProps = ({ widgetTreeLoss, location, countryData }) => ({
   title: widgetTreeLoss.title,
   anchorLink: widgetTreeLoss.anchorLink,
-  isLoading: widgetTreeLoss.isLoading,
+  loading: widgetTreeLoss.loading,
   location: location.payload,
   data:
     filterData({
@@ -115,14 +114,9 @@ class WidgetTreeLossContainer extends PureComponent {
      with canopy density <span>> ${settings.threshold}%</span>.`;
   };
 
-  viewOnMap = () => {
-    this.props.setLayers(['loss']);
-  };
-
   render() {
     return createElement(WidgetTreeLossComponent, {
       ...this.props,
-      viewOnMap: this.viewOnMap,
       getSentence: this.getSentence
     });
   }
@@ -134,7 +128,6 @@ WidgetTreeLossContainer.propTypes = {
   settings: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
   getTreeLoss: PropTypes.func.isRequired,
-  setLayers: PropTypes.func.isRequired,
   data: PropTypes.array.isRequired,
   extent: PropTypes.number.isRequired
 };

--- a/app/javascript/pages/sgf/section-projects/section-projects-component.jsx
+++ b/app/javascript/pages/sgf/section-projects/section-projects-component.jsx
@@ -59,7 +59,7 @@ class SectionProjects extends PureComponent {
           </div>
           <div className="row">
             <div className="column small-12 large-7">
-              <div className="row">
+              <div className="row project-cards">
                 {hasData ? (
                   data.map(d => (
                     <div key={d.id} className="column small-12 medium-6">

--- a/app/javascript/pages/sgf/section-projects/section-projects-styles.scss
+++ b/app/javascript/pages/sgf/section-projects/section-projects-styles.scss
@@ -21,6 +21,11 @@
     margin-bottom: rem(30px);
   }
 
+  .project-cards {
+    position: relative;
+    min-height: rem(100px);
+  }
+
   .project-card {
     margin-bottom: rem(20px);
 

--- a/app/javascript/styles/themes/dropdown/dropdown-button.scss
+++ b/app/javascript/styles/themes/dropdown/dropdown-button.scss
@@ -5,6 +5,12 @@
     display: none;
   }
 
+  .dd__selected {
+    display: flex;
+    justify-content: center;
+    align-content: center;
+  }
+
   .dd__selectControl {
     height: rem(27px);
     padding: 0 rem(21px);
@@ -20,6 +26,7 @@
     font-size: rem(13px);
     letter-spacing: 0.1px;
     color: $green-gfw;
+    text-align: center;
   }
 
   .dd__list {
@@ -31,6 +38,9 @@
 
   .dd__option {
     color: rgba($slate, 0.6);
+    display: flex;
+    justify-content: center;
+    align-content: center;
 
     &:hover {
       background-color: $white;

--- a/app/javascript/styles/themes/subnav/subnav-dark.scss
+++ b/app/javascript/styles/themes/subnav/subnav-dark.scss
@@ -15,8 +15,7 @@ $subnav-height-dark: rem(40px);
       max-width: 100%;
       width: auto;
 
-      > a,
-      button {
+      > a {
         background-color: $black-menu;
         color: #9f9f9f;
         text-transform: uppercase;

--- a/app/javascript/utils/stateToUrl.js
+++ b/app/javascript/utils/stateToUrl.js
@@ -1,0 +1,7 @@
+export function encodeStateForUrl(obj) {
+  return btoa(JSON.stringify(obj));
+}
+
+export function decodeUrlForState(string) {
+  return JSON.parse(atob(string));
+}

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "postcss-loader": "^2.0.6",
     "postcss-smart-import": "^0.7.5",
     "precss": "^2.0.0",
+    "query-string": "^5.0.1",
     "rails-erb-loader": "^5.1.0",
     "raw-loader": "^0.5.1",
     "react": "^15.6.1",


### PR DESCRIPTION
## Overview

A rather belated and well needed refactor and feature addition to the widgets and their fancy pants headers. 

Firstly, the feature we needed was to store all the different widget settings in the URL. We needed this for two reasons:
- So you can share the current state of the page after you have filtered the widgets to your wishes
- To set embedded widgets with the settings of the widget at the point it was selected to be embedded.

So the main feature of this PR does the following:
- When a user changes the state of a widget a hash against the widgets key is stored in the URL
- This URL is then decoded and passed to a single action for that widget which updates its settings in the store. Simple!
- Only store changes to those widgets that need it, keeping URL to a minimum
- Base64 the state for even more compressed data transfer
- Update the share modal to find the specific embed key and add it to the iFrame

This means that each widget lives truly independently now :).

As a side effect of this excellent feature I discovered that the widget creation process, and therefore the header and settings data flow could be simplified greatly. I did the following:
- Move the <WidgetHeader /> component to the global <Widget /> component so it isn't included in each widget -> DRY as baking tray at 200degC. 
- Update the header component to handle a single action and function for updating the URL
- Update the <Widget /> component to get all the necessary selector data (Units, Indicators, Thresholds...) only if required by that widget.
- Update the Widgets Config JSON file to handle these requirements

tldr; Widgets are DOPE and the do DOPE THINGS. Now they DOPE [even] more with less NOPE.

## Demo

Visually no change. It's a 'you have to be there sort of thing'...

## Notes

This was hard. Most notably because there aren't any visuals.

## Testing

If you can break it, I will ship you a thank you card.
