### PR TITLE
Fixes incorrect date ranges in Analysis

### DIFF
--- a/app/assets/javascripts/map/presenters/tabs/AnalysisNewPresenter.js
+++ b/app/assets/javascripts/map/presenters/tabs/AnalysisNewPresenter.js
@@ -457,6 +457,19 @@ define([
         }
       },
       {
+        'Torque/date-range-change': function(date) {
+          var dateFormat = 'YYYY-MM-DD';
+          var date = date.map(function(date) {
+            return moment(date).format(dateFormat);
+          });
+
+          this.status.set({
+            begin: date[0],
+            end: date[1]
+          });
+        }
+      },
+      {
         'Timeline/start-playing': function() {
           this.status.set('enabledUpdating', false);
         }


### PR DESCRIPTION
## Overview

Fixes mismatching date range between the analysis window and the timeline widget on load and when toggling between layers (see: [Basecamp Thread](https://basecamp.com/3063126/projects/10728552/todos/336207167#comment_589219492)).

Affected Analyses: 'Terra-i' and 'Forma'

<img width="1247" alt="screen shot 2018-01-09 at 17 16 50" src="https://user-images.githubusercontent.com/30242314/34731175-d9cd603a-f561-11e7-9a57-c4481087e0a7.png">

