### PR TITLE
Mangrove (2000) layer style change

### DIFF
--- a/app/assets/javascripts/map/cartocss/style.cartocss
+++ b/app/assets/javascripts/map/cartocss/style.cartocss
@@ -529,9 +529,9 @@
   }
 
   [layer='global_mangroves'] {
-      polygon-fill: #05ffaa;
+      polygon-fill: #06ef9f;
       polygon-opacity: 0.7;
-      line-color: #05ffaa;
+      line-color: #06ef9f;
       line-width: 1;
       line-opacity: 1;
   }


### PR DESCRIPTION
Changed the colour of the Mangrove (2000) layer to match the style change of the new Mangrove layer.

* Updated Carto table too 
* Color change from #05ffaa to  #06ef9f

![screen shot 2018-01-10 at 09 58 40](https://user-images.githubusercontent.com/6503031/34763900-050a0844-f5ed-11e7-8262-9c6ea38df1b5.png)
