### PR TITLE
Include info button on places to watch legend

### DIFF
--- a/app/assets/javascripts/map/templates/layersNav.handlebars
+++ b/app/assets/javascripts/map/templates/layersNav.handlebars
@@ -12,10 +12,9 @@
         <ul class="layers-list scroll-thin-dark">
           <div class="layer-group">
             <span class="group-name">Deforestation alerts <em>(near real-time)</em></span>
-            <li class="layer" data-layer="umd_as_it_happens">
+            <li class="layer" data-layer="umd_as_it_happens" data-open-with-sublayer="places_to_watch">
               <span class="onoffradio"><span></span></span>
               <span class="layer-title">GLAD alerts<a href='#' data-source='umd_landsat_alerts' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
-
               <span class="layer-info">(weekly, 30m, select countries, UMD/GLAD)
               </span>
             </li>

--- a/app/assets/javascripts/map/templates/legend/glad.handlebars
+++ b/app/assets/javascripts/map/templates/legend/glad.handlebars
@@ -5,7 +5,11 @@
 </div>
 <div data-autotoggle="true" data-sublayer="places_to_watch" data-parent="umd_as_it_happens" class="layer-sublayer js-toggle-sublayer">
   <span class="onoffswitch" style="background-color:#f69;"><span></span></span>
-  <div class="sublayer-title">Places to Watch</div>
+  <div class="sublayer-title">Places to watch
+    <a href="#" data-source="places_to_watch" class="source source-shape-info js-tooltip" data-description="High-priority alerts from last month">
+      <svg class="icon-info-green -source"><use xlink:href="#shape-info"></use></svg>
+    </a>
+  </div>
   <div class="layer-details layer-details-places-to-watch">
     <p class="canopy">To receive monthly email updates</p>
     <p class="canopy"><a href="http://connect.wri.org/l/120942/2017-12-07/3mtt5w" target="_blank">Sign up for the PTW newsletter ➤</a></p>


### PR DESCRIPTION
## Overview

This PR attempts to solve BC threads [here](https://basecamp.com/3063126/projects/10726176/todos/335091623)  and [here](https://basecamp.com/3063126/projects/10726176/todos/335169764). 

The info button has been added to the PTW layer. But we are still missing the layer being turned on by default when a user selects GLAD Alerts.

![screen shot 2018-01-15 at 12 38 34](https://user-images.githubusercontent.com/6503031/34940776-3336b232-f9f1-11e7-8743-cd4b91569642.png)
