### PR TITLE
Adds analysis capability to Tree Cover 2010 layer

### DIFF
--- a/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
+++ b/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
@@ -132,10 +132,10 @@ define([
       if (p.slug === 'umd-loss-gain') {
         var results = (type == 'country') ? results.total : results;
         p.areaHa = this.roundNumber(results.areaHa || 0);
-
         p.alerts.totalAlerts = this.roundNumber(results.loss || 0);
         p.alerts.gainAlerts = this.roundNumber(results.gain || 0);
         p.alerts.treeExtent = this.roundNumber(results.treeExtent || 0);
+        p.alerts.treeExtent2010 = this.roundNumber(results.treeExtent2010 || 0);
 
         // Dates
         p.dates.lossDateRange = '{0}-{1}'.format(dateRange[0].year(), dateRange[1].year()-1);
@@ -190,11 +190,10 @@ define([
         return (value < 10 && value % 1 != 0) ? value.toFixed(2).toLocaleString() : (~~value).toLocaleString();
       }
       return 0;
-    },
+    }
 
 
   });
 
   return AnalysisResultsPresenter;
-
 });

--- a/app/assets/javascripts/map/presenters/analysis/AnalysisResultsPresenter.js
+++ b/app/assets/javascripts/map/presenters/analysis/AnalysisResultsPresenter.js
@@ -45,6 +45,7 @@ define([
       'prodes': 'prodes-loss',
       'guyra': 'guira-loss',
       'forest2000': 'umd-loss-gain',
+      'forest2010': 'umd-loss-gain',
       'umd_as_it_happens':'glad-alerts',
       'umd_as_it_happens_per':'glad-alerts',
       'umd_as_it_happens_cog':'glad-alerts',
@@ -297,7 +298,7 @@ define([
        *   - gainAlerts
        *   - extent
        */
-      if (layer.slug === 'loss' || layer.slug === 'forestgain' || layer.slug === 'forestgain' || layer.slug === 'forest2000') {
+      if (layer.slug === 'loss' || layer.slug === 'forestgain' || layer.slug === 'forestgain' || layer.slug === 'forest2000' || layer.slug === 'forest2010') {
         p.lossDateRange = '{0}-{1}'.format(dateRange[0].year(), dateRange[1].year()-1);
         p.extent = p.gainAlerts = p.lossAlerts = 0;
         p.threshold  = results.params.thresh || 30;

--- a/app/assets/javascripts/map/presenters/tabs/AnalysisNewPresenter.js
+++ b/app/assets/javascripts/map/presenters/tabs/AnalysisNewPresenter.js
@@ -124,6 +124,9 @@ define([
         name: 'forest2000',
         slug: 'umd-loss-gain'
       },{
+        name: 'forest2010',
+        slug: 'umd-loss-gain'
+      },{
         name: 'forma_month_3',
         slug: 'forma250GFW',
         subscription: true

--- a/app/assets/javascripts/map/templates/analysis/analysis-results.handlebars
+++ b/app/assets/javascripts/map/templates/analysis/analysis-results.handlebars
@@ -48,6 +48,13 @@
       </li>
       {{/if}}
 
+      {{#if resource.baselayers.forest2010}}
+      <li>
+        <span class="stats-title">Tree cover (2010)<span class="stats-threshold" title="Click the gear icon located on the map to change the tree cover canopy density">with >{{resource.options.threshold}}% <a href="#" class="btn-analysis-canopy">canopy density</a></span></span>
+        <span class="stats-count" style="color: {{resource.baselayers.forest2010.title_color}};"><strong>{{resource.alerts.treeExtent2010}}</strong> ha</span>
+      </li>
+      {{/if}}
+
       <li>
         <div class="stats-notice">This algorithm approximates the results by sampling the selected area. Results are more accurate at closer zoom levels.</div>
       </li>


### PR DESCRIPTION
## Overview

Adds the ability to analyse the 2010 Tree Cover layer using the new staging api as requested [here](https://basecamp.com/3063126/projects/10726176/todos/287938139#comment_590680218).

![screen shot 2018-01-15 at 13 51 31](https://user-images.githubusercontent.com/30242314/34943276-4cd62e7a-f9fb-11e7-8cb6-82249d68ed1e.png)

## Testing

When testing be sure to use the staging api **not production**!

e.g. ```https://staging-api.globalforestwatch.org/v1/umd-loss-gain?geostore=cea8c6...```
