### PR TITLE
Feature/forests located update

### DIFF
--- a/app/javascript/pages/country/data/colors.json
+++ b/app/javascript/pages/country/data/colors.json
@@ -2,5 +2,6 @@
   "darkGreen": "#1e5a00",
   "mediumGreen": "#2d8700",
   "lightGreen": "#959a00",
-  "nonForest": "#E2CF96"
+  "nonForest": "#E2CF96",
+  "grey": "#d9d9dc"
 }

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -15,7 +15,7 @@
       "threshold": 30,
       "extentYear": 2000
     },
-    "active": true
+    "active": false
   },
   "treeLocated": {
     "title": "Where are the forests located",
@@ -63,7 +63,7 @@
       "endYear": 2016,
       "extentYear": 2010
     },
-    "active": true
+    "active": false
   },
   "treeGain": {
     "title": "Tree cover gain",

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -28,13 +28,14 @@
                       "plantations__wdpa", "plantations__landmark"],
       "categories": ["summary", "land-cover"],
       "admins": ["country", "region"],
-      "selectors": ["indicators", "thresholds", "units"],
+      "selectors": ["indicators", "thresholds", "units", "extentYears"],
       "locationCheck": true,
       "type": "extent"
     },
     "settings": {
       "indicator": "gadm28",
       "threshold": 30,
+      "extentYear": 2010,
       "unit": "ha",
       "pageSize": 10,
       "page": 0

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -20,7 +20,7 @@
   "treeLocated": {
     "title": "Where are the forests located",
     "config": {
-      "gridWidth": 6,
+      "gridWidth": 12,
       "indicators": ["gadm28", "ifl_2013", "wdpa",
                       "ifl_2013__wdpa", "ifl_2013__mining",
                       "primary_forest", "primary_forest__landmark",

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -15,7 +15,7 @@
       "threshold": 30,
       "extentYear": 2000
     },
-    "active": false
+    "active": true
   },
   "treeLocated": {
     "title": "Where are the forests located",
@@ -63,7 +63,7 @@
       "endYear": 2016,
       "extentYear": 2010
     },
-    "active": false
+    "active": true
   },
   "treeGain": {
     "title": "Tree cover gain",

--- a/app/javascript/pages/country/widget/components/widget-chart-tooltip/widget-chart-tooltip-component.js
+++ b/app/javascript/pages/country/widget/components/widget-chart-tooltip/widget-chart-tooltip-component.js
@@ -13,7 +13,7 @@ class WidgetChartTooltip extends PureComponent {
       <div className="c-widget-chart-tooltip">
         {settings.map(d => (
           <div key={d.key} className="data-line">
-            {d.label && <span className="label">{values.name}</span>}
+            {d.label && <span className="label">{values.label}</span>}
             {d.unit
               ? format(d.unit === '%' ? '.1f' : '.3s')(values[d.key])
               : values[d.key]}

--- a/app/javascript/pages/country/widget/components/widget-chart-tooltip/widget-chart-tooltip-styles.scss
+++ b/app/javascript/pages/country/widget/components/widget-chart-tooltip/widget-chart-tooltip-styles.scss
@@ -5,6 +5,7 @@
   box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.19);
   background-color: $slate;
   color: $white;
+  border-radius: rem(2px);
 
   .data-line {
     display: block;

--- a/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-component.jsx
@@ -42,7 +42,7 @@ class WidgetNumberedList extends PureComponent {
                     <div className="item-name">{item.label}</div>
                   </div>
                   <div className="item-value">
-                    {format('.3s')(item.value)}
+                    {format(item.value < 1 ? '.2f' : '.3s')(item.value)}
                     {unit}
                   </div>
                 </Link>

--- a/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-styles.scss
+++ b/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-styles.scss
@@ -16,10 +16,9 @@
     color: $slate;
 
     &:hover {
-      text-decoration: underline;
-
-      .item-bubble {
-        text-decoration: none;
+      .item-name,
+      .item-value {
+        text-decoration: underline;
       }
     }
   }

--- a/app/javascript/pages/country/widget/components/widget-pie-chart-legend/widget-pie-chart-legend-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-pie-chart-legend/widget-pie-chart-legend-component.jsx
@@ -14,7 +14,7 @@ class WidgetPieChartLegend extends PureComponent {
           <li key={index.toString()}>
             <div className="legend-title">
               <span style={{ backgroundColor: item.color }}>{}</span>
-              {item.name}
+              {item.label}
             </div>
             <div className="legend-value" style={{ color: item.color }}>
               {format(config.format)(item[config.key])}

--- a/app/javascript/pages/country/widget/components/widget-pie-chart-legend/widget-pie-chart-legend-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-pie-chart-legend/widget-pie-chart-legend-component.jsx
@@ -14,7 +14,7 @@ class WidgetPieChartLegend extends PureComponent {
           <li key={index.toString()}>
             <div className="legend-title">
               <span style={{ backgroundColor: item.color }}>{}</span>
-              {item.label}
+              <p>{item.label}</p>
             </div>
             <div className="legend-value" style={{ color: item.color }}>
               {format(config.format)(item[config.key])}

--- a/app/javascript/pages/country/widget/components/widget-pie-chart-legend/widget-pie-chart-legend-styles.scss
+++ b/app/javascript/pages/country/widget/components/widget-pie-chart-legend/widget-pie-chart-legend-styles.scss
@@ -8,10 +8,11 @@
     font-size: rem(12px);
     line-height: 1;
     color: $slate;
+    position: relative;
 
     span {
-      position: relative;
-      top: rem(1px);
+      position: absolute;
+      top: 0;
       display: inline-block;
       width: rem(12px);
       min-width: rem(12px);
@@ -20,10 +21,17 @@
       margin-right: rem(7px);
       border-radius: 100%;
     }
+
+    p {
+      color: $slate;
+      font-size: rem(12px);
+      margin-left: rem(20px);
+      line-height: 1.4;
+    }
   }
 
   .legend-value {
-    padding: rem(7px) 0 0 rem(19px);
+    padding: rem(5px) 0 0 rem(20px);
     font-size: rem(28px);
     font-weight: 500;
     margin-bottom: rem(20px);

--- a/app/javascript/pages/country/widget/components/widget-pie-chart/widget-pie-chart-component.js
+++ b/app/javascript/pages/country/widget/components/widget-pie-chart/widget-pie-chart-component.js
@@ -34,7 +34,8 @@ class WidgetPieChart extends PureComponent {
                 <Cell
                   key={index.toString()}
                   fill={item.color}
-                  strokeWidth={0}
+                  // strokeWidth={0}
+                  stroke={item.color}
                 />
               ))}
             </Pie>

--- a/app/javascript/pages/country/widget/components/widget-pie-chart/widget-pie-chart-component.js
+++ b/app/javascript/pages/country/widget/components/widget-pie-chart/widget-pie-chart-component.js
@@ -9,7 +9,7 @@ class WidgetPieChart extends PureComponent {
   render() {
     const {
       data,
-      height,
+      maxSize,
       dataKey,
       innerRadius,
       outerRadius,
@@ -20,7 +20,7 @@ class WidgetPieChart extends PureComponent {
 
     return (
       <div className={`c-pie-chart ${className}`}>
-        <ResponsiveContainer width="100%" height={height}>
+        <ResponsiveContainer width="100%" height={maxSize}>
           <PieChart>
             <Pie
               data={data}
@@ -31,7 +31,11 @@ class WidgetPieChart extends PureComponent {
               endAngle={endAngle}
             >
               {data.map((item, index) => (
-                <Cell key={index.toString()} fill={item.color} strokeWidth={0} />
+                <Cell
+                  key={index.toString()}
+                  fill={item.color}
+                  strokeWidth={0}
+                />
               ))}
             </Pie>
             <Tooltip
@@ -56,20 +60,17 @@ class WidgetPieChart extends PureComponent {
 
 WidgetPieChart.propTypes = {
   data: PropTypes.array,
-  width: PropTypes.number,
-  height: PropTypes.number,
+  maxSize: PropTypes.number,
   dataKey: PropTypes.string,
-  cx: PropTypes.number,
-  cy: PropTypes.number,
-  innerRadius: PropTypes.number,
-  outerRadius: PropTypes.number,
+  innerRadius: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  outerRadius: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   startAngle: PropTypes.number,
   endAngle: PropTypes.number,
   className: PropTypes.string
 };
 
 WidgetPieChart.defaultProps = {
-  height: 300,
+  maxSize: 300,
   dataKey: 'value',
   innerRadius: '50%',
   outerRadius: '100%',

--- a/app/javascript/pages/country/widget/components/widget-pie-chart/widget-pie-chart-component.js
+++ b/app/javascript/pages/country/widget/components/widget-pie-chart/widget-pie-chart-component.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { PieChart, Pie, Cell, Tooltip } from 'recharts';
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
 import WidgetChartToolTip from 'pages/country/widget/components/widget-chart-tooltip';
 
 import './widget-pie-chart-styles.scss';
@@ -9,11 +9,8 @@ class WidgetPieChart extends PureComponent {
   render() {
     const {
       data,
-      width,
       height,
       dataKey,
-      cx,
-      cy,
       innerRadius,
       outerRadius,
       startAngle,
@@ -23,35 +20,35 @@ class WidgetPieChart extends PureComponent {
 
     return (
       <div className={`c-pie-chart ${className}`}>
-        <PieChart width={width} height={height}>
-          <Pie
-            data={data}
-            dataKey={dataKey}
-            cx={cx}
-            cy={cy}
-            innerRadius={innerRadius}
-            outerRadius={outerRadius}
-            startAngle={startAngle}
-            endAngle={endAngle}
-          >
-            {data.map((item, index) => (
-              <Cell key={index.toString()} fill={item.color} strokeWidth={0} />
-            ))}
-          </Pie>
-          <Tooltip
-            content={
-              <WidgetChartToolTip
-                settings={[
-                  {
-                    key: 'percentage',
-                    unit: '%',
-                    label: true
-                  }
-                ]}
-              />
-            }
-          />
-        </PieChart>
+        <ResponsiveContainer width="100%" height={height}>
+          <PieChart>
+            <Pie
+              data={data}
+              dataKey={dataKey}
+              innerRadius={innerRadius}
+              outerRadius={outerRadius}
+              startAngle={startAngle}
+              endAngle={endAngle}
+            >
+              {data.map((item, index) => (
+                <Cell key={index.toString()} fill={item.color} strokeWidth={0} />
+              ))}
+            </Pie>
+            <Tooltip
+              content={
+                <WidgetChartToolTip
+                  settings={[
+                    {
+                      key: 'percentage',
+                      unit: '%',
+                      label: true
+                    }
+                  ]}
+                />
+              }
+            />
+          </PieChart>
+        </ResponsiveContainer>
       </div>
     );
   }
@@ -72,13 +69,10 @@ WidgetPieChart.propTypes = {
 };
 
 WidgetPieChart.defaultProps = {
-  width: 123,
-  height: 123,
+  height: 300,
   dataKey: 'value',
-  cx: 56,
-  cy: 56,
-  innerRadius: 28,
-  outerRadius: 60,
+  innerRadius: '50%',
+  outerRadius: '100%',
   startAngle: 90,
   endAngle: 450
 };

--- a/app/javascript/pages/country/widget/components/widget-pie-chart/widget-pie-chart-styles.scss
+++ b/app/javascript/pages/country/widget/components/widget-pie-chart/widget-pie-chart-styles.scss
@@ -2,6 +2,7 @@
 
 .c-pie-chart {
   height: 100%;
+  width: 100%;
 
   .recharts-wrapper {
     display: inline-block;

--- a/app/javascript/pages/country/widget/components/widget-pie-chart/widget-pie-chart-styles.scss
+++ b/app/javascript/pages/country/widget/components/widget-pie-chart/widget-pie-chart-styles.scss
@@ -1,6 +1,8 @@
 @import '~styles/settings.scss';
 
 .c-pie-chart {
+  height: 100%;
+
   .recharts-wrapper {
     display: inline-block;
   }

--- a/app/javascript/pages/country/widget/widget-component.jsx
+++ b/app/javascript/pages/country/widget/widget-component.jsx
@@ -58,7 +58,7 @@ class Widget extends PureComponent {
           embed={embed}
         />
         <div className="container">
-          {!loading &&
+          {!loading && !error &&
             isEmpty(data) && (
               <NoContent
                 message={`No data in selection for ${locationNames.current &&

--- a/app/javascript/pages/country/widget/widget-selectors.js
+++ b/app/javascript/pages/country/widget/widget-selectors.js
@@ -30,7 +30,7 @@ export const getActiveAdmin = location => {
 
 // helper to get active filter from state based on key
 export const getActiveFilter = (settings, filters, key) =>
-  filters.find(i => i.value === settings[key]);
+  (filters ? filters.find(i => i.value === settings[key]) : null);
 
 export const getLocationLabel = (location, indicator, indicators) => {
   if (!location || !indicators || !indicators.length) return '';

--- a/app/javascript/pages/country/widget/widget.js
+++ b/app/javascript/pages/country/widget/widget.js
@@ -64,6 +64,11 @@ const mapStateToProps = (state, ownProps) => {
     activeLocation: widgetSelectors.getActiveAdmin({
       location: location.payload
     }),
+    activeIndicator: widgetSelectors.getActiveFilter(
+      settings,
+      options.indicators,
+      'indicator'
+    ),
     location: location.payload,
     title,
     loading,

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-component.js
@@ -4,26 +4,15 @@ import PropTypes from 'prop-types';
 import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
 import WidgetPieChart from 'pages/country/widget/components/widget-pie-chart';
 import WidgetPieChartLegend from 'pages/country/widget/components/widget-pie-chart-legend';
-import NoContent from 'components/no-content';
 import './widget-fao-cover-styles.scss';
 
 class WidgetFAOCover extends PureComponent {
   render() {
-    const { locationNames, loading, data, getSentence } = this.props;
+    const { data, getSentence } = this.props;
 
     return (
       <div className="c-widget-fao-cover">
-        {!loading &&
-          data &&
-          data.length === 0 && (
-            <NoContent
-              message={`No forest cover for ${locationNames.current &&
-                locationNames.current.label}`}
-              icon
-            />
-          )}
-        {!loading &&
-          data &&
+        {data &&
           data.length > 0 && (
             <div>
               <WidgetDynamicSentence sentence={getSentence()} />
@@ -37,7 +26,11 @@ class WidgetFAOCover extends PureComponent {
                     key: 'percentage'
                   }}
                 />
-                <WidgetPieChart className="cover-pie-chart" data={data} />
+                <WidgetPieChart
+                  className="cover-pie-chart"
+                  data={data}
+                  maxSize={140}
+                />
               </div>
             </div>
           )}
@@ -47,8 +40,6 @@ class WidgetFAOCover extends PureComponent {
 }
 
 WidgetFAOCover.propTypes = {
-  locationNames: PropTypes.object.isRequired,
-  loading: PropTypes.bool.isRequired,
   data: PropTypes.array.isRequired,
   getSentence: PropTypes.func.isRequired
 };

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-selectors.js
@@ -31,25 +31,25 @@ export const getFAOCoverData = createSelector(
       naturallyRegenerated + primaryForest + plantedForest + area_ha;
     return [
       {
-        name: 'Naturally regenerated Forest',
+        label: 'Naturally regenerated Forest',
         value: naturallyRegenerated,
         percentage: naturallyRegenerated / total * 100,
         color: COLORS.darkGreen
       },
       {
-        name: 'Primary Forest',
+        label: 'Primary Forest',
         value: primaryForest,
         percentage: primaryForest / total * 100,
         color: COLORS.mediumGreen
       },
       {
-        name: 'Planted Forest',
+        label: 'Planted Forest',
         value: plantedForest,
         percentage: plantedForest / total * 100,
         color: COLORS.lightGreen
       },
       {
-        name: 'Non-Forest',
+        label: 'Non-Forest',
         value: nonForest,
         percentage: nonForest / total * 100,
         color: COLORS.nonForest

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-styles.scss
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-styles.scss
@@ -7,6 +7,6 @@
   }
 
   .pie-chart-legend {
-    width: auto;
+    min-width: 50%;
   }
 }

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover.js
@@ -12,7 +12,6 @@ import WidgetFAOCoverComponent from './widget-fao-cover-component';
 const mapStateToProps = ({ widgetFAOCover }, ownProps) => {
   const { fao, rank } = widgetFAOCover.data;
   return {
-    loading: widgetFAOCover.loading || ownProps.isMetaLoading,
     fao,
     rank,
     data:

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-component.js
@@ -18,6 +18,7 @@ class WidgetTreeCover extends PureComponent {
             <WidgetDynamicSentence sentence={getSentence()} />
             <div className="pie-chart-container">
               <WidgetPieChartLegend
+                className="cover-legend"
                 data={parsedData}
                 config={{
                   ...settings,
@@ -26,7 +27,11 @@ class WidgetTreeCover extends PureComponent {
                   key: 'value'
                 }}
               />
-              <WidgetPieChart className="cover-pie-chart" data={parsedData} />
+              <WidgetPieChart
+                className="cover-pie-chart"
+                data={parsedData}
+                maxSize={140}
+              />
             </div>
           </div>
         )}

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-selectors.js
@@ -16,7 +16,7 @@ export const getTreeCoverData = createSelector(
     const hasPlantations = Object.keys(whitelist).indexOf('plantations') > -1;
     const parsedData = [
       {
-        name:
+        label:
           hasPlantations && indicator === 'gadm28'
             ? 'Natural Forest'
             : 'Tree cover',
@@ -25,7 +25,7 @@ export const getTreeCoverData = createSelector(
         percentage: (cover - plantations) / totalArea * 100
       },
       {
-        name: 'Non-Forest',
+        label: 'Non-Forest',
         value: totalArea - cover,
         color: COLORS.nonForest,
         percentage: (totalArea - cover) / totalArea * 100
@@ -33,7 +33,7 @@ export const getTreeCoverData = createSelector(
     ];
     if (indicator === 'gadm28' && hasPlantations) {
       parsedData.splice(1, 0, {
-        name: 'Tree plantations',
+        label: 'Tree plantations',
         value: plantations,
         color: COLORS.mediumGreen,
         percentage: plantations / totalArea * 100

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-styles.scss
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-styles.scss
@@ -3,6 +3,10 @@
 .c-widget-tree-cover {
   padding-top: rem(15px);
 
+  .cover-legend {
+    min-width: 50%;
+  }
+
   .pie-chart-container {
     display: flex;
     flex-direction: row;

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-actions.js
@@ -20,8 +20,8 @@ const getTreeLocated = createThunkAction(
           if (data && data.length) {
             mappedData = data.map(d => ({
               id: d[params.region ? 'adm2' : 'adm1'],
-              area: d.value || 0,
-              percentage: d.value ? d.value / d.total_area * 100 : 0
+              extent: d.value || 0,
+              percentage: d.value ? (d.value / d.total_area) * 100 : 0
             }));
           }
           dispatch(setTreeLocatedData(mappedData));

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-actions.js
@@ -19,9 +19,9 @@ const getTreeLocated = createThunkAction(
           let mappedData = [];
           if (data && data.length) {
             mappedData = data.map(d => ({
-              id: d[params.region ? 'adm2' : 'adm1'],
-              extent: d.value || 0,
-              percentage: d.value ? (d.value / d.total_area) * 100 : 0
+              id: d.region,
+              extent: d.extent || 0,
+              percentage: d.extent ? d.extent / d.total * 100 : 0
             }));
           }
           dispatch(setTreeLocatedData(mappedData));

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import WidgetPieChart from 'pages/country/widget/components/widget-pie-chart';
 import WidgetNumberedList from 'pages/country/widget/components/widget-numbered-list';
+import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
 import COLORS from 'pages/country/data/colors.json';
 
 import './widget-tree-located-styles.scss';
@@ -14,11 +15,13 @@ class WidgetTreeLocated extends PureComponent {
       chartData,
       settings,
       handlePageChange,
-      embed
+      embed,
+      getSentence
     } = this.props;
 
     return (
       <div className="c-widget-tree-located">
+        <WidgetDynamicSentence sentence={getSentence()} />
         {data && chartData &&
           data.length > 0 && (
             <div className="locations-container">

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-component.js
@@ -16,16 +16,21 @@ class WidgetTreeLocated extends PureComponent {
       settings,
       handlePageChange,
       embed,
-      getSentence
+      sentence
     } = this.props;
 
     return (
       <div className="c-widget-tree-located">
-        <WidgetDynamicSentence sentence={getSentence()} />
-        {data && chartData &&
+        <WidgetDynamicSentence sentence={sentence} />
+        {data &&
+          chartData &&
           data.length > 0 && (
             <div className="locations-container">
-              <WidgetPieChart className="locations-pie-chart" data={chartData} dataKey="percentage" />
+              <WidgetPieChart
+                className="locations-pie-chart"
+                data={chartData}
+                dataKey="percentage"
+              />
               <WidgetNumberedList
                 className="locations-list"
                 data={data}
@@ -46,7 +51,8 @@ WidgetTreeLocated.propTypes = {
   chartData: PropTypes.array,
   settings: PropTypes.object.isRequired,
   handlePageChange: PropTypes.func.isRequired,
-  embed: PropTypes.bool
+  embed: PropTypes.bool,
+  sentence: PropTypes.string
 };
 
 export default WidgetTreeLocated;

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-component.js
@@ -1,8 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
+import WidgetPieChart from 'pages/country/widget/components/widget-pie-chart';
 import WidgetNumberedList from 'pages/country/widget/components/widget-numbered-list';
-import NoContent from 'components/no-content';
 import COLORS from 'pages/country/data/colors.json';
 
 import './widget-tree-located-styles.scss';
@@ -10,35 +10,28 @@ import './widget-tree-located-styles.scss';
 class WidgetTreeLocated extends PureComponent {
   render() {
     const {
-      locationNames,
-      loading,
       data,
+      chartData,
       settings,
       handlePageChange,
       embed
     } = this.props;
+
     return (
       <div className="c-widget-tree-located">
-        {!loading &&
-          data &&
-          data.length === 0 && (
-            <NoContent
-              message={`No regions for ${locationNames.current &&
-                locationNames.current.label}`}
-              icon
-            />
-          )}
-        {!loading &&
-          data &&
+        {data && chartData &&
           data.length > 0 && (
-            <WidgetNumberedList
-              className="locations-list"
-              data={data}
-              settings={settings}
-              handlePageChange={handlePageChange}
-              colorRange={[COLORS.darkGreen, COLORS.nonForest]}
-              linksDisabled={embed}
-            />
+            <div className="locations-container">
+              <WidgetPieChart className="locations-pie-chart" data={chartData} dataKey="percentage" />
+              <WidgetNumberedList
+                className="locations-list"
+                data={data}
+                settings={settings}
+                handlePageChange={handlePageChange}
+                colorRange={[COLORS.darkGreen, COLORS.nonForest]}
+                linksDisabled={embed}
+              />
+            </div>
           )}
       </div>
     );
@@ -46,9 +39,8 @@ class WidgetTreeLocated extends PureComponent {
 }
 
 WidgetTreeLocated.propTypes = {
-  loading: PropTypes.bool.isRequired,
-  locationNames: PropTypes.object,
-  data: PropTypes.array.isRequired,
+  data: PropTypes.array,
+  chartData: PropTypes.array,
   settings: PropTypes.object.isRequired,
   handlePageChange: PropTypes.func.isRequired,
   embed: PropTypes.bool

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-selectors.js
@@ -84,7 +84,7 @@ export const getSentence = createSelector(
       locationNames && locationNames.current && locationNames.current.label;
     const topRegion = data.length && data[0];
     const avgExtentPercentage = sumBy(data, 'percentage') / data.length;
-    const avgExtent = sumBy(data, 'extent');
+    const avgExtent = sumBy(data, 'extent') / data.length;
     let percentileExtent = 0;
     let percentileLength = 0;
     let sentence = '';
@@ -128,9 +128,9 @@ export const getSentence = createSelector(
         avgExtentPercentage
       )}%</b>.`;
     } else {
-      sentence += `<b>${format('.2s')(
+      sentence += `<b>${format('.3s')(
         topRegion.extent
-      )}ha</b> compared to an average of <b>${format('.2s')(avgExtent)}ha</b>.`;
+      )}ha</b> compared to an average of <b>${format('.3s')(avgExtent)}ha</b>.`;
     }
 
     return sentence;

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-selectors.js
@@ -3,17 +3,21 @@ import isEmpty from 'lodash/isEmpty';
 import uniqBy from 'lodash/uniqBy';
 import sumBy from 'lodash/sumBy';
 import { sortByKey, getColorPalette } from 'utils/data';
+import { format } from 'd3-format';
 
 // get list data
 const getData = state => state.data || null;
-const getUnit = state => state.unit || null;
+const getSettings = state => state.settings || null;
+const getOptions = state => state.options || null;
+const getIndicator = state => state.indicator || null;
 const getLocation = state => state.location || null;
 const getLocationsMeta = state => state.meta || null;
+const getLocationNames = state => state.locationNames || null;
 const getColors = state => state.colors || null;
 
 export const getSortedData = createSelector(
-  [getData, getUnit, getLocation, getLocationsMeta],
-  (data, unit, location, meta) => {
+  [getData, getSettings, getLocation, getLocationsMeta],
+  (data, settings, location, meta) => {
     if (!data || isEmpty(data) || !meta || isEmpty(meta)) return null;
     const dataMapped = [];
     data.forEach(d => {
@@ -23,7 +27,7 @@ export const getSortedData = createSelector(
           label: (region && region.label) || '',
           extent: d.extent,
           percentage: d.percentage,
-          value: unit === 'ha' ? d.extent : d.percentage,
+          value: settings.unit === 'ha' ? d.extent : d.percentage,
           path: `/country/${location.country}/${
             location.region ? `${location.region}/` : ''
           }${d.id}`
@@ -35,28 +39,105 @@ export const getSortedData = createSelector(
 );
 
 export const getChartData = createSelector(
-  [getSortedData, getUnit, getColors],
-  (data, unit, colors) => {
+  [getSortedData, getColors],
+  (data, colors) => {
     if (!data || !data.length) return null;
     const topRegions = data.length > 10 ? data.slice(0, 10) : data;
     const totalExtent = sumBy(data, 'extent');
     const otherRegions = data.length > 10 ? data.slice(10) : [];
     const othersExtent = otherRegions.length && sumBy(otherRegions, 'extent');
-    const colorRange = getColorPalette([colors.darkGreen, colors.nonForest], topRegions.length);
+    const colorRange = getColorPalette(
+      [colors.darkGreen, colors.nonForest],
+      topRegions.length
+    );
     const topChartData = topRegions.map((d, index) => ({
       ...d,
       percentage: d.extent / totalExtent * 100,
       color: colorRange[index]
     }));
-    const otherRegionsData = otherRegions.length ? {
-      label: 'Other regions',
-      percentage: othersExtent ? othersExtent / totalExtent * 100 : 0,
-      color: colors.grey
-    } : {};
+    const otherRegionsData = otherRegions.length
+      ? {
+        label: 'Other regions',
+        percentage: othersExtent ? othersExtent / totalExtent * 100 : 0,
+        color: colors.grey
+      }
+      : {};
 
-    return [
-      ...topChartData,
-      otherRegionsData
-    ];
+    return [...topChartData, otherRegionsData];
+  }
+);
+
+export const getSentence = createSelector(
+  [
+    getSortedData,
+    getSettings,
+    getOptions,
+    getLocation,
+    getIndicator,
+    getLocationNames
+  ],
+  (data, settings, options, location, indicator, locationNames) => {
+    if (!data || !options || !indicator || !locationNames) return '';
+    const { extentYear, threshold } = settings;
+    const totalExtent = sumBy(data, 'extent');
+    const currentLocation =
+      locationNames && locationNames.current && locationNames.current.label;
+    const topRegion = data.length && data[0];
+    const avgExtentPercentage = sumBy(data, 'percentage') / data.length;
+    const avgExtent = sumBy(data, 'extent');
+    let percentileExtent = 0;
+    let percentileLength = 0;
+    let sentence = '';
+
+    if (indicator.value !== 'gadm28') {
+      sentence += `For <b>${
+        indicator.label
+      }</b> in <b>${currentLocation}</b>, `;
+    } else {
+      sentence += `In <b>${currentLocation}</b>, `;
+    }
+
+    if (data.length > 10) {
+      while (
+        percentileLength < data.length &&
+        percentileExtent / totalExtent < 0.5
+      ) {
+        percentileExtent += data[percentileLength].extent;
+        percentileLength += 1;
+      }
+      const topExtent = percentileExtent / totalExtent * 100;
+
+      if (percentileLength > 1) {
+        sentence += `the top <b>${percentileLength}</b> regions represents <b>`;
+      } else {
+        sentence += `<b>${currentLocation}</b>, <b>${
+          topRegion.label
+        }</b> represents <b>`;
+      }
+      if (!location.region) {
+        sentence += `more than half (${format('.0f')(topExtent)}%)`;
+      } else {
+        sentence += `${format('.0f')(topExtent)}%`;
+      }
+      sentence += `</b> of all tree cover in <b>${extentYear}</b> where tree canopy is greater than <b>${threshold}%</b>. `;
+    }
+    sentence += `${
+      percentileLength > 1 || data.length < 10
+        ? `<b>${topRegion.label}</b>`
+        : 'This region'
+    } has the largest relative tree cover at `;
+    if (topRegion.percentage > 1) {
+      sentence += `<b>${format('.0f')(
+        topRegion.percentage
+      )}%</b> compared to an average of <b>${format('.0f')(
+        avgExtentPercentage
+      )}%</b>.`;
+    } else {
+      sentence += `<b>${format('.2s')(
+        topRegion.extent
+      )}ha</b> compared to an average of <b>${format('.2s')(avgExtent)}ha</b>.`;
+    }
+
+    return sentence;
   }
 );

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-styles.scss
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-styles.scss
@@ -1,11 +1,36 @@
 @import '~styles/settings.scss';
 
 .c-widget-tree-located {
-  .locations-list {
-    padding: rem(40px) rem(10px) 0;
+  .locations-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-top: rem(30px);
+    padding: 0 rem(15px);
 
-    @media screen and (min-width: $screen-m) {
-      padding: rem(40px) rem(20px) 0;
+    .locations-list {
+      width: 100%;
+
+      @media screen and (min-width: $screen-m) {
+        width: 50%;
+      }
+
+      @media screen and (min-width: $screen-l) {
+        width: 40%;
+      }
+    }
+
+    .locations-pie-chart {
+      display: none;
+      max-width: rem(250px);
+      width: 50%;
+      justify-content: center;
+      align-items: center;
+
+      @media screen and (min-width: $screen-m) {
+        display: flex;
+      }
     }
   }
 }

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-styles.scss
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-styles.scss
@@ -23,13 +23,23 @@
 
     .locations-pie-chart {
       display: none;
-      max-width: rem(250px);
       width: 50%;
+      min-width: 50%;
       justify-content: center;
       align-items: center;
 
       @media screen and (min-width: $screen-m) {
         display: flex;
+        padding-right: rem(40px);
+      }
+
+      @media screen and (min-width: $screen-l) {
+        width: 60%;
+        min-width: 60%;
+      }
+
+      .recharts-responsive-container {
+        max-width: rem(230px);
       }
     }
   }

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located.js
@@ -2,31 +2,41 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
-import sumBy from 'lodash/sumBy';
-import { format } from 'd3-format';
-import { getLocationLabel } from 'pages/country/widget/widget-selectors';
 import COLORS from 'pages/country/data/colors.json';
 
 import actions from './widget-tree-located-actions';
 import reducers, { initialState } from './widget-tree-located-reducers';
-import { getSortedData, getChartData } from './widget-tree-located-selectors';
+import {
+  getSortedData,
+  getChartData,
+  getSentence
+} from './widget-tree-located-selectors';
 import WidgetTreeLocatedComponent from './widget-tree-located-component';
 
-const mapStateToProps = ({ location, widgetTreeLocated, countryData }) => {
+const mapStateToProps = (
+  { location, widgetTreeLocated, countryData },
+  ownProps
+) => {
   const { isCountriesLoading, isRegionsLoading } = countryData;
-  const data = {
-    data: widgetTreeLocated.data.regions,
-    unit: widgetTreeLocated.settings.unit,
-    meta: countryData[!location.payload.region ? 'regions' : 'subRegions'],
-    location: location.payload,
-    colors: COLORS
+  const { settings, data, loading } = widgetTreeLocated;
+  const { settingsConfig, activeIndicator } = ownProps;
+  const { payload } = location;
+  const selectorData = {
+    data: data.regions,
+    settings,
+    options: settingsConfig.options,
+    meta: countryData[!payload.region ? 'regions' : 'subRegions'],
+    location: payload,
+    colors: COLORS,
+    indicator: activeIndicator,
+    locationNames: ownProps.locationNames
   };
   return {
     regions: countryData.regions,
-    loading:
-      widgetTreeLocated.loading || isCountriesLoading || isRegionsLoading,
-    data: getSortedData(data) || [],
-    chartData: getChartData(data)
+    loading: loading || isCountriesLoading || isRegionsLoading,
+    data: getSortedData(selectorData),
+    chartData: getChartData(selectorData),
+    sentence: getSentence(selectorData)
   };
 };
 
@@ -56,40 +66,6 @@ class WidgetTreeLocatedContainer extends PureComponent {
     }
   }
 
-  getSentence = () => {
-    // The top 11 sub-regions are responsible for 49% of England's regional tree cover 
-    // in 2000 where tree canopy is greater than 0%. North Yorkshire has 
-    // the largest relative tree cover in England, at 8% compared to an average of 0.9%.
-
-    const { data, settings, options, location, locationNames } = this.props;
-    const { extentYear, indicator, threshold } = this.props.settings;
-    const { indicators } = this.props.options;
-
-    const totalExtent = sumBy(data, 'extent');
-    const currentLocation = locationNames && locationNames.current && locationNames.current.label;
-    const locationLabel = getLocationLabel(currentLocation, indicator, indicators);
-    const topRegion = data.length && data[0];
-    console.log(totalExtent, data.length);
-    const avgExtent = totalExtent / data.length;
-    let percentileExtent = 0;
-    let percentileLength = 0;
-    let first = '';
-    let second = '';
-
-    if (data.length > 10) {
-      while (percentileLength < data.length && percentileExtent / totalExtent < 0.5) {
-        percentileExtent += data[percentileLength].extent;
-        percentileLength += 1;
-      }
-      const topExtent = percentileExtent / totalExtent * 100;
-      first = `The top <b>${percentileLength}</b> regions are responsible for more than half <b>(${format('.0f')(topExtent)}%)</b> of <b>${locationLabel}'s</b> regional tree cover in <b>${extentYear}</b> where tree canopy is greater than <b>${threshold}%</b>.`;
-    }
-
-    second = `${!first ? `Within <b>${currentLocation}</b>,` : ''}<b> ${topRegion.label}</b> has the largest relative tree cover in ${currentLocation}, at <b>${format('.0f')(topRegion.percentage)}%</b> compared to an average of <b>${format('.0f')(avgExtent)}%</b>`;
-
-    return `${first} ${second}`;
-  };
-
   handlePageChange = change => {
     const { setTreeLocatedPage, settings } = this.props;
     setTreeLocatedPage(settings.page + change);
@@ -98,8 +74,7 @@ class WidgetTreeLocatedContainer extends PureComponent {
   render() {
     return createElement(WidgetTreeLocatedComponent, {
       ...this.props,
-      handlePageChange: this.handlePageChange,
-      getSentence: this.getSentence
+      handlePageChange: this.handlePageChange
     });
   }
 }

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located.js
@@ -2,7 +2,7 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
-import { getLocationLabel } from 'pages/country/widget/widget-selectors';
+// import { getLocationLabel } from 'pages/country/widget/widget-selectors';
 import COLORS from 'pages/country/data/colors.json';
 
 import actions from './widget-tree-located-actions';
@@ -44,6 +44,7 @@ class WidgetTreeLocatedContainer extends PureComponent {
       !isEqual(location.country, this.props.location.country) ||
       !isEqual(location.region, this.props.location.region) ||
       !isEqual(settings.indicator, this.props.settings.indicator) ||
+      !isEqual(settings.extentYear, this.props.settings.extentYear) ||
       !isEqual(settings.threshold, this.props.settings.threshold)
     ) {
       getTreeLocated({

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located.js
@@ -2,10 +2,12 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import { getLocationLabel } from 'pages/country/widget/widget-selectors';
+import COLORS from 'pages/country/data/colors.json';
 
 import actions from './widget-tree-located-actions';
 import reducers, { initialState } from './widget-tree-located-reducers';
-import { getSortedData } from './widget-tree-located-selectors';
+import { getSortedData, getChartData } from './widget-tree-located-selectors';
 import WidgetTreeLocatedComponent from './widget-tree-located-component';
 
 const mapStateToProps = ({ location, widgetTreeLocated, countryData }) => {
@@ -14,13 +16,15 @@ const mapStateToProps = ({ location, widgetTreeLocated, countryData }) => {
     data: widgetTreeLocated.data.regions,
     unit: widgetTreeLocated.settings.unit,
     meta: countryData[!location.payload.region ? 'regions' : 'subRegions'],
-    location: location.payload
+    location: location.payload,
+    colors: COLORS
   };
   return {
     regions: countryData.regions,
     loading:
       widgetTreeLocated.loading || isCountriesLoading || isRegionsLoading,
-    data: getSortedData(data) || []
+    data: getSortedData(data) || [],
+    chartData: getChartData(data)
   };
 };
 
@@ -48,6 +52,22 @@ class WidgetTreeLocatedContainer extends PureComponent {
       });
     }
   }
+
+  // getSentence = () => {
+  //   const { locationNames, settings } = this.props;
+  //   const { indicators } = this.props.options;
+  //   const { totalArea, cover } = this.props.data;
+  //   const indicator = getLocationLabel(settings.indicator, indicators);
+  //   const coverStatus = cover / totalArea > 0.5 ? 'tree covered' : 'non-forest';
+  //   const first = `<b>${
+  //     locationNames.current.label
+  //   } (${indicator})</b> is mainly ${coverStatus}, `;
+  //   const second = `considering tree cover extent in <b>${
+  //     settings.extentYear
+  //   }</b> where tree canopy is greater than <b>${settings.threshold}%</b>`;
+
+  //   return `${first} ${second}`;
+  // };
 
   handlePageChange = change => {
     const { setTreeLocatedPage, settings } = this.props;


### PR DESCRIPTION
## Overview

"Yo, I heard you like dynamic sentences... so I put a dynamic sentence inside your dynamic setence inside yo widget DAWG." - Xibit (if he worked on GFW. Probably.)

The `treeLocations` (ranked extent by location) widget needed some additional mods to help it keep up with the saturating widget market. After a short visit to the chop shop, Xibit kitted this mean piece of analysis out with a fresh dynamic sentence, an ENTIRE pie chart, and some hella upgrades to the widget data flow. How did he do that? Imma tell you:
- Dynamic sentence: move it to the selector and pass to the component
- Pie chart: update component to handle responsive layouts, update defaults
- Data selectors: new selector for pie chart to handle different calculations
- Add `activeIndicator` to the Widget component and pass to children to keep that stuff DRY.

## Demo

![screen shot 2018-01-16 at 12 24 23](https://user-images.githubusercontent.com/20288774/34986529-364e75b4-fab8-11e7-8d7b-a00c8b877d4e.png)

## Testing

Tested for all major countries and regions. Please review any outliers and report back. Prefered method: fax or morse code to ASCII.

