### PR TITLE
Feature/update tree cover gain

### DIFF
--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -78,7 +78,9 @@
       "indicator": "gadm28",
       "threshold": "0",
       "unit": "ha",
-      "extentYear": 2010
+      "extentYear": 2010,
+      "pageSize": 5,
+      "page": 0
     },
     "active": true
   },

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -71,12 +71,13 @@
       "indicators": ["gadm28", "wdpa", "primary_forests", "plantations", "ifl_2013"],
       "categories": ["summary", "forest-change"],
       "admins": ["country", "region", "subRegion"],
-      "selectors": ["indicators", "thresholds", "extentYears"],
+      "selectors": ["indicators", "thresholds", "extentYears", "units"],
       "type": "gain"
     },
     "settings": {
       "indicator": "gadm28",
       "threshold": "0",
+      "unit": "ha",
       "extentYear": 2010
     },
     "active": true

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -71,12 +71,13 @@
       "indicators": ["gadm28", "wdpa", "primary_forests", "plantations", "ifl_2013"],
       "categories": ["summary", "forest-change"],
       "admins": ["country", "region", "subRegion"],
-      "selectors": ["indicators", "thresholds"],
+      "selectors": ["indicators", "thresholds", "extentYears"],
       "type": "gain"
     },
     "settings": {
       "indicator": "gadm28",
-      "threshold": "0"
+      "threshold": "0",
+      "extentYear": 2010
     },
     "active": true
   },

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -79,9 +79,7 @@
       "indicator": "gadm28",
       "threshold": "0",
       "unit": "ha",
-      "extentYear": 2010,
-      "pageSize": 5,
-      "page": 0
+      "extentYear": 2010
     },
     "active": true
   },

--- a/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-component.jsx
@@ -37,7 +37,7 @@ class WidgetNumberedList extends PureComponent {
                       className="item-bubble"
                       style={{ backgroundColor: COLORS[index] }}
                     >
-                      {index + 1 + pageSize * page}
+                      {item.rank || index + 1 + pageSize * page}
                     </div>
                     <div className="item-name">{item.label}</div>
                   </div>

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions.js
@@ -1,8 +1,7 @@
 import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
-import axios from 'axios';
 
-import { getGain, getExtent, getGainRanking } from 'services/forest-data';
+import { getGainExtent } from 'services/forest-data';
 
 const setTreeGainLoading = createAction('setTreeGainLoading');
 const setTreeGainData = createAction('setTreeGainData');
@@ -13,29 +12,22 @@ const getTreeGain = createThunkAction(
   params => (dispatch, state) => {
     if (!state().widgetTreeGain.loading) {
       dispatch(setTreeGainLoading({ loading: true, error: false }));
-      axios
-        .all([
-          getGain({ ...params }),
-          getExtent({ ...params }),
-          getGainRanking({ ...params })
-        ])
-        .then(
-          axios.spread((gainResponse, extentResponse, gainRankingResponse) => {
-            const gain = gainResponse.data.data;
-            const extent = extentResponse.data.data;
-            const ranking = getProcessedRankingData(
-              gainRankingResponse.data.data,
-              { ...params }
-            );
-            dispatch(
-              setTreeGainData({
-                gain: (gain && gain.length > 0 && gain[0].value) || 0,
-                extent: (gain && extent.length > 0 && extent[0].value) || 0,
-                ranking
-              })
-            );
-          })
-        )
+      getGainExtent(params)
+        .then(response => {
+          const { data } = response.data;
+          let mappedData = [];
+          if (data && data.length) {
+            mappedData = data.map(item => {
+              const gain = item.gain ? item.gain : 0;
+              return {
+                id: item.region,
+                gain,
+                percentage: 100 * gain / item.extent
+              };
+            });
+          }
+          dispatch(setTreeGainData(mappedData));
+        })
         .catch(error => {
           console.info(error);
           dispatch(setTreeGainLoading({ loading: false, error: true }));
@@ -43,28 +35,6 @@ const getTreeGain = createThunkAction(
     }
   }
 );
-
-const getProcessedRankingData = (rawData, params) => {
-  const output = rawData
-    .map(item => {
-      const gain = item.gain ? item.gain : 0;
-      return {
-        id: item.region,
-        gain,
-        relative: 100 * gain / item.extent
-      };
-    })
-    .filter(item => {
-      if (params.subRegion) {
-        return item.id !== params.subRegion;
-      } else if (params.region) {
-        return item.id !== params.region;
-      }
-      return item.id !== params.country;
-    });
-
-  return output.slice(0, 5);
-};
 
 export default {
   setTreeGainLoading,

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions.js
@@ -26,7 +26,7 @@ const getTreeGain = createThunkAction(
               };
             });
           }
-          dispatch(setTreeGainData(mappedData));
+          dispatch(setTreeGainData({ gain: mappedData }));
         })
         .catch(error => {
           console.info(error);

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions.js
@@ -2,7 +2,7 @@ import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 import axios from 'axios';
 
-import { getGain, getExtent } from 'services/forest-data';
+import { getGain, getExtent, getGainRanking } from 'services/forest-data';
 
 const setTreeGainLoading = createAction('setTreeGainLoading');
 const setTreeGainData = createAction('setTreeGainData');
@@ -14,15 +14,21 @@ const getTreeGain = createThunkAction(
     if (!state().widgetTreeGain.loading) {
       dispatch(setTreeGainLoading({ loading: true, error: false }));
       axios
-        .all([getGain({ ...params }), getExtent({ ...params })])
+        .all([
+          getGain({ ...params }),
+          getExtent({ ...params }),
+          getGainRanking({ ...params })
+        ])
         .then(
-          axios.spread((gainResponse, extentResponse) => {
+          axios.spread((gainResponse, extentResponse, gainRankingResponse) => {
             const gain = gainResponse.data.data;
             const extent = extentResponse.data.data;
+            const gainRanking = gainRankingResponse.data.data;
             dispatch(
               setTreeGainData({
                 gain: (gain && gain.length > 0 && gain[0].value) || 0,
-                extent: (gain && extent.length > 0 && extent[0].value) || 0
+                extent: (gain && extent.length > 0 && extent[0].value) || 0,
+                gainRanking
               })
             );
           })

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions.js
@@ -23,12 +23,14 @@ const getTreeGain = createThunkAction(
           axios.spread((gainResponse, extentResponse, gainRankingResponse) => {
             const gain = gainResponse.data.data;
             const extent = extentResponse.data.data;
-            const gainRanking = gainRankingResponse.data.data;
+            const ranking = getProcessedRankingData(
+              gainRankingResponse.data.data
+            );
             dispatch(
               setTreeGainData({
                 gain: (gain && gain.length > 0 && gain[0].value) || 0,
                 extent: (gain && extent.length > 0 && extent[0].value) || 0,
-                gainRanking
+                ranking
               })
             );
           })
@@ -40,6 +42,19 @@ const getTreeGain = createThunkAction(
     }
   }
 );
+
+const getProcessedRankingData = rawData => {
+  const output = rawData.map(item => {
+    const gain = item.gain ? item.gain : 0;
+    return {
+      id: item.region,
+      gain,
+      relative: 100 * gain / item.extent
+    };
+  });
+
+  return output.slice(0, 5);
+};
 
 export default {
   setTreeGainLoading,

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions.js
@@ -24,7 +24,8 @@ const getTreeGain = createThunkAction(
             const gain = gainResponse.data.data;
             const extent = extentResponse.data.data;
             const ranking = getProcessedRankingData(
-              gainRankingResponse.data.data
+              gainRankingResponse.data.data,
+              { ...params }
             );
             dispatch(
               setTreeGainData({
@@ -43,15 +44,24 @@ const getTreeGain = createThunkAction(
   }
 );
 
-const getProcessedRankingData = rawData => {
-  const output = rawData.map(item => {
-    const gain = item.gain ? item.gain : 0;
-    return {
-      id: item.region,
-      gain,
-      relative: 100 * gain / item.extent
-    };
-  });
+const getProcessedRankingData = (rawData, params) => {
+  const output = rawData
+    .map(item => {
+      const gain = item.gain ? item.gain : 0;
+      return {
+        id: item.region,
+        gain,
+        relative: 100 * gain / item.extent
+      };
+    })
+    .filter(item => {
+      if (params.subRegion) {
+        return item.id !== params.subRegion;
+      } else if (params.region) {
+        return item.id !== params.region;
+      }
+      return item.id !== params.country;
+    });
 
   return output.slice(0, 5);
 };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-component.js
@@ -3,28 +3,17 @@ import PropTypes from 'prop-types';
 
 import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
 import WidgetNumberedList from 'pages/country/widget/components/widget-numbered-list';
-import NoContent from 'components/no-content';
 import COLORS from 'pages/country/data/colors.json';
 
 import './widget-tree-gain-styles.scss';
 
 class WidgetTreeCoverGain extends PureComponent {
   render() {
-    const { locationNames, loading, data, settings, getSentence } = this.props;
+    const { data, settings, getSentence } = this.props;
 
     return (
       <div className="c-widget-tree-cover-gain">
-        {!loading &&
-          data &&
-          data.ranking.length === 0 && (
-            <NoContent
-              message={`No data for ${locationNames.current &&
-                locationNames.current.label}`}
-              icon
-            />
-          )}
-        {!loading &&
-          data &&
+        {data &&
           data.ranking.length > 0 && (
             <div className="gain-data">
               <WidgetDynamicSentence sentence={getSentence()} />
@@ -43,8 +32,6 @@ class WidgetTreeCoverGain extends PureComponent {
 }
 
 WidgetTreeCoverGain.propTypes = {
-  loading: PropTypes.bool.isRequired,
-  locationNames: PropTypes.object,
   data: PropTypes.object.isRequired,
   settings: PropTypes.object.isRequired,
   getSentence: PropTypes.func.isRequired

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-component.js
@@ -2,24 +2,51 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
+import WidgetNumberedList from 'pages/country/widget/components/widget-numbered-list';
+import NoContent from 'components/no-content';
+import COLORS from 'pages/country/data/colors.json';
 
 import './widget-tree-gain-styles.scss';
 
 class WidgetTreeCoverGain extends PureComponent {
   render() {
-    const { getSentence } = this.props;
+    const { locationNames, loading, data, settings, getSentence } = this.props;
 
     return (
       <div className="c-widget-tree-cover-gain">
-        <div className="gain-data">
-          <WidgetDynamicSentence sentence={getSentence()} />
-        </div>
+        {!loading &&
+          data &&
+          data.ranking.length === 0 && (
+            <NoContent
+              message={`No data for ${locationNames.current &&
+                locationNames.current.label}`}
+              icon
+            />
+          )}
+        {!loading &&
+          data &&
+          data.ranking.length > 0 && (
+            <div className="gain-data">
+              <WidgetDynamicSentence sentence={getSentence()} />
+              <WidgetNumberedList
+                className="ranking-list"
+                data={data.ranking}
+                settings={settings}
+                colorRange={[COLORS.darkGreen, COLORS.nonForest]}
+                handlePageChange={() => {}}
+              />
+            </div>
+          )}
       </div>
     );
   }
 }
 
 WidgetTreeCoverGain.propTypes = {
+  loading: PropTypes.bool.isRequired,
+  locationNames: PropTypes.object,
+  data: PropTypes.object.isRequired,
+  settings: PropTypes.object.isRequired,
   getSentence: PropTypes.func.isRequired
 };
 

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-component.js
@@ -14,12 +14,12 @@ class WidgetTreeCoverGain extends PureComponent {
     return (
       <div className="c-widget-tree-cover-gain">
         {data &&
-          data.ranking.length > 0 && (
+          data.length > 0 && (
             <div className="gain-data">
               <WidgetDynamicSentence sentence={sentence} />
               <WidgetNumberedList
                 className="ranking-list"
-                data={data.ranking}
+                data={data}
                 settings={settings}
                 colorRange={[COLORS.darkGreen, COLORS.nonForest]}
                 handlePageChange={() => {}}
@@ -32,7 +32,7 @@ class WidgetTreeCoverGain extends PureComponent {
 }
 
 WidgetTreeCoverGain.propTypes = {
-  data: PropTypes.object.isRequired,
+  data: PropTypes.array.isRequired,
   settings: PropTypes.object.isRequired,
   sentence: PropTypes.string.isRequired
 };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-component.js
@@ -9,14 +9,14 @@ import './widget-tree-gain-styles.scss';
 
 class WidgetTreeCoverGain extends PureComponent {
   render() {
-    const { data, settings, getSentence } = this.props;
+    const { data, sentence, settings } = this.props;
 
     return (
       <div className="c-widget-tree-cover-gain">
         {data &&
           data.ranking.length > 0 && (
             <div className="gain-data">
-              <WidgetDynamicSentence sentence={getSentence()} />
+              <WidgetDynamicSentence sentence={sentence} />
               <WidgetNumberedList
                 className="ranking-list"
                 data={data.ranking}
@@ -34,7 +34,7 @@ class WidgetTreeCoverGain extends PureComponent {
 WidgetTreeCoverGain.propTypes = {
   data: PropTypes.object.isRequired,
   settings: PropTypes.object.isRequired,
-  getSentence: PropTypes.func.isRequired
+  sentence: PropTypes.string.isRequired
 };
 
 export default WidgetTreeCoverGain;

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-reducers.js
@@ -4,8 +4,7 @@ export const initialState = {
   loading: false,
   error: false,
   data: {
-    gain: 0,
-    extent: 0
+    gain: []
   },
   ...WIDGETS_CONFIG.treeGain
 };
@@ -19,7 +18,7 @@ const setTreeGainData = (state, { payload }) => ({
   ...state,
   loading: false,
   data: {
-    ...payload
+    gain: payload
   }
 });
 

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-reducers.js
@@ -18,7 +18,7 @@ const setTreeGainData = (state, { payload }) => ({
   ...state,
   loading: false,
   data: {
-    gain: payload
+    ...payload
   }
 });
 

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
@@ -1,0 +1,38 @@
+import { createSelector } from 'reselect';
+import isEmpty from 'lodash/isEmpty';
+import uniqBy from 'lodash/uniqBy';
+import { sortByKey } from 'utils/data';
+
+// get list data
+const getData = state => state.ranking || null;
+const getUnit = state => state.unit || null;
+const getLocation = state => state.location || null;
+const getLocationsMeta = state => state.meta || null;
+
+export const getSortedData = createSelector(
+  [getData, getUnit, getLocation, getLocationsMeta],
+  (data, unit, location, meta) => {
+    if (!data || isEmpty(data) || !meta || isEmpty(meta)) return null;
+    const dataMapped = [];
+    data.forEach(d => {
+      const region = meta.find(l => d.id === l.value);
+      let path = '/country/';
+      if (location.subRegion) {
+        path += `${location.country}/${location.region}/${d.id}`;
+      } else if (location.region) {
+        path += `${location.country}/${d.id}`;
+      } else {
+        path = d.id;
+      }
+
+      if (region) {
+        dataMapped.push({
+          label: (region && region.label) || '',
+          value: unit === 'ha' ? d.gain : d.relative,
+          path
+        });
+      }
+    });
+    return sortByKey(uniqBy(dataMapped, 'label'), 'value', true);
+  }
+);

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
@@ -2,19 +2,24 @@ import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import uniqBy from 'lodash/uniqBy';
 import { sortByKey } from 'utils/data';
+import { format } from 'd3-format';
 
 // get list data
-const getData = state => state.ranking || null;
-const getUnit = state => state.unit || null;
+const getRanking = state => state.ranking || null;
+const getGain = state => state.gain || null;
+const getExtent = state => state.extent || null;
+const getSettings = state => state.settings || null;
 const getLocation = state => state.location || null;
 const getLocationsMeta = state => state.meta || null;
+const getIndicator = state => state.indicator || null;
+const getLocationNames = state => state.locationNames || null;
 
 export const getSortedData = createSelector(
-  [getData, getUnit, getLocation, getLocationsMeta],
-  (data, unit, location, meta) => {
-    if (!data || isEmpty(data) || !meta || isEmpty(meta)) return null;
+  [getRanking, getSettings, getLocation, getLocationsMeta],
+  (ranking, settings, location, meta) => {
+    if (!ranking || isEmpty(ranking) || !meta || isEmpty(meta)) return [];
     const dataMapped = [];
-    data.forEach(d => {
+    ranking.forEach(d => {
       const region = meta.find(l => d.id === l.value);
       let path = '/country/';
       if (location.subRegion) {
@@ -28,11 +33,35 @@ export const getSortedData = createSelector(
       if (region) {
         dataMapped.push({
           label: (region && region.label) || '',
-          value: unit === 'ha' ? d.gain : d.relative,
+          value: settings.unit === 'ha' ? d.gain : d.relative,
           path
         });
       }
     });
     return sortByKey(uniqBy(dataMapped, 'label'), 'value', true);
+  }
+);
+
+export const getSentence = createSelector(
+  [getGain, getExtent, getSettings, getIndicator, getLocationNames],
+  (gain, extent, settings, indicator, locationNames) => {
+    if (!gain || !extent || !settings || !indicator || !locationNames) { return ''; }
+    const regionPhrase =
+      indicator.indicator === 'gadm28'
+        ? '<span>region-wide</span>'
+        : `in <span>${indicator && indicator.label.toLowerCase()}</span>`;
+
+    const areaPercent = format('.1f')(100 * gain / extent);
+    const firstSentence = `From 2001 to 2012, <span>${locationNames.current &&
+      locationNames.current.label}</span> gained <strong>${
+      gain ? format('.3s')(gain) : '0'
+    }ha</strong> of tree cover ${regionPhrase}`;
+    const secondSentence = gain
+      ? `, equivalent to a <strong>${areaPercent}%</strong> increase relative to <b>${
+        settings.extentYear
+      }</b> tree cover extent.`
+      : '.';
+
+    return `${firstSentence}${secondSentence}`;
   }
 );

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
@@ -21,7 +21,10 @@ export const getSortedData = createSelector(
       uniqBy(data, 'id'),
       settings.unit === 'ha' ? 'gain' : 'percentage',
       true
-    );
+    ).map((d, i) => ({
+      ...d,
+      rank: i + 1
+    }));
   }
 );
 

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
@@ -22,7 +22,7 @@ export const getSortedData = createSelector(
       } else if (location.region) {
         path += `${location.country}/${d.id}`;
       } else {
-        path = d.id;
+        path += d.id;
       }
 
       if (region) {

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
@@ -45,9 +45,11 @@ export const getSortedData = createSelector(
 export const getSentence = createSelector(
   [getGain, getExtent, getSettings, getIndicator, getLocationNames],
   (gain, extent, settings, indicator, locationNames) => {
-    if (!gain || !extent || !settings || !indicator || !locationNames) { return ''; }
+    if (!gain || !extent || !settings || !indicator || !locationNames) {
+      return '';
+    }
     const regionPhrase =
-      indicator.indicator === 'gadm28'
+      indicator.value === 'gadm28'
         ? '<span>region-wide</span>'
         : `in <span>${indicator && indicator.label.toLowerCase()}</span>`;
 

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
@@ -1,26 +1,62 @@
 import { createSelector } from 'reselect';
-import isEmpty from 'lodash/isEmpty';
 import uniqBy from 'lodash/uniqBy';
-import { sortByKey } from 'utils/data';
+import findIndex from 'lodash/findIndex';
+import { sortByKey, getColorPalette } from 'utils/data';
 import { format } from 'd3-format';
 
 // get list data
-const getRanking = state => state.ranking || null;
-const getGain = state => state.gain || null;
-const getExtent = state => state.extent || null;
+const getData = state => state.data || null;
 const getSettings = state => state.settings || null;
 const getLocation = state => state.location || null;
 const getLocationsMeta = state => state.meta || null;
+const getColors = state => state.colors || null;
 const getIndicator = state => state.indicator || null;
 const getLocationNames = state => state.locationNames || null;
 
 export const getSortedData = createSelector(
-  [getRanking, getSettings, getLocation, getLocationsMeta],
-  (ranking, settings, location, meta) => {
-    if (!ranking || isEmpty(ranking) || !meta || isEmpty(meta)) return [];
-    const dataMapped = [];
-    ranking.forEach(d => {
-      const region = meta.find(l => d.id === l.value);
+  [getData, getSettings],
+  (data, settings) => {
+    if (!data || !data.length) return null;
+    return sortByKey(
+      uniqBy(data, 'id'),
+      settings.unit === 'ha' ? 'gain' : 'percentage',
+      true
+    );
+  }
+);
+
+export const getFilteredData = createSelector(
+  [
+    getSortedData,
+    getSettings,
+    getLocation,
+    getLocationNames,
+    getLocationsMeta,
+    getColors
+  ],
+  (data, settings, location, locationNames, meta, colors) => {
+    if (!data || !data.length) return null;
+    const locationIndex = findIndex(
+      data,
+      d => d.id === locationNames.current.value
+    );
+    let trimStart = locationIndex - 2;
+    let trimEnd = locationIndex + 3;
+    if (locationIndex < 2) {
+      trimStart = 0;
+      trimEnd = 5;
+    }
+    if (locationIndex > data.length - 3) {
+      trimStart = data.length - 5;
+      trimEnd = data.length;
+    }
+    const dataTrimmed = data.slice(trimStart, trimEnd);
+    const colorRange = getColorPalette(
+      [colors.darkGreen, colors.lightGreen],
+      dataTrimmed.length
+    );
+    return dataTrimmed.map((d, index) => {
+      const locationData = meta.find(l => d.id === l.value);
       let path = '/country/';
       if (location.subRegion) {
         path += `${location.country}/${location.region}/${d.id}`;
@@ -30,35 +66,33 @@ export const getSortedData = createSelector(
         path += d.id;
       }
 
-      if (region) {
-        dataMapped.push({
-          label: (region && region.label) || '',
-          value: settings.unit === 'ha' ? d.gain : d.relative,
-          path
-        });
-      }
+      return {
+        ...d,
+        label: (locationData && locationData.label) || '',
+        color: colorRange[index],
+        path,
+        value: settings.unit === 'ha' ? d.gain : d.percentage
+      };
     });
-    return sortByKey(uniqBy(dataMapped, 'label'), 'value', true);
   }
 );
 
 export const getSentence = createSelector(
-  [getGain, getExtent, getSettings, getIndicator, getLocationNames],
-  (gain, extent, settings, indicator, locationNames) => {
-    if (!gain || !extent || !settings || !indicator || !locationNames) {
-      return '';
-    }
+  [getData, getSettings, getIndicator, getLocationNames],
+  (data, settings, indicator, locationNames) => {
+    if (!data || !data.length) return null;
+    const locationData = data.find(l => l.id === locationNames.current.value);
     const regionPhrase =
       indicator.value === 'gadm28'
         ? '<span>region-wide</span>'
         : `in <span>${indicator && indicator.label.toLowerCase()}</span>`;
 
-    const areaPercent = format('.1f')(100 * gain / extent);
+    const areaPercent = format('.1f')(locationData.percentage);
     const firstSentence = `From 2001 to 2012, <span>${locationNames.current &&
       locationNames.current.label}</span> gained <strong>${
-      gain ? format('.3s')(gain) : '0'
+      locationData.gain ? format('.3s')(locationData.gain) : '0'
     }ha</strong> of tree cover ${regionPhrase}`;
-    const secondSentence = gain
+    const secondSentence = locationData.gain
       ? `, equivalent to a <strong>${areaPercent}%</strong> increase relative to <b>${
         settings.extentYear
       }</b> tree cover extent.`

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-styles.scss
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-styles.scss
@@ -4,4 +4,8 @@
   .gain-data {
     padding-top: rem(30px);
   }
+
+  .ranking-list {
+    padding-top: rem(40px);
+  }
 }

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
@@ -51,7 +51,9 @@ class WidgetTreeGainContainer extends PureComponent {
     const { settings, location, getTreeGain } = nextProps;
     if (
       !isEqual(location, this.props.location) ||
-      !isEqual(settings, this.props.settings)
+      !isEqual(settings.indicator, this.props.settings.indicator) ||
+      !isEqual(settings.threshold, this.props.settings.threshold) ||
+      !isEqual(settings.extent, this.props.settings.extent)
     ) {
       getTreeGain({
         ...location,

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
@@ -53,7 +53,7 @@ class WidgetTreeGainContainer extends PureComponent {
       !isEqual(location, this.props.location) ||
       !isEqual(settings.indicator, this.props.settings.indicator) ||
       !isEqual(settings.threshold, this.props.settings.threshold) ||
-      !isEqual(settings.extent, this.props.settings.extent)
+      !isEqual(settings.extentYear, this.props.settings.extentYear)
     ) {
       getTreeGain({
         ...location,

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
@@ -2,10 +2,11 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import COLORS from 'pages/country/data/colors.json';
 
 import actions from './widget-tree-gain-actions';
 import reducers, { initialState } from './widget-tree-gain-reducers';
-import { getSortedData, getSentence } from './widget-tree-gain-selectors';
+import { getFilteredData, getSentence } from './widget-tree-gain-selectors';
 import WidgetTreeGainComponent from './widget-tree-gain-component';
 
 const mapStateToProps = (
@@ -13,7 +14,7 @@ const mapStateToProps = (
   ownProps
 ) => {
   const { locationNames, activeIndicator } = ownProps;
-  const { data: { ranking, gain, extent }, settings } = widgetTreeGain;
+  const { data: { gain }, settings } = widgetTreeGain;
   let meta = countryData.countries;
   if (location.payload.subRegion) {
     meta = countryData.subRegions;
@@ -22,23 +23,18 @@ const mapStateToProps = (
   }
 
   const selectorData = {
-    ranking,
-    gain,
-    extent,
+    data: gain,
     settings,
     location: location.payload,
     meta,
+    colors: COLORS,
     indicator: activeIndicator,
     locationNames
   };
 
   return {
-    data: {
-      gain: widgetTreeGain.data.gain,
-      extent: widgetTreeGain.data.extent,
-      ranking: getSortedData(selectorData)
-    },
-    sentence: getSentence(selectorData)
+    data: getFilteredData(selectorData) || [],
+    sentence: getSentence(selectorData) || ''
   };
 };
 

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
@@ -27,7 +27,6 @@ class WidgetTreeGainContainer extends PureComponent {
 
   componentWillReceiveProps(nextProps) {
     const { settings, location, getTreeGain } = nextProps;
-
     if (
       !isEqual(location, this.props.location) ||
       !isEqual(settings, this.props.settings)

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
@@ -13,13 +13,11 @@ import WidgetTreeGainComponent from './widget-tree-gain-component';
 
 const mapStateToProps = ({ location, widgetTreeGain, countryData }) => {
   const { isCountriesLoading, isRegionsLoading } = countryData;
-  let meta = [];
+  let meta = countryData.countries;
   if (location.payload.subRegion) {
     meta = countryData.subRegions;
   } else if (location.payload.region) {
     meta = countryData.regions;
-  } else {
-    meta = countryData.countries;
   }
 
   return {

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
@@ -12,7 +12,6 @@ const mapStateToProps = (
   { location, widgetTreeGain, countryData },
   ownProps
 ) => {
-  const { isCountriesLoading, isRegionsLoading } = countryData;
   const { locationNames, activeIndicator } = ownProps;
   const { data: { ranking, gain, extent }, settings } = widgetTreeGain;
   let meta = countryData.countries;
@@ -34,7 +33,6 @@ const mapStateToProps = (
   };
 
   return {
-    loading: widgetTreeGain.loading || isCountriesLoading || isRegionsLoading,
     data: {
       gain: widgetTreeGain.data.gain,
       extent: widgetTreeGain.data.extent,

--- a/app/javascript/services/forest-data.js
+++ b/app/javascript/services/forest-data.js
@@ -10,7 +10,7 @@ const SQL_QUERIES = {
   gain:
     "SELECT {calc} as value FROM data WHERE {location} AND polyname = '{indicator}' AND thresh = {threshold}",
   gainRanking:
-    "SELECT {region} as region, SUM(area_gain) AS value, SUM({extentYear}) AS extent FROM data WHERE {location} AND polyname = '{polyname}' AND thresh = 0 GROUP BY region",
+    "SELECT {region} as region, SUM(area_gain) AS gain, SUM({extentYear}) AS extent FROM data WHERE {location} AND polyname = '{polyname}' AND extent <> -9999 AND thresh = 0 GROUP BY region",
   loss:
     "SELECT polyname, year_data.year as year, SUM(year_data.area_loss) as area, SUM(year_data.emissions) as emissions FROM data WHERE polyname = '{indicator}' AND {location} AND thresh= {threshold} GROUP BY polyname, iso, nested(year_data.year)",
   locations:

--- a/app/javascript/services/forest-data.js
+++ b/app/javascript/services/forest-data.js
@@ -29,13 +29,6 @@ const getLocationQuery = (country, region, subRegion) =>
     subRegion ? ` AND adm2 = ${subRegion}` : ''
   }`;
 
-const getRankingLocationQuery = (country, region, subRegion) =>
-  `${
-    region
-      ? `iso = '${country}' ${subRegion ? `AND adm1 = ${region}` : ''}`
-      : '1 = 1'
-  }`;
-
 export const getLocations = ({
   country,
   region,
@@ -137,9 +130,13 @@ export const getGainExtent = ({
     regionValue = 'adm1';
   }
 
+  const location = region
+    ? `iso = '${country}' ${subRegion ? `AND adm1 = ${region}` : ''}`
+    : '1 = 1';
+
   const url = `${REQUEST_URL}${SQL_QUERIES.gainExtent}`
     .replace('{region}', regionValue)
-    .replace('{location}', getRankingLocationQuery(country, region, subRegion))
+    .replace('{location}', location)
     .replace(
       '{extentYear}',
       extentYear === 2000 ? 'area_extent_2000' : 'area_extent'

--- a/app/javascript/services/forest-data.js
+++ b/app/javascript/services/forest-data.js
@@ -9,7 +9,7 @@ const SQL_QUERIES = {
     "SELECT SUM({extentYear}) as value, SUM(area_gadm28) as total_area FROM data WHERE {location} AND thresh = {threshold} AND polyname = '{indicator}'",
   gain:
     "SELECT {calc} as value FROM data WHERE {location} AND polyname = '{indicator}' AND thresh = {threshold}",
-  gainRanking:
+  gainExtent:
     "SELECT {region} as region, SUM(area_gain) AS gain, SUM({extentYear}) AS extent FROM data WHERE {location} AND polyname = '{polyname}' AND extent <> -9999 AND thresh = 0 GROUP BY region",
   loss:
     "SELECT polyname, year_data.year as year, SUM(year_data.area_loss) as area, SUM(year_data.emissions) as emissions FROM data WHERE polyname = '{indicator}' AND {location} AND thresh= {threshold} GROUP BY polyname, iso, nested(year_data.year)",
@@ -122,7 +122,7 @@ export const getFAOExtent = ({ country, period }) => {
   return axios.get(url);
 };
 
-export const getGainRanking = ({
+export const getGainExtent = ({
   country,
   region,
   subRegion,
@@ -136,7 +136,7 @@ export const getGainRanking = ({
     regionValue = 'adm1';
   }
 
-  const url = `${REQUEST_URL}${SQL_QUERIES.gainRanking}`
+  const url = `${REQUEST_URL}${SQL_QUERIES.gainExtent}`
     .replace('{region}', regionValue)
     .replace('{location}', getRankingLocationQuery(country, region, subRegion))
     .replace(


### PR DESCRIPTION
## Overview

The Tree cover gain widget that is currently just a dynamic sentence should be extended. A ranked list should be added to the whitespace in that widget showing 5 items at a time.

- As with all lists, the list items should be a link to their relevant country page.

- At the Admin-0 level, the ranked list shows the selected country in relation to its neighbouring ranked countries.

- At the admin-1 level, it shows the current selected admin-1 in relation to its neighbouring ranked admin-1 regions.

- At the admin-2 level, it shows the currently selected admin-2 in relation to its neighbouring ranked areas.

- A selector to change units between Ha and % should be added to the settings. This will affect whether or not we show rank order based on % or ha.

## Demo

![kapture 2018-01-17 at 12 18 41](https://user-images.githubusercontent.com/1432880/35040625-23531634-fb82-11e7-9e75-e9dec237bbb5.gif)
