### PR TITLE
Added config for relative TC widget

### DIFF
--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -43,7 +43,7 @@
     "active": true
   },
   "relativeTreeCover": {
-    "title": "Which regions are proportionatley most forested",
+    "title": "Which regions are the most forest-covered",
     "config": {
       "gridWidth": 6,
       "indicators": ["gadm28", "ifl_2013", "wdpa",

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -42,6 +42,31 @@
     },
     "active": true
   },
+  "treeLocatedRelative": {
+    "title": "Which regions are proportionatley most forested",
+    "config": {
+      "gridWidth": 6,
+      "indicators": ["gadm28", "ifl_2013", "wdpa",
+                      "ifl_2013__wdpa", "ifl_2013__mining",
+                      "primary_forest", "primary_forest__landmark",
+                      "plantations", "plantations__mining",
+                      "plantations__wdpa", "plantations__landmark"],
+      "categories": ["land-cover"],
+      "admins": ["country", "region"],
+      "selectors": ["indicators", "thresholds", "units", "extentYears"],
+      "locationCheck": true,
+      "type": "extent"
+    },
+    "settings": {
+      "indicator": "gadm28",
+      "threshold": 30,
+      "extentYear": 2010,
+      "unit": "%",
+      "pageSize": 10,
+      "page": 0
+    },
+    "active": true
+  },
   "treeLoss": {
     "title": "Tree cover loss",
     "config": {

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -42,16 +42,16 @@
     },
     "active": true
   },
-  "treeLocatedRelative": {
+  "relativeTreeCover": {
     "title": "Which regions are proportionatley most forested",
     "config": {
-      "gridWidth": 6,
+      "gridWidth": 12,
       "indicators": ["gadm28", "ifl_2013", "wdpa",
                       "ifl_2013__wdpa", "ifl_2013__mining",
                       "primary_forest", "primary_forest__landmark",
                       "plantations", "plantations__mining",
                       "plantations__wdpa", "plantations__landmark"],
-      "categories": ["land-cover"],
+      "categories": ["summary", "land-cover"],
       "admins": ["country", "region"],
       "selectors": ["indicators", "thresholds", "units", "extentYears"],
       "locationCheck": true,

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -45,7 +45,7 @@
   "relativeTreeCover": {
     "title": "Which regions are proportionatley most forested",
     "config": {
-      "gridWidth": 12,
+      "gridWidth": 6,
       "indicators": ["gadm28", "ifl_2013", "wdpa",
                       "ifl_2013__wdpa", "ifl_2013__mining",
                       "primary_forest", "primary_forest__landmark",
@@ -53,7 +53,7 @@
                       "plantations__wdpa", "plantations__landmark"],
       "categories": ["summary", "land-cover"],
       "admins": ["country", "region"],
-      "selectors": ["indicators", "thresholds", "units", "extentYears"],
+      "selectors": ["indicators", "thresholds", "extentYears"],
       "locationCheck": true,
       "type": "extent"
     },

--- a/app/javascript/pages/country/reducers.js
+++ b/app/javascript/pages/country/reducers.js
@@ -24,6 +24,7 @@ import * as widgetTreeCoverComponent from 'pages/country/widget/widgets/widget-t
 import * as widgetTreeGainComponent from 'pages/country/widget/widgets/widget-tree-gain';
 import * as widgetTreeCoverLossAreasComponent from 'pages/country/widget/widgets/widget-tree-cover-loss-areas';
 import * as widgetTreeLocatedComponent from 'pages/country/widget/widgets/widget-tree-located';
+import * as widgetRelativeTreeCoverComponent from 'pages/country/widget/widgets/widget-relative-tree-cover';
 import * as widgetTreeLossComponent from 'pages/country/widget/widgets/widget-tree-loss';
 import * as widgetFAOCoverComponent from 'pages/country/widget/widgets/widget-fao-cover';
 import * as widgetFAOReforestationComponent from 'pages/country/widget/widgets/widget-fao-reforestation';
@@ -45,6 +46,7 @@ const componentsReducers = {
   widgetTreeGain: handleActions(widgetTreeGainComponent),
   widgetTreeCoverLossAreas: handleActions(widgetTreeCoverLossAreasComponent),
   widgetTreeLocated: handleActions(widgetTreeLocatedComponent),
+  widgetRelativeTreeCover: handleActions(widgetRelativeTreeCoverComponent),
   widgetTreeLoss: handleActions(widgetTreeLossComponent),
   widgetFAOCover: handleActions(widgetFAOCoverComponent),
   widgetFAOReforestation: handleActions(widgetFAOReforestationComponent)

--- a/app/javascript/pages/country/widget/widget-actions.js
+++ b/app/javascript/pages/country/widget/widget-actions.js
@@ -7,6 +7,7 @@ import { encodeStateForUrl, decodeUrlForState } from 'utils/stateToUrl';
 import * as treeLossActions from 'pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions';
 import * as treeCoverActions from 'pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-actions';
 import * as treeLocatedActions from 'pages/country/widget/widgets/widget-tree-located/widget-tree-located-actions';
+import * as relativeTreeCoverActions from 'pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-actions';
 import * as treeGainActions from 'pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions';
 import * as FAOReforestationActions from 'pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-actions';
 import * as FAOCoverActions from 'pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-actions';
@@ -15,6 +16,7 @@ const widgetActions = {
   ...treeLossActions.default,
   ...treeCoverActions.default,
   ...treeLocatedActions.default,
+  ...relativeTreeCoverActions.default,
   ...treeGainActions.default,
   ...FAOReforestationActions.default,
   ...FAOCoverActions.default

--- a/app/javascript/pages/country/widget/widget-component.jsx
+++ b/app/javascript/pages/country/widget/widget-component.jsx
@@ -10,6 +10,7 @@ import WidgetHeader from 'pages/country/widget/components/widget-header';
 
 import WidgetTreeCover from 'pages/country/widget/widgets/widget-tree-cover';
 import WidgetTreeLocated from 'pages/country/widget/widgets/widget-tree-located';
+import WidgetRelativeTreeCover from 'pages/country/widget/widgets/widget-relative-tree-cover';
 import WidgetTreeLoss from 'pages/country/widget/widgets/widget-tree-loss';
 import WidgetTotalAreaPlantations from 'pages/country/widget/widgets/widget-total-area-plantations';
 import WidgetTreeGain from 'pages/country/widget/widgets/widget-tree-gain';
@@ -24,6 +25,7 @@ const widgets = {
   WidgetTreeCover,
   WidgetTreeGain,
   WidgetTreeLocated,
+  WidgetRelativeTreeCover,
   WidgetTreeLoss,
   WidgetTotalAreaPlantations,
   WidgetPlantationArea,
@@ -58,7 +60,8 @@ class Widget extends PureComponent {
           embed={embed}
         />
         <div className="container">
-          {!loading && !error &&
+          {!loading &&
+            !error &&
             isEmpty(data) && (
               <NoContent
                 message={`No data in selection for ${locationNames.current &&

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-actions.js
@@ -1,0 +1,47 @@
+import { createAction } from 'redux-actions';
+import { createThunkAction } from 'utils/redux';
+
+import { getLocations } from 'services/forest-data';
+
+const setRelativeTreeCoverData = createAction('setRelativeTreeCoverData');
+const setRelativeTreeCoverPage = createAction('setRelativeTreeCoverPage');
+const setRelativeTreeCoverSettings = createAction(
+  'setRelativeTreeCoverSettings'
+);
+const setRelativeTreeCoverLoading = createAction('setRelativeTreeCoverLoading');
+
+const getRelativeTreeCover = createThunkAction(
+  'getRelativeTreeCover',
+  params => (dispatch, state) => {
+    if (!state().widgetRelativeTreeCover.loading) {
+      dispatch(setRelativeTreeCoverLoading({ loading: true, error: false }));
+      getLocations(params)
+        .then(response => {
+          const { data } = response.data;
+          let mappedData = [];
+          if (data && data.length) {
+            mappedData = data.map(d => ({
+              id: d.region,
+              extent: d.extent || 0,
+              percentage: d.extent ? d.extent / d.total * 100 : 0
+            }));
+          }
+          dispatch(setRelativeTreeCoverData(mappedData));
+        })
+        .catch(error => {
+          dispatch(
+            setRelativeTreeCoverLoading({ loading: false, error: true })
+          );
+          console.error(error);
+        });
+    }
+  }
+);
+
+export default {
+  setRelativeTreeCoverData,
+  setRelativeTreeCoverPage,
+  setRelativeTreeCoverSettings,
+  setRelativeTreeCoverLoading,
+  getRelativeTreeCover
+};

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-component.js
@@ -1,0 +1,58 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import WidgetPieChart from 'pages/country/widget/components/widget-pie-chart';
+import WidgetNumberedList from 'pages/country/widget/components/widget-numbered-list';
+import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
+import COLORS from 'pages/country/data/colors.json';
+
+import './widget-relative-tree-cover-styles.scss';
+
+class WidgetRelativeTreeCover extends PureComponent {
+  render() {
+    const {
+      data,
+      chartData,
+      settings,
+      handlePageChange,
+      embed,
+      sentence
+    } = this.props;
+
+    return (
+      <div className="c-widget-relative-tree-cover">
+        <WidgetDynamicSentence sentence={sentence} />
+        {data &&
+          chartData &&
+          data.length > 0 && (
+            <div className="locations-container">
+              <WidgetPieChart
+                className="locations-pie-chart"
+                data={chartData}
+                dataKey="percentage"
+              />
+              <WidgetNumberedList
+                className="locations-list"
+                data={data}
+                settings={settings}
+                handlePageChange={handlePageChange}
+                colorRange={[COLORS.darkGreen, COLORS.nonForest]}
+                linksDisabled={embed}
+              />
+            </div>
+          )}
+      </div>
+    );
+  }
+}
+
+WidgetRelativeTreeCover.propTypes = {
+  data: PropTypes.array,
+  chartData: PropTypes.array,
+  settings: PropTypes.object.isRequired,
+  handlePageChange: PropTypes.func.isRequired,
+  embed: PropTypes.bool,
+  sentence: PropTypes.string
+};
+
+export default WidgetRelativeTreeCover;

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-component.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-import WidgetPieChart from 'pages/country/widget/components/widget-pie-chart';
 import WidgetNumberedList from 'pages/country/widget/components/widget-numbered-list';
 import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
 import COLORS from 'pages/country/data/colors.json';
@@ -10,27 +9,14 @@ import './widget-relative-tree-cover-styles.scss';
 
 class WidgetRelativeTreeCover extends PureComponent {
   render() {
-    const {
-      data,
-      chartData,
-      settings,
-      handlePageChange,
-      embed,
-      sentence
-    } = this.props;
+    const { data, settings, handlePageChange, embed, sentence } = this.props;
 
     return (
       <div className="c-widget-relative-tree-cover">
         <WidgetDynamicSentence sentence={sentence} />
         {data &&
-          chartData &&
           data.length > 0 && (
             <div className="locations-container">
-              <WidgetPieChart
-                className="locations-pie-chart"
-                data={chartData}
-                dataKey="percentage"
-              />
               <WidgetNumberedList
                 className="locations-list"
                 data={data}
@@ -48,7 +34,6 @@ class WidgetRelativeTreeCover extends PureComponent {
 
 WidgetRelativeTreeCover.propTypes = {
   data: PropTypes.array,
-  chartData: PropTypes.array,
   settings: PropTypes.object.isRequired,
   handlePageChange: PropTypes.func.isRequired,
   embed: PropTypes.bool,

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-reducers.js
@@ -1,0 +1,50 @@
+import WIDGETS_CONFIG from 'pages/country/data/widgets-config.json';
+
+export const initialState = {
+  loading: false,
+  error: false,
+  data: {
+    regions: []
+  },
+  ...WIDGETS_CONFIG.relativeTreeCover
+};
+
+const setRelativeTreeCoverData = (state, { payload }) => ({
+  ...state,
+  loading: false,
+  data: {
+    regions: payload
+  },
+  settings: {
+    ...state.settings,
+    page: 0
+  }
+});
+
+const setRelativeTreeCoverPage = (state, { payload }) => ({
+  ...state,
+  settings: {
+    ...state.settings,
+    page: payload
+  }
+});
+
+const setRelativeTreeCoverSettings = (state, { payload }) => ({
+  ...state,
+  settings: {
+    ...state.settings,
+    ...payload
+  }
+});
+
+const setRelativeTreeCoverLoading = (state, { payload }) => ({
+  ...state,
+  ...payload
+});
+
+export default {
+  setRelativeTreeCoverData,
+  setRelativeTreeCoverPage,
+  setRelativeTreeCoverSettings,
+  setRelativeTreeCoverLoading
+};

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-selectors.js
@@ -1,0 +1,138 @@
+import { createSelector } from 'reselect';
+import isEmpty from 'lodash/isEmpty';
+import uniqBy from 'lodash/uniqBy';
+import sumBy from 'lodash/sumBy';
+import { sortByKey, getColorPalette } from 'utils/data';
+import { format } from 'd3-format';
+
+// get list data
+const getData = state => state.data || null;
+const getSettings = state => state.settings || null;
+const getOptions = state => state.options || null;
+const getIndicator = state => state.indicator || null;
+const getLocation = state => state.location || null;
+const getLocationsMeta = state => state.meta || null;
+const getLocationNames = state => state.locationNames || null;
+const getColors = state => state.colors || null;
+
+export const getSortedData = createSelector(
+  [getData, getSettings, getLocation, getLocationsMeta],
+  (data, settings, location, meta) => {
+    if (!data || isEmpty(data) || !meta || isEmpty(meta)) return null;
+    const dataMapped = [];
+    const totalExtent = sumBy(data, 'extent');
+    data.forEach(d => {
+      const region = meta.find(l => d.id === l.value);
+      if (region) {
+        const percentage = d.extent / totalExtent * 100;
+        dataMapped.push({
+          label: (region && region.label) || '',
+          extent: d.extent,
+          percentage,
+          value: settings.unit === 'ha' ? d.extent : percentage,
+          path: `/country/${location.country}/${
+            location.region ? `${location.region}/` : ''
+          }${d.id}`
+        });
+      }
+    });
+    return sortByKey(uniqBy(dataMapped, 'label'), 'value', true);
+  }
+);
+
+export const getChartData = createSelector(
+  [getSortedData, getColors],
+  (data, colors) => {
+    if (!data || !data.length) return null;
+    const topRegions = data.length > 10 ? data.slice(0, 10) : data;
+    const totalExtent = sumBy(data, 'extent');
+    const otherRegions = data.length > 10 ? data.slice(10) : [];
+    const othersExtent = otherRegions.length && sumBy(otherRegions, 'extent');
+    const colorRange = getColorPalette(
+      [colors.darkGreen, colors.nonForest],
+      data.length > 10 ? topRegions.length + 1 : data.length
+    );
+    const topChartData = topRegions.map((d, index) => ({
+      ...d,
+      color: colorRange[index]
+    }));
+    const otherRegionsData = otherRegions.length
+      ? {
+        label: 'Other regions',
+        percentage: othersExtent ? othersExtent / totalExtent * 100 : 0,
+        color: colorRange[topRegions.length]
+      }
+      : {};
+
+    return [...topChartData, otherRegionsData];
+  }
+);
+
+export const getSentence = createSelector(
+  [
+    getSortedData,
+    getSettings,
+    getOptions,
+    getLocation,
+    getIndicator,
+    getLocationNames
+  ],
+  (data, settings, options, location, indicator, locationNames) => {
+    if (!data || !options || !indicator || !locationNames) return '';
+    const { extentYear, threshold } = settings;
+    const totalExtent = sumBy(data, 'extent');
+    const currentLocation =
+      locationNames && locationNames.current && locationNames.current.label;
+    const topRegion = data.length && data[0];
+    const avgExtentPercentage = sumBy(data, 'percentage') / data.length;
+    const avgExtent = sumBy(data, 'extent') / data.length;
+    let percentileExtent = 0;
+    let percentileLength = 0;
+    let sentence = '';
+
+    if (indicator.value !== 'gadm28') {
+      sentence += `For <b>${
+        indicator.label
+      }</b> in <b>${currentLocation}</b>, `;
+    } else {
+      sentence += `In <b>${currentLocation}</b>, `;
+    }
+    while (
+      (percentileLength < data.length &&
+        percentileExtent / totalExtent < 0.5) ||
+      (percentileLength < 10 && data.length > 10)
+    ) {
+      percentileExtent += data[percentileLength].extent;
+      percentileLength += 1;
+    }
+    const topExtent = percentileExtent / totalExtent * 100;
+
+    if (percentileLength > 1) {
+      sentence += `the top <b>${percentileLength}</b> regions represents <b>`;
+    } else {
+      sentence += `<b>${topRegion.label}</b> represents <b>`;
+    }
+    if (!location.region) {
+      sentence += `more than half (${format('.0f')(topExtent)}%)`;
+    } else {
+      sentence += `${format('.0f')(topExtent)}%`;
+    }
+    sentence += `</b> of all tree cover in <b>${extentYear}</b> where tree canopy is greater than <b>${threshold}%</b>. `;
+    sentence += `${
+      percentileLength > 1 ? `<b>${topRegion.label}</b>` : 'This region'
+    } has the largest tree cover at `;
+    if (topRegion.percentage > 1 && settings.unit === '%') {
+      sentence += `<b>${format('.0f')(
+        topRegion.percentage
+      )}%</b> compared to an average of <b>${format('.0f')(
+        avgExtentPercentage
+      )}%</b>.`;
+    } else {
+      sentence += `<b>${format('.3s')(
+        topRegion.extent
+      )}ha</b> compared to an average of <b>${format('.3s')(avgExtent)}ha</b>.`;
+    }
+
+    return sentence;
+  }
+);

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-selectors.js
@@ -2,7 +2,7 @@ import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import uniqBy from 'lodash/uniqBy';
 import sumBy from 'lodash/sumBy';
-import { sortByKey, getColorPalette } from 'utils/data';
+import { sortByKey } from 'utils/data';
 import { format } from 'd3-format';
 
 // get list data
@@ -13,23 +13,20 @@ const getIndicator = state => state.indicator || null;
 const getLocation = state => state.location || null;
 const getLocationsMeta = state => state.meta || null;
 const getLocationNames = state => state.locationNames || null;
-const getColors = state => state.colors || null;
 
 export const getSortedData = createSelector(
   [getData, getSettings, getLocation, getLocationsMeta],
   (data, settings, location, meta) => {
     if (!data || isEmpty(data) || !meta || isEmpty(meta)) return null;
     const dataMapped = [];
-    const totalExtent = sumBy(data, 'extent');
     data.forEach(d => {
       const region = meta.find(l => d.id === l.value);
       if (region) {
-        const percentage = d.extent / totalExtent * 100;
         dataMapped.push({
           label: (region && region.label) || '',
           extent: d.extent,
-          percentage,
-          value: settings.unit === 'ha' ? d.extent : percentage,
+          percentage: d.percentage,
+          value: settings.unit === 'ha' ? d.extent : d.percentage,
           path: `/country/${location.country}/${
             location.region ? `${location.region}/` : ''
           }${d.id}`
@@ -37,34 +34,6 @@ export const getSortedData = createSelector(
       }
     });
     return sortByKey(uniqBy(dataMapped, 'label'), 'value', true);
-  }
-);
-
-export const getChartData = createSelector(
-  [getSortedData, getColors],
-  (data, colors) => {
-    if (!data || !data.length) return null;
-    const topRegions = data.length > 10 ? data.slice(0, 10) : data;
-    const totalExtent = sumBy(data, 'extent');
-    const otherRegions = data.length > 10 ? data.slice(10) : [];
-    const othersExtent = otherRegions.length && sumBy(otherRegions, 'extent');
-    const colorRange = getColorPalette(
-      [colors.darkGreen, colors.nonForest],
-      data.length > 10 ? topRegions.length + 1 : data.length
-    );
-    const topChartData = topRegions.map((d, index) => ({
-      ...d,
-      color: colorRange[index]
-    }));
-    const otherRegionsData = otherRegions.length
-      ? {
-        label: 'Other regions',
-        percentage: othersExtent ? othersExtent / totalExtent * 100 : 0,
-        color: colorRange[topRegions.length]
-      }
-      : {};
-
-    return [...topChartData, otherRegionsData];
   }
 );
 
@@ -80,58 +49,15 @@ export const getSentence = createSelector(
   (data, settings, options, location, indicator, locationNames) => {
     if (!data || !options || !indicator || !locationNames) return '';
     const { extentYear, threshold } = settings;
-    const totalExtent = sumBy(data, 'extent');
-    const currentLocation =
-      locationNames && locationNames.current && locationNames.current.label;
     const topRegion = data.length && data[0];
     const avgExtentPercentage = sumBy(data, 'percentage') / data.length;
-    const avgExtent = sumBy(data, 'extent') / data.length;
-    let percentileExtent = 0;
-    let percentileLength = 0;
-    let sentence = '';
-
-    if (indicator.value !== 'gadm28') {
-      sentence += `For <b>${
-        indicator.label
-      }</b> in <b>${currentLocation}</b>, `;
-    } else {
-      sentence += `In <b>${currentLocation}</b>, `;
-    }
-    while (
-      (percentileLength < data.length &&
-        percentileExtent / totalExtent < 0.5) ||
-      (percentileLength < 10 && data.length > 10)
-    ) {
-      percentileExtent += data[percentileLength].extent;
-      percentileLength += 1;
-    }
-    const topExtent = percentileExtent / totalExtent * 100;
-
-    if (percentileLength > 1) {
-      sentence += `the top <b>${percentileLength}</b> regions represents <b>`;
-    } else {
-      sentence += `<b>${topRegion.label}</b> represents <b>`;
-    }
-    if (!location.region) {
-      sentence += `more than half (${format('.0f')(topExtent)}%)`;
-    } else {
-      sentence += `${format('.0f')(topExtent)}%`;
-    }
-    sentence += `</b> of all tree cover in <b>${extentYear}</b> where tree canopy is greater than <b>${threshold}%</b>. `;
-    sentence += `${
-      percentileLength > 1 ? `<b>${topRegion.label}</b>` : 'This region'
-    } has the largest tree cover at `;
-    if (topRegion.percentage > 1 && settings.unit === '%') {
-      sentence += `<b>${format('.0f')(
-        topRegion.percentage
-      )}%</b> compared to an average of <b>${format('.0f')(
-        avgExtentPercentage
-      )}%</b>.`;
-    } else {
-      sentence += `<b>${format('.3s')(
-        topRegion.extent
-      )}ha</b> compared to an average of <b>${format('.3s')(avgExtent)}ha</b>.`;
-    }
+    const sentence = `<b>${
+      topRegion.label
+    }</b> had the largest relative tree cover of <b>${format('.0f')(
+      topRegion.percentage
+    )}%</b>, compared to a regional average of <b>${format('.0f')(
+      avgExtentPercentage
+    )}%</b>, considering tree cover extent in <b>${extentYear}</b> with a canopy cover of greater than <b>${threshold}%</b>.`;
 
     return sentence;
   }

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-styles.scss
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-styles.scss
@@ -2,45 +2,6 @@
 
 .c-widget-relative-tree-cover {
   .locations-container {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: flex-start;
     margin-top: rem(30px);
-    padding: 0 rem(15px);
-
-    .locations-list {
-      width: 100%;
-
-      @media screen and (min-width: $screen-m) {
-        width: 50%;
-      }
-
-      @media screen and (min-width: $screen-l) {
-        width: 40%;
-      }
-    }
-
-    .locations-pie-chart {
-      display: none;
-      width: 50%;
-      min-width: 50%;
-      justify-content: center;
-      align-items: center;
-
-      @media screen and (min-width: $screen-m) {
-        display: flex;
-        padding-right: rem(40px);
-      }
-
-      @media screen and (min-width: $screen-l) {
-        width: 60%;
-        min-width: 60%;
-      }
-
-      .recharts-responsive-container {
-        max-width: rem(230px);
-      }
-    }
   }
 }

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-styles.scss
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-styles.scss
@@ -1,0 +1,46 @@
+@import '~styles/settings.scss';
+
+.c-widget-relative-tree-cover {
+  .locations-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-top: rem(30px);
+    padding: 0 rem(15px);
+
+    .locations-list {
+      width: 100%;
+
+      @media screen and (min-width: $screen-m) {
+        width: 50%;
+      }
+
+      @media screen and (min-width: $screen-l) {
+        width: 40%;
+      }
+    }
+
+    .locations-pie-chart {
+      display: none;
+      width: 50%;
+      min-width: 50%;
+      justify-content: center;
+      align-items: center;
+
+      @media screen and (min-width: $screen-m) {
+        display: flex;
+        padding-right: rem(40px);
+      }
+
+      @media screen and (min-width: $screen-l) {
+        width: 60%;
+        min-width: 60%;
+      }
+
+      .recharts-responsive-container {
+        max-width: rem(230px);
+      }
+    }
+  }
+}

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover.js
@@ -1,0 +1,93 @@
+import { createElement, PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import isEqual from 'lodash/isEqual';
+import COLORS from 'pages/country/data/colors.json';
+
+import actions from './widget-relative-tree-cover-actions';
+import reducers, { initialState } from './widget-relative-tree-cover-reducers';
+import {
+  getSortedData,
+  getChartData,
+  getSentence
+} from './widget-relative-tree-cover-selectors';
+import WidgetRelativeTreeCoverComponent from './widget-relative-tree-cover-component';
+
+const mapStateToProps = (
+  { location, widgetRelativeTreeCover, countryData },
+  ownProps
+) => {
+  const { isCountriesLoading, isRegionsLoading } = countryData;
+  const { settings, data, loading } = widgetRelativeTreeCover;
+  const { settingsConfig, activeIndicator } = ownProps;
+  const { payload } = location;
+  const selectorData = {
+    data: data.regions,
+    settings,
+    options: settingsConfig.options,
+    meta: countryData[!payload.region ? 'regions' : 'subRegions'],
+    location: payload,
+    colors: COLORS,
+    indicator: activeIndicator,
+    locationNames: ownProps.locationNames
+  };
+  return {
+    regions: countryData.regions,
+    loading: loading || isCountriesLoading || isRegionsLoading,
+    data: getSortedData(selectorData),
+    chartData: getChartData(selectorData),
+    sentence: getSentence(selectorData)
+  };
+};
+
+class WidgetRelativeTreeCoverContainer extends PureComponent {
+  componentWillMount() {
+    const { location, settings, getRelativeTreeCover } = this.props;
+    getRelativeTreeCover({
+      ...location,
+      ...settings
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { settings, location, getRelativeTreeCover } = nextProps;
+
+    if (
+      !isEqual(location.country, this.props.location.country) ||
+      !isEqual(location.region, this.props.location.region) ||
+      !isEqual(settings.indicator, this.props.settings.indicator) ||
+      !isEqual(settings.extentYear, this.props.settings.extentYear) ||
+      !isEqual(settings.threshold, this.props.settings.threshold)
+    ) {
+      getRelativeTreeCover({
+        ...location,
+        ...settings
+      });
+    }
+  }
+
+  handlePageChange = change => {
+    const { setRelativeTreeCoverPage, settings } = this.props;
+    setRelativeTreeCoverPage(settings.page + change);
+  };
+
+  render() {
+    return createElement(WidgetRelativeTreeCoverComponent, {
+      ...this.props,
+      handlePageChange: this.handlePageChange
+    });
+  }
+}
+
+WidgetRelativeTreeCoverContainer.propTypes = {
+  setRelativeTreeCoverPage: PropTypes.func.isRequired,
+  settings: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  getRelativeTreeCover: PropTypes.func.isRequired
+};
+
+export { actions, reducers, initialState };
+
+export default connect(mapStateToProps, actions)(
+  WidgetRelativeTreeCoverContainer
+);

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover.js
@@ -2,13 +2,11 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
-import COLORS from 'pages/country/data/colors.json';
 
 import actions from './widget-relative-tree-cover-actions';
 import reducers, { initialState } from './widget-relative-tree-cover-reducers';
 import {
   getSortedData,
-  getChartData,
   getSentence
 } from './widget-relative-tree-cover-selectors';
 import WidgetRelativeTreeCoverComponent from './widget-relative-tree-cover-component';
@@ -27,7 +25,6 @@ const mapStateToProps = (
     options: settingsConfig.options,
     meta: countryData[!payload.region ? 'regions' : 'subRegions'],
     location: payload,
-    colors: COLORS,
     indicator: activeIndicator,
     locationNames: ownProps.locationNames
   };
@@ -35,7 +32,6 @@ const mapStateToProps = (
     regions: countryData.regions,
     loading: loading || isCountriesLoading || isRegionsLoading,
     data: getSortedData(selectorData),
-    chartData: getChartData(selectorData),
     sentence: getSentence(selectorData)
   };
 };


### PR DESCRIPTION
## Overview

Added start of Relative tree cover widget by updating config file. This is the remaining piece of the tree cover widget which was split up after suggestions from Juan Carlos.

The widget should show a ranked list of relative tree cover (%), in a half-width widget.

The dynamic sentence should say. 

```<1st Sub region> had the largest relative tree cover of <X>%, compared to a regional average of <Y>%, considering tree cover extent in <year> with a canopy cover of greater than <Z>%.```
