### PR TITLE
Feature/intact forest layer widget

### DIFF
--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -22,7 +22,6 @@
     "config": {
       "gridWidth": 6,
       "indicators": ["ifl_2013", "ifl_2013__wdpa", "ifl_2013__mining"],
-      "showIndicators": ["ifl_2013", "ifl_2013__wdpa", "ifl_2013__mining"],
       "categories": ["land-cover"],
       "admins": ["country", "region", "subRegion"],
       "selectors": ["indicators", "thresholds", "extentYears"],

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -21,7 +21,8 @@
     "title": "Intact forests tree cover extent",
     "config": {
       "gridWidth": 6,
-      "indicators": ["ifl_2013", "ifl_2013__wdpa", "ifl_2013__mining", "landmark"],
+      "indicators": ["ifl_2013", "ifl_2013__wdpa", "ifl_2013__mining"],
+      "showIndicators": ["ifl_2013", "ifl_2013__wdpa", "ifl_2013__mining"],
       "categories": ["land-cover"],
       "admins": ["country", "region", "subRegion"],
       "selectors": ["indicators", "thresholds", "extentYears"],

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -13,12 +13,12 @@
     "settings": {
       "indicator": "gadm28",
       "threshold": 30,
-      "extentYear": 2000
+      "extentYear": 2010
     },
     "active": true
   },
   "intactTreeCover": {
-    "title": "Intact forests tree cover extent",
+    "title": "Intact forest extent",
     "config": {
       "gridWidth": 6,
       "indicators": ["ifl_2013", "ifl_2013__wdpa", "ifl_2013__mining"],
@@ -31,7 +31,7 @@
     "settings": {
       "indicator": "ifl_2013",
       "threshold": 30,
-      "extentYear": 2000
+      "extentYear": 2010
     },
     "active": true
   },

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -17,6 +17,23 @@
     },
     "active": true
   },
+  "intactTreeCover": {
+    "title": "Intact forests tree cover extent",
+    "config": {
+      "gridWidth": 6,
+      "indicators": ["ifl_2013", "ifl_2013__wdpa", "ifl_2013__mining", "landmark"],
+      "categories": ["land-cover"],
+      "admins": ["country", "region", "subRegion"],
+      "selectors": ["indicators", "thresholds", "extentYears"],
+      "type": "extent"
+    },
+    "settings": {
+      "indicator": "ifl_2013",
+      "threshold": 30,
+      "extentYear": 2000
+    },
+    "active": true
+  },
   "treeLocated": {
     "title": "Where are the forests located",
     "config": {

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -47,7 +47,7 @@
       "categories": ["summary", "land-cover"],
       "admins": ["country", "region"],
       "selectors": ["indicators", "thresholds", "units", "extentYears"],
-      "locationCheck": false,
+      "locationCheck": true,
       "type": "extent"
     },
     "settings": {
@@ -58,7 +58,7 @@
       "pageSize": 10,
       "page": 0
     },
-    "active": false
+    "active": true
   },
   "treeLoss": {
     "title": "Tree cover loss",
@@ -81,7 +81,7 @@
       "endYear": 2016,
       "extentYear": 2000
     },
-    "active": false
+    "active": true
   },
   "treeGain": {
     "title": "Tree cover gain",
@@ -97,7 +97,7 @@
       "indicator": "gadm28",
       "threshold": "0"
     },
-    "active": false
+    "active": true
   },
   "FAOReforestation": {
     "title": "FAO reforestation",
@@ -112,7 +112,7 @@
       "period": 2010,
       "unit": "ha/year"
     },
-    "active": false
+    "active": true
   },
   "FAOCover": {
     "title": "Forest cover",
@@ -122,6 +122,6 @@
       "admins": ["country"],
       "type": "fao"
     },
-    "active": false
+    "active": true
   }
 }

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -29,7 +29,7 @@
       "categories": ["summary", "land-cover"],
       "admins": ["country", "region"],
       "selectors": ["indicators", "thresholds", "units", "extentYears"],
-      "locationCheck": true,
+      "locationCheck": false,
       "type": "extent"
     },
     "settings": {
@@ -40,7 +40,7 @@
       "pageSize": 10,
       "page": 0
     },
-    "active": true
+    "active": false
   },
   "treeLoss": {
     "title": "Tree cover loss",
@@ -63,7 +63,7 @@
       "endYear": 2016,
       "extentYear": 2000
     },
-    "active": true
+    "active": false
   },
   "treeGain": {
     "title": "Tree cover gain",
@@ -79,7 +79,7 @@
       "indicator": "gadm28",
       "threshold": "0"
     },
-    "active": true
+    "active": false
   },
   "FAOReforestation": {
     "title": "FAO reforestation",
@@ -94,7 +94,7 @@
       "period": 2010,
       "unit": "ha/year"
     },
-    "active": true
+    "active": false
   },
   "FAOCover": {
     "title": "Forest cover",
@@ -104,6 +104,6 @@
       "admins": ["country"],
       "type": "fao"
     },
-    "active": true
+    "active": false
   }
 }

--- a/app/javascript/pages/country/reducers.js
+++ b/app/javascript/pages/country/reducers.js
@@ -21,6 +21,7 @@ import * as widgetAreasMostCoverGainComponent from 'pages/country/widget/widgets
 import * as widgetPlantationAreaComponent from 'pages/country/widget/widgets/widget-plantation-area';
 import * as widgetTotalAreaPlantationsComponent from 'pages/country/widget/widgets/widget-total-area-plantations';
 import * as widgetTreeCoverComponent from 'pages/country/widget/widgets/widget-tree-cover';
+import * as widgetIntactTreeCoverComponent from 'pages/country/widget/widgets/widget-intact-tree-cover';
 import * as widgetTreeGainComponent from 'pages/country/widget/widgets/widget-tree-gain';
 import * as widgetTreeCoverLossAreasComponent from 'pages/country/widget/widgets/widget-tree-cover-loss-areas';
 import * as widgetTreeLocatedComponent from 'pages/country/widget/widgets/widget-tree-located';
@@ -42,6 +43,7 @@ const componentsReducers = {
     widgetTotalAreaPlantationsComponent
   ),
   widgetTreeCover: handleActions(widgetTreeCoverComponent),
+  widgetIntactTreeCover: handleActions(widgetIntactTreeCoverComponent),
   widgetTreeGain: handleActions(widgetTreeGainComponent),
   widgetTreeCoverLossAreas: handleActions(widgetTreeCoverLossAreasComponent),
   widgetTreeLocated: handleActions(widgetTreeLocatedComponent),

--- a/app/javascript/pages/country/root/root-styles.scss
+++ b/app/javascript/pages/country/root/root-styles.scss
@@ -47,6 +47,7 @@ $black-tabs: #404040;
       width: 30%;
       position: absolute;
       margin-top: 0;
+      z-index: 200;
     }
 
     @media screen and (min-width: $screen-xl) {
@@ -93,6 +94,7 @@ $black-tabs: #404040;
 
     @media screen and (min-width: $screen-m) {
       display: none;
+      z-index: 220;
     }
 
     &:focus {
@@ -100,6 +102,7 @@ $black-tabs: #404040;
     }
 
     &.close-map {
+      background-color: $white;
       top: rem(15px);
     }
 

--- a/app/javascript/pages/country/widget/widget-actions.js
+++ b/app/javascript/pages/country/widget/widget-actions.js
@@ -6,6 +6,7 @@ import { encodeStateForUrl, decodeUrlForState } from 'utils/stateToUrl';
 
 import * as treeLossActions from 'pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions';
 import * as treeCoverActions from 'pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-actions';
+import * as intactTreeCoverActions from 'pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-actions';
 import * as treeLocatedActions from 'pages/country/widget/widgets/widget-tree-located/widget-tree-located-actions';
 import * as treeGainActions from 'pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions';
 import * as FAOReforestationActions from 'pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-actions';
@@ -14,6 +15,7 @@ import * as FAOCoverActions from 'pages/country/widget/widgets/widget-fao-cover/
 const widgetActions = {
   ...treeLossActions.default,
   ...treeCoverActions.default,
+  ...intactTreeCoverActions.default,
   ...treeLocatedActions.default,
   ...treeGainActions.default,
   ...FAOReforestationActions.default,

--- a/app/javascript/pages/country/widget/widget-component.jsx
+++ b/app/javascript/pages/country/widget/widget-component.jsx
@@ -9,6 +9,7 @@ import NoContent from 'components/no-content';
 import WidgetHeader from 'pages/country/widget/components/widget-header';
 
 import WidgetTreeCover from 'pages/country/widget/widgets/widget-tree-cover';
+import WidgetIntactTreeCover from 'pages/country/widget/widgets/widget-intact-tree-cover';
 import WidgetTreeLocated from 'pages/country/widget/widgets/widget-tree-located';
 import WidgetTreeLoss from 'pages/country/widget/widgets/widget-tree-loss';
 import WidgetTotalAreaPlantations from 'pages/country/widget/widgets/widget-total-area-plantations';
@@ -22,6 +23,7 @@ import './widget-tooltip-styles.scss';
 
 const widgets = {
   WidgetTreeCover,
+  WidgetIntactTreeCover,
   WidgetTreeGain,
   WidgetTreeLocated,
   WidgetTreeLoss,
@@ -58,7 +60,8 @@ class Widget extends PureComponent {
           embed={embed}
         />
         <div className="container">
-          {!loading && !error &&
+          {!loading &&
+            !error &&
             isEmpty(data) && (
               <NoContent
                 message={`No data in selection for ${locationNames.current &&

--- a/app/javascript/pages/country/widget/widget-selectors.js
+++ b/app/javascript/pages/country/widget/widget-selectors.js
@@ -32,6 +32,9 @@ export const getActiveAdmin = location => {
 export const getActiveFilter = (settings, filters, key) =>
   (filters ? filters.find(i => i.value === settings[key]) : null);
 
+export const getActiveIndicator = indicator =>
+  INDICATORS.find(i => i.value === indicator);
+
 export const getLocationLabel = (location, indicator, indicators) => {
   if (!location || !indicators || !indicators.length) return '';
   const activeIndicator = indicators.find(i => i.value === indicator);

--- a/app/javascript/pages/country/widget/widget.js
+++ b/app/javascript/pages/country/widget/widget.js
@@ -64,11 +64,7 @@ const mapStateToProps = (state, ownProps) => {
     activeLocation: widgetSelectors.getActiveAdmin({
       location: location.payload
     }),
-    activeIndicator: widgetSelectors.getActiveFilter(
-      settings,
-      options.indicators,
-      'indicator'
-    ),
+    activeIndicator: widgetSelectors.getActiveIndicator(settings.indicator),
     location: location.payload,
     title,
     loading,

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-actions.js
@@ -17,16 +17,16 @@ const getFAOCover = createThunkAction(
         .all([getFAO({ ...params }), getRanking({ ...params })])
         .then(
           axios.spread((getFAOResponse, getRankingResponse) => {
-            const data =
-              getFAOResponse.data.rows.length && getFAOResponse.data.rows[0];
+            let data = {};
+            const fao = getFAOResponse.data.rows;
             const ranking = getRankingResponse.data.rows;
-            const values = {
-              fao: {
-                ...data
-              },
-              rank: ranking[0].rank || 0
-            };
-            dispatch(setFAOCoverData(values));
+            if (fao.length && ranking.length) {
+              data = {
+                ...fao[0],
+                rank: ranking[0].rank || 0
+              };
+            }
+            dispatch(setFAOCoverData(data));
           })
         )
         .catch(error => {

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-component.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import isEmpty from 'lodash/isEmpty';
 
 import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
 import WidgetPieChart from 'pages/country/widget/components/widget-pie-chart';
@@ -8,40 +9,39 @@ import './widget-fao-cover-styles.scss';
 
 class WidgetFAOCover extends PureComponent {
   render() {
-    const { data, getSentence } = this.props;
+    const { data, sentence } = this.props;
 
     return (
       <div className="c-widget-fao-cover">
-        {data &&
-          data.length > 0 && (
-            <div>
-              <WidgetDynamicSentence sentence={getSentence()} />
-              <div className="pie-chart-container">
-                <WidgetPieChartLegend
-                  className="pie-chart-legend"
-                  data={data}
-                  settings={{
-                    unit: '%',
-                    format: '.1f',
-                    key: 'percentage'
-                  }}
-                />
-                <WidgetPieChart
-                  className="cover-pie-chart"
-                  data={data}
-                  maxSize={140}
-                />
-              </div>
+        {!isEmpty(data) && (
+          <div>
+            {sentence && <WidgetDynamicSentence sentence={sentence} />}
+            <div className="pie-chart-container">
+              <WidgetPieChartLegend
+                className="pie-chart-legend"
+                data={data}
+                settings={{
+                  unit: '%',
+                  format: '.1f',
+                  key: 'percentage'
+                }}
+              />
+              <WidgetPieChart
+                className="cover-pie-chart"
+                data={data}
+                maxSize={140}
+              />
             </div>
-          )}
+          </div>
+        )}
       </div>
     );
   }
 }
 
 WidgetFAOCover.propTypes = {
-  data: PropTypes.array.isRequired,
-  getSentence: PropTypes.func.isRequired
+  data: PropTypes.array,
+  sentence: PropTypes.string
 };
 
 export default WidgetFAOCover;

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-reducers.js
@@ -3,10 +3,7 @@ import WIDGETS_CONFIG from 'pages/country/data/widgets-config.json';
 export const initialState = {
   loading: false,
   error: false,
-  data: {
-    fao: {},
-    rank: 0
-  },
+  data: {},
   ...WIDGETS_CONFIG.FAOCover
 };
 
@@ -18,9 +15,7 @@ const setFAOCoverLoading = (state, { payload }) => ({
 const setFAOCoverData = (state, { payload }) => ({
   ...state,
   loading: false,
-  data: {
-    ...payload
-  }
+  data: payload
 });
 
 export default {

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover.js
@@ -2,21 +2,22 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
-import { format } from 'd3-format';
 
 import actions from './widget-fao-cover-actions';
 import reducers, { initialState } from './widget-fao-cover-reducers';
-import { getFAOCoverData } from './widget-fao-cover-selectors';
+import { getFAOCoverData, getSentence } from './widget-fao-cover-selectors';
 import WidgetFAOCoverComponent from './widget-fao-cover-component';
 
 const mapStateToProps = ({ widgetFAOCover }, ownProps) => {
-  const { fao, rank } = widgetFAOCover.data;
+  const { data } = widgetFAOCover;
+  const { locationNames } = ownProps;
+  const selectorData = {
+    data,
+    locationNames
+  };
   return {
-    fao,
-    rank,
-    data:
-      getFAOCoverData({ fao, rank, locationNames: ownProps.locationNames }) ||
-      {}
+    data: getFAOCoverData(selectorData),
+    sentence: getSentence(selectorData)
   };
 };
 
@@ -34,53 +35,15 @@ class WidgetFAOCoverContainer extends PureComponent {
     }
   }
 
-  getSentence = () => {
-    const {
-      locationNames,
-      fao: {
-        area_ha,
-        extent,
-        forest_planted,
-        forest_primary,
-        forest_regenerated
-      },
-      rank
-    } = this.props;
-
-    const naturallyRegenerated = extent / 100 * forest_regenerated;
-    const primaryForest = extent / 100 * forest_primary;
-    const plantedForest = extent / 100 * forest_planted;
-    const nonForest =
-      area_ha - (naturallyRegenerated + primaryForest + plantedForest);
-
-    const sentence = `FAO data from 2015 shows that ${locationNames.current &&
-      locationNames.current.label} is ${
-      nonForest / area_ha > 0.5 ? 'mostly non-forest.' : 'mostly forest.'
-    }${
-      primaryForest > 0
-        ? ` Primary forest occupies <strong>${format('.1f')(
-          primaryForest / area_ha * 100
-        )}%</strong> of the country. This gives ${locationNames.current &&
-            locationNames.current
-              .label} a rank of <strong>${rank}th</strong> out of 110 countries in terms of its relative amount of primary forest.`
-        : ''
-    }`;
-    return sentence;
-  };
-
   render() {
     return createElement(WidgetFAOCoverComponent, {
-      ...this.props,
-      getSentence: this.getSentence
+      ...this.props
     });
   }
 }
 
 WidgetFAOCoverContainer.propTypes = {
   location: PropTypes.object.isRequired,
-  locationNames: PropTypes.object.isRequired,
-  fao: PropTypes.object.isRequired,
-  rank: PropTypes.number.isRequired,
   getFAOCover: PropTypes.func.isRequired
 };
 

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-actions.js
@@ -1,6 +1,7 @@
 import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 import { getExtent } from 'services/forest-data';
+import axios from 'axios';
 
 const setIntactTreeCoverLoading = createAction('setIntactTreeCoverLoading');
 const setIntactTreeCoverData = createAction('setIntactTreeCoverData');
@@ -10,44 +11,65 @@ export const getIntactTreeCover = createThunkAction(
   'getIntactTreeCover',
   params => (dispatch, state) => {
     if (!state().widgetIntactTreeCover.loading) {
+      const { countryWhitelist, regionWhitelist } = state().countryData;
+      const { region } = state().location.payload;
+      const whitelist = Object.keys(
+        region ? regionWhitelist : countryWhitelist
+      );
       dispatch(setIntactTreeCoverLoading({ loading: true, error: false }));
-      getExtent(params)
-        .then(response => {
-          const extent = response.data && response.data.data;
-          let totalArea = 0;
-          let cover = 0;
-          let plantations = 0;
-          let data = {};
-          if (extent.length) {
-            totalArea = extent[0].total_area;
-            cover = extent[0].value;
-            data = {
-              totalArea,
-              cover,
-              plantations
-            };
-          }
-          if (params.indicator !== 'gadm28') {
-            dispatch(setIntactTreeCoverData(data));
-          } else {
-            getExtent({ ...params, indicator: 'plantations' }).then(
-              plantationsResponse => {
-                const plantationsData =
-                  plantationsResponse.data && plantationsResponse.data.data;
-                plantations = plantationsData.length
-                  ? plantationsData[0].value
-                  : 0;
-                if (extent.length) {
-                  data = {
-                    ...data,
-                    plantations
-                  };
-                }
-                dispatch(setIntactTreeCoverData(data));
+      axios
+        .all([
+          getExtent({ ...params, indicator: 'gadm28' }),
+          getExtent({ ...params })
+        ])
+        .then(
+          axios.spread((gadm28Response, iflResponse) => {
+            const gadmExtent = gadm28Response.data && gadm28Response.data.data;
+            const iflExtent = iflResponse.data && iflResponse.data.data;
+            let totalArea = 0;
+            let totalExtent = 0;
+            let extent = 0;
+            let plantations = 0;
+            let data = {};
+            if (iflExtent.length && gadmExtent.length) {
+              totalArea = gadmExtent[0].total_area;
+              totalExtent = gadmExtent[0].value;
+              extent = iflExtent[0].value;
+              data = {
+                totalArea,
+                totalExtent,
+                extent,
+                plantations
+              };
+            }
+            if (whitelist.indexOf('plantations') === -1) {
+              dispatch(setIntactTreeCoverData(data));
+            } else {
+              let polyname = 'plantations';
+              if (params.indicator === 'ifl_2013__wdpa') {
+                polyname = 'plantations__wdpa';
+              } else if (params.indicator === 'ifl_2013__mining') {
+                polyname = 'plantations__mining';
               }
-            );
-          }
-        })
+              getExtent({ ...params, indicator: polyname }).then(
+                plantationsResponse => {
+                  const plantationsData =
+                    plantationsResponse.data && plantationsResponse.data.data;
+                  plantations = plantationsData.length
+                    ? plantationsData[0].value
+                    : 0;
+                  if (iflExtent.length && gadmExtent.length) {
+                    data = {
+                      ...data,
+                      plantations
+                    };
+                  }
+                  dispatch(setIntactTreeCoverData(data));
+                }
+              );
+            }
+          })
+        )
         .catch(error => {
           dispatch(setIntactTreeCoverLoading({ loading: false, error: true }));
           console.info(error);

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-actions.js
@@ -1,0 +1,64 @@
+import { createAction } from 'redux-actions';
+import { createThunkAction } from 'utils/redux';
+import { getExtent } from 'services/forest-data';
+
+const setIntactTreeCoverLoading = createAction('setIntactTreeCoverLoading');
+const setIntactTreeCoverData = createAction('setIntactTreeCoverData');
+const setIntactTreeCoverSettings = createAction('setIntactTreeCoverSettings');
+
+export const getIntactTreeCover = createThunkAction(
+  'getIntactTreeCover',
+  params => (dispatch, state) => {
+    if (!state().widgetIntactTreeCover.loading) {
+      dispatch(setIntactTreeCoverLoading({ loading: true, error: false }));
+      getExtent(params)
+        .then(response => {
+          const extent = response.data && response.data.data;
+          let totalArea = 0;
+          let cover = 0;
+          let plantations = 0;
+          let data = {};
+          if (extent.length) {
+            totalArea = extent[0].total_area;
+            cover = extent[0].value;
+            data = {
+              totalArea,
+              cover,
+              plantations
+            };
+          }
+          if (params.indicator !== 'gadm28') {
+            dispatch(setIntactTreeCoverData(data));
+          } else {
+            getExtent({ ...params, indicator: 'plantations' }).then(
+              plantationsResponse => {
+                const plantationsData =
+                  plantationsResponse.data && plantationsResponse.data.data;
+                plantations = plantationsData.length
+                  ? plantationsData[0].value
+                  : 0;
+                if (extent.length) {
+                  data = {
+                    ...data,
+                    plantations
+                  };
+                }
+                dispatch(setIntactTreeCoverData(data));
+              }
+            );
+          }
+        })
+        .catch(error => {
+          dispatch(setIntactTreeCoverLoading({ loading: false, error: true }));
+          console.info(error);
+        });
+    }
+  }
+);
+
+export default {
+  setIntactTreeCoverLoading,
+  setIntactTreeCoverData,
+  getIntactTreeCover,
+  setIntactTreeCoverSettings
+};

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-component.js
@@ -1,0 +1,49 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import WidgetPieChart from 'pages/country/widget/components/widget-pie-chart';
+import WidgetPieChartLegend from 'pages/country/widget/components/widget-pie-chart-legend';
+import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
+
+import './widget-intact-tree-cover-styles.scss';
+
+class WidgetIntactTreeCover extends PureComponent {
+  render() {
+    const { parsedData, settings, sentence } = this.props;
+
+    return (
+      <div className="c-widget-intact-tree-cover">
+        {parsedData && (
+          <div>
+            <WidgetDynamicSentence sentence={sentence} />
+            <div className="pie-chart-container">
+              <WidgetPieChartLegend
+                className="cover-legend"
+                data={parsedData}
+                config={{
+                  ...settings,
+                  format: '.3s',
+                  unit: 'ha',
+                  key: 'value'
+                }}
+              />
+              <WidgetPieChart
+                className="cover-pie-chart"
+                data={parsedData}
+                maxSize={140}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+WidgetIntactTreeCover.propTypes = {
+  parsedData: PropTypes.array,
+  settings: PropTypes.object.isRequired,
+  sentence: PropTypes.string.isRequired
+};
+
+export default WidgetIntactTreeCover;

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-component.js
@@ -43,7 +43,7 @@ class WidgetIntactTreeCover extends PureComponent {
 WidgetIntactTreeCover.propTypes = {
   parsedData: PropTypes.array,
   settings: PropTypes.object.isRequired,
-  sentence: PropTypes.string.isRequired
+  sentence: PropTypes.string
 };
 
 export default WidgetIntactTreeCover;

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-reducers.js
@@ -1,0 +1,33 @@
+import WIDGETS_CONFIG from 'pages/country/data/widgets-config.json';
+
+export const initialState = {
+  loading: false,
+  error: false,
+  data: {},
+  ...WIDGETS_CONFIG.intactTreeCover
+};
+
+const setIntactTreeCoverLoading = (state, { payload }) => ({
+  ...state,
+  ...payload
+});
+
+const setIntactTreeCoverData = (state, { payload }) => ({
+  ...state,
+  loading: false,
+  data: payload
+});
+
+const setIntactTreeCoverSettings = (state, { payload }) => ({
+  ...state,
+  settings: {
+    ...state.settings,
+    ...payload
+  }
+});
+
+export default {
+  setIntactTreeCoverLoading,
+  setIntactTreeCoverData,
+  setIntactTreeCoverSettings
+};

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
@@ -27,11 +27,11 @@ export const getIntactTreeCoverData = createSelector(
         label: hasPlantations ? 'Degraded Forest' : 'Other Tree Cover',
         value: totalExtent - extent - plantations,
         color: COLORS.lightGreen,
-        percentage: (extent - plantations) / totalArea * 100
+        percentage: (totalExtent - extent - plantations) / totalArea * 100
       },
       {
         label: 'Non-Forest',
-        value: totalArea - extent,
+        value: totalArea - totalExtent,
         color: COLORS.nonForest,
         percentage: (totalArea - totalExtent) / totalArea * 100
       }
@@ -49,18 +49,19 @@ export const getIntactTreeCoverData = createSelector(
 );
 
 export const getSentence = createSelector(
-  [getData, getSettings, getLocationNames, getActiveIndicator],
+  [getIntactTreeCoverData, getSettings, getLocationNames, getActiveIndicator],
   (data, settings, locationNames, indicator) => {
-    if (!data) return null;
-    const { totalArea, cover } = data;
-    const coverStatus = cover / totalArea > 0.5 ? 'tree covered' : 'non-forest';
+    if (!data || !locationNames) return null;
+    const largestContrib = data.find(d => d.percentage >= 0.5);
     const locationLabel = locationNames.current && locationNames.current.label;
     const locationIntro = `${
       indicator.value !== 'gadm28'
-        ? `<b>${indicator.label}</b> in <b>${locationLabel}</b> are `
-        : `<b>${locationLabel}</b> is `
+        ? `For <b>${indicator.label}</b> in <b>${locationLabel}</b>,`
+        : `In <b>${locationLabel}</b>,`
     }`;
-    const first = `${locationIntro} mainly ${coverStatus}, `;
+    const first = `${locationIntro} the majority of tree cover is found in <b>${
+      largestContrib.label
+    }</b>, `;
     const second = `considering tree cover extent in <b>${
       settings.extentYear
     }</b> where tree canopy is greater than <b>${settings.threshold}%</b>.`;

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
@@ -54,11 +54,9 @@ export const getSentence = createSelector(
     if (!data || !locationNames) return null;
     const largestContrib = data.find(d => d.percentage >= 0.5);
     const locationLabel = locationNames.current && locationNames.current.label;
-    const locationIntro = `${
-      indicator.value !== 'gadm28'
-        ? `For <b>${indicator.label}</b> in <b>${locationLabel}</b>,`
-        : `In <b>${locationLabel}</b>,`
-    }`;
+    const locationIntro = `For <b>${
+      indicator.label
+    }</b> in <b>${locationLabel}</b>,`;
     const first = `${locationIntro} the majority of tree cover is found in <b>${
       largestContrib.label
     }</b>, `;

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
@@ -14,29 +14,31 @@ export const getIntactTreeCoverData = createSelector(
   [getData, getSettings, getIndicatorWhitelist],
   (data, settings, whitelist) => {
     if (isEmpty(data) || isEmpty(whitelist)) return null;
-    const { totalArea, cover, plantations } = data;
-    const { indicator } = settings;
+    const { totalArea, totalExtent, extent, plantations } = data;
     const hasPlantations = Object.keys(whitelist).indexOf('plantations') > -1;
     const parsedData = [
       {
-        label:
-          hasPlantations && indicator === 'gadm28'
-            ? 'Natural Forest'
-            : 'Tree cover',
-        value: cover - plantations,
+        label: 'Intact Forest',
+        value: extent,
         color: COLORS.darkGreen,
-        percentage: (cover - plantations) / totalArea * 100
+        percentage: extent / totalArea * 100
+      },
+      {
+        label: hasPlantations ? 'Degraded Forest' : 'Other Tree Cover',
+        value: totalExtent - extent - plantations,
+        color: COLORS.lightGreen,
+        percentage: (extent - plantations) / totalArea * 100
       },
       {
         label: 'Non-Forest',
-        value: totalArea - cover,
+        value: totalArea - extent,
         color: COLORS.nonForest,
-        percentage: (totalArea - cover) / totalArea * 100
+        percentage: (totalArea - totalExtent) / totalArea * 100
       }
     ];
-    if (indicator === 'gadm28' && hasPlantations) {
-      parsedData.splice(1, 0, {
-        label: 'Tree plantations',
+    if (hasPlantations) {
+      parsedData.splice(2, 0, {
+        label: 'Plantations',
         value: plantations,
         color: COLORS.mediumGreen,
         percentage: plantations / totalArea * 100

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
@@ -1,0 +1,68 @@
+import { createSelector } from 'reselect';
+import COLORS from 'pages/country/data/colors.json';
+import isEmpty from 'lodash/isEmpty';
+
+// get list data
+const getData = state => state.data;
+const getSettings = state => state.settings;
+const getLocationNames = state => state.locationNames;
+const getActiveIndicator = state => state.activeIndicator;
+const getIndicatorWhitelist = state => state.whitelist;
+
+// get lists selected
+export const getIntactTreeCoverData = createSelector(
+  [getData, getSettings, getIndicatorWhitelist],
+  (data, settings, whitelist) => {
+    if (isEmpty(data) || isEmpty(whitelist)) return null;
+    const { totalArea, cover, plantations } = data;
+    const { indicator } = settings;
+    const hasPlantations = Object.keys(whitelist).indexOf('plantations') > -1;
+    const parsedData = [
+      {
+        label:
+          hasPlantations && indicator === 'gadm28'
+            ? 'Natural Forest'
+            : 'Tree cover',
+        value: cover - plantations,
+        color: COLORS.darkGreen,
+        percentage: (cover - plantations) / totalArea * 100
+      },
+      {
+        label: 'Non-Forest',
+        value: totalArea - cover,
+        color: COLORS.nonForest,
+        percentage: (totalArea - cover) / totalArea * 100
+      }
+    ];
+    if (indicator === 'gadm28' && hasPlantations) {
+      parsedData.splice(1, 0, {
+        label: 'Tree plantations',
+        value: plantations,
+        color: COLORS.mediumGreen,
+        percentage: plantations / totalArea * 100
+      });
+    }
+    return parsedData;
+  }
+);
+
+export const getSentence = createSelector(
+  [getData, getSettings, getLocationNames, getActiveIndicator],
+  (data, settings, locationNames, indicator) => {
+    if (!data) return null;
+    const { totalArea, cover } = data;
+    const coverStatus = cover / totalArea > 0.5 ? 'tree covered' : 'non-forest';
+    const locationLabel = locationNames.current && locationNames.current.label;
+    const locationIntro = `${
+      indicator.value !== 'gadm28'
+        ? `<b>${indicator.label}</b> in <b>${locationLabel}</b> are `
+        : `<b>${locationLabel}</b> is `
+    }`;
+    const first = `${locationIntro} mainly ${coverStatus}, `;
+    const second = `considering tree cover extent in <b>${
+      settings.extentYear
+    }</b> where tree canopy is greater than <b>${settings.threshold}%</b>.`;
+
+    return `${first} ${second}`;
+  }
+);

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-styles.scss
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-styles.scss
@@ -1,0 +1,16 @@
+@import '~styles/settings.scss';
+
+.c-widget-intact-tree-cover {
+  padding-top: rem(15px);
+
+  .cover-legend {
+    min-width: 50%;
+  }
+
+  .pie-chart-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    padding-top: rem(40px);
+  }
+}

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover.js
@@ -32,8 +32,8 @@ const mapStateToProps = ({ widgetIntactTreeCover, countryData }, ownProps) => {
     loading: loading || isCountriesLoading || isRegionsLoading,
     regions,
     data,
-    parsedData: getIntactTreeCoverData(selectorData)
-    // sentence: getSentence(selectorData)
+    parsedData: getIntactTreeCoverData(selectorData),
+    sentence: getSentence(selectorData)
   };
 };
 

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover.js
@@ -1,0 +1,80 @@
+import { createElement, PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import isEqual from 'lodash/isEqual';
+
+import actions from './widget-intact-tree-cover-actions';
+import reducers, { initialState } from './widget-intact-tree-cover-reducers';
+import {
+  getIntactTreeCoverData,
+  getSentence
+} from './widget-intact-tree-cover-selectors';
+import WidgetIntactTreeCoverComponent from './widget-intact-tree-cover-component';
+
+const mapStateToProps = ({ widgetIntactTreeCover, countryData }, ownProps) => {
+  const {
+    isCountriesLoading,
+    isRegionsLoading,
+    countryWhitelist,
+    regions
+  } = countryData;
+  const { settings, loading, data } = widgetIntactTreeCover;
+  const { locationNames, activeIndicator } = ownProps;
+  const selectorData = {
+    data,
+    settings,
+    whitelist: countryWhitelist,
+    locationNames,
+    activeIndicator
+  };
+
+  return {
+    loading: loading || isCountriesLoading || isRegionsLoading,
+    regions,
+    data,
+    parsedData: getIntactTreeCoverData(selectorData)
+    // sentence: getSentence(selectorData)
+  };
+};
+
+class WidgetIntactTreeCoverContainer extends PureComponent {
+  componentDidMount() {
+    const { location, settings, getIntactTreeCover } = this.props;
+    getIntactTreeCover({
+      ...location,
+      ...settings
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { settings, getIntactTreeCover, location } = nextProps;
+
+    if (
+      !isEqual(location, this.props.location) ||
+      !isEqual(settings, this.props.settings)
+    ) {
+      getIntactTreeCover({
+        ...location,
+        ...settings
+      });
+    }
+  }
+
+  render() {
+    return createElement(WidgetIntactTreeCoverComponent, {
+      ...this.props
+    });
+  }
+}
+
+WidgetIntactTreeCoverContainer.propTypes = {
+  settings: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  getIntactTreeCover: PropTypes.func.isRequired
+};
+
+export { actions, reducers, initialState };
+
+export default connect(mapStateToProps, actions)(
+  WidgetIntactTreeCoverContainer
+);

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-component.js
@@ -9,13 +9,13 @@ import './widget-tree-cover-styles.scss';
 
 class WidgetTreeCover extends PureComponent {
   render() {
-    const { parsedData, settings, getSentence } = this.props;
+    const { parsedData, settings, sentence } = this.props;
 
     return (
       <div className="c-widget-tree-cover">
         {parsedData && (
           <div>
-            <WidgetDynamicSentence sentence={getSentence()} />
+            <WidgetDynamicSentence sentence={sentence} />
             <div className="pie-chart-container">
               <WidgetPieChartLegend
                 className="cover-legend"
@@ -43,7 +43,7 @@ class WidgetTreeCover extends PureComponent {
 WidgetTreeCover.propTypes = {
   parsedData: PropTypes.array,
   settings: PropTypes.object.isRequired,
-  getSentence: PropTypes.func.isRequired
+  sentence: PropTypes.string.isRequired
 };
 
 export default WidgetTreeCover;

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-reducers.js
@@ -15,10 +15,7 @@ const setTreeCoverLoading = (state, { payload }) => ({
 const setTreeCoverData = (state, { payload }) => ({
   ...state,
   loading: false,
-  data: {
-    ...state.data,
-    ...payload
-  }
+  data: payload
 });
 
 const setTreeCoverSettings = (state, { payload }) => ({

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-selectors.js
@@ -4,15 +4,18 @@ import isEmpty from 'lodash/isEmpty';
 
 // get list data
 const getData = state => state.data;
-const getIndicator = state => state.indicator;
+const getSettings = state => state.settings;
+const getLocationNames = state => state.locationNames;
+const getActiveIndicator = state => state.activeIndicator;
 const getIndicatorWhitelist = state => state.whitelist;
 
 // get lists selected
 export const getTreeCoverData = createSelector(
-  [getData, getIndicator, getIndicatorWhitelist],
-  (data, indicator, whitelist) => {
+  [getData, getSettings, getIndicatorWhitelist],
+  (data, settings, whitelist) => {
     if (isEmpty(data) || isEmpty(whitelist)) return null;
     const { totalArea, cover, plantations } = data;
+    const { indicator } = settings;
     const hasPlantations = Object.keys(whitelist).indexOf('plantations') > -1;
     const parsedData = [
       {
@@ -40,5 +43,26 @@ export const getTreeCoverData = createSelector(
       });
     }
     return parsedData;
+  }
+);
+
+export const getSentence = createSelector(
+  [getData, getSettings, getLocationNames, getActiveIndicator],
+  (data, settings, locationNames, indicator) => {
+    if (!data) return null;
+    const { totalArea, cover } = data;
+    const coverStatus = cover / totalArea > 0.5 ? 'tree covered' : 'non-forest';
+    const locationLabel = locationNames.current && locationNames.current.label;
+    const locationIntro = `${
+      indicator.value !== 'gadm28'
+        ? `<b>${indicator.label}</b> in <b>${locationLabel}</b> are `
+        : `<b>${locationLabel}</b> is `
+    }`;
+    const first = `${locationIntro} mainly ${coverStatus}, `;
+    const second = `considering tree cover extent in <b>${
+      settings.extentYear
+    }</b> where tree canopy is greater than <b>${settings.threshold}%</b>.`;
+
+    return `${first} ${second}`;
   }
 );

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover.js
@@ -2,31 +2,35 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
-import { getLocationLabel } from 'pages/country/widget/widget-selectors';
 
 import actions from './widget-tree-cover-actions';
 import reducers, { initialState } from './widget-tree-cover-reducers';
-import { getTreeCoverData } from './widget-tree-cover-selectors';
+import { getTreeCoverData, getSentence } from './widget-tree-cover-selectors';
 import WidgetTreeCoverComponent from './widget-tree-cover-component';
 
-const mapStateToProps = ({ widgetTreeCover, countryData }) => {
+const mapStateToProps = ({ widgetTreeCover, countryData }, ownProps) => {
   const {
     isCountriesLoading,
     isRegionsLoading,
-    countryWhitelist
+    countryWhitelist,
+    regions
   } = countryData;
-  const { data } = widgetTreeCover;
-  const { indicator } = widgetTreeCover.settings;
+  const { settings, loading, data } = widgetTreeCover;
+  const { locationNames, activeIndicator } = ownProps;
+  const selectorData = {
+    data,
+    settings,
+    whitelist: countryWhitelist,
+    locationNames,
+    activeIndicator
+  };
 
   return {
-    loading: widgetTreeCover.loading || isCountriesLoading || isRegionsLoading,
-    regions: countryData.regions,
-    data: widgetTreeCover.data,
-    parsedData: getTreeCoverData({
-      data,
-      indicator,
-      whitelist: countryWhitelist
-    })
+    loading: loading || isCountriesLoading || isRegionsLoading,
+    regions,
+    data,
+    parsedData: getTreeCoverData(selectorData),
+    sentence: getSentence(selectorData)
   };
 };
 
@@ -53,30 +57,9 @@ class WidgetTreeCoverContainer extends PureComponent {
     }
   }
 
-  getSentence = () => {
-    const { locationNames, settings } = this.props;
-    const { indicators } = this.props.options;
-    const { totalArea, cover } = this.props.data;
-    const locationLabel = getLocationLabel(
-      locationNames.current.label,
-      settings.indicator,
-      indicators
-    );
-    const coverStatus = cover / totalArea > 0.5 ? 'tree covered' : 'non-forest';
-    const first = `<b>${locationLabel}</b> ${
-      settings.indicator === 'gadm28' ? 'is' : 'are'
-    } mainly ${coverStatus}, `;
-    const second = `considering tree cover extent in <b>${
-      settings.extentYear
-    }</b> where tree canopy is greater than <b>${settings.threshold}%</b>.`;
-
-    return `${first} ${second}`;
-  };
-
   render() {
     return createElement(WidgetTreeCoverComponent, {
-      ...this.props,
-      getSentence: this.getSentence
+      ...this.props
     });
   }
 }
@@ -84,10 +67,7 @@ class WidgetTreeCoverContainer extends PureComponent {
 WidgetTreeCoverContainer.propTypes = {
   settings: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
-  locationNames: PropTypes.object.isRequired,
-  getTreeCover: PropTypes.func.isRequired,
-  options: PropTypes.object.isRequired,
-  data: PropTypes.object.isRequired
+  getTreeCover: PropTypes.func.isRequired
 };
 
 export { actions, reducers, initialState };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { format } from 'd3-format';
 import isEqual from 'lodash/isEqual';
 
-import { getActiveFilter } from 'pages/country/widget/widget-selectors';
+import { getActiveIndicator } from 'pages/country/widget/widget-selectors';
 
 import actions from './widget-tree-gain-actions';
 import reducers, { initialState } from './widget-tree-gain-reducers';
@@ -41,9 +41,7 @@ class WidgetTreeGainContainer extends PureComponent {
 
   getSentence = () => {
     const { locationNames, gain, extent, settings } = this.props;
-    const { indicators } = this.props.options;
-    const indicator =
-      indicators && getActiveFilter(settings, indicators, 'indicator');
+    const indicator = getActiveIndicator(settings.indicator);
     const regionPhrase =
       settings.indicator === 'gadm28'
         ? '<span>region-wide</span>'
@@ -73,7 +71,6 @@ WidgetTreeGainContainer.propTypes = {
   locationNames: PropTypes.object.isRequired,
   gain: PropTypes.number.isRequired,
   extent: PropTypes.number.isRequired,
-  options: PropTypes.object.isRequired,
   settings: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
   getTreeGain: PropTypes.func.isRequired


### PR DESCRIPTION
## Overview

> "Change your opinions, keep to your principles; change your leaves, keep intact your roots."

-Victor Hugo

Oh boy, if Victor could have imagined the influence his work would have on our widget driven society today, maybe he wouldn't have caught pneumonia and would still be with us. 

Much like Victor's work, this new widget not only inspires, but gives a truly specific and detailed understanding of Intact Forests and their extent on a country and regional level. And if _hugo_ to a country that contains plantations, you can now explore how intact forests can be used to understand forest degradation within a region. Pretty powerful ey?! Thanks Vicky boy.

A breakdown of the poetic process is as follows:
- Copy the treeCover widget
- Change the fetches to handle dynamic plantations
- Update settings to limit user selection
- Change the extent calcualtions

## Demo

![screen shot 2018-01-17 at 16 34 33](https://user-images.githubusercontent.com/20288774/35050943-539b348a-fba4-11e7-8b8c-1b143f250c33.png)

## Notes

I have the deepest more respect and understanding for the works of Victor Hugo. Little of the actual words, as I don't speak french.