### PR TITLE
Feature/primary forests tree cover widget

### DIFF
--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -35,7 +35,7 @@
     "active": true
   },
   "primaryTreeCover": {
-    "title": "Primary forests tree cover extent",
+    "title": "Primary forest extent",
     "config": {
       "gridWidth": 6,
       "indicators": ["primary_forest", "primary_forest__mining", "primary_forest__wdpa", "primary_forest__landmark"],
@@ -47,7 +47,7 @@
     "settings": {
       "indicator": "primary_forest",
       "threshold": 30,
-      "extentYear": 2000
+      "extentYear": 2010
     },
     "active": true
   },

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -35,6 +35,24 @@
     },
     "active": true
   },
+  "primaryTreeCover": {
+    "title": "Primary forests tree cover extent",
+    "config": {
+      "gridWidth": 6,
+      "indicators": ["primary_forest", "primary_forest__mining", "primary_forest__wdpa", "primary_forest__landmark"],
+      "showIndicators": ["primary_forest", "primary_forest__mining", "primary_forest__wdpa", "primary_forest__landmark"],
+      "categories": ["land-cover"],
+      "admins": ["country", "region", "subRegion"],
+      "selectors": ["indicators", "thresholds", "extentYears"],
+      "type": "extent"
+    },
+    "settings": {
+      "indicator": "primary_forest",
+      "threshold": 30,
+      "extentYear": 2000
+    },
+    "active": true
+  },
   "treeLocated": {
     "title": "Where are the forests located",
     "config": {

--- a/app/javascript/pages/country/header/header.js
+++ b/app/javascript/pages/country/header/header.js
@@ -7,6 +7,7 @@ import isEqual from 'lodash/isEqual';
 import remove from 'lodash/remove';
 import { decodeUrlForState, encodeStateForUrl } from 'utils/stateToUrl';
 import { format } from 'd3-format';
+import WIDGETS_CONFIG from 'pages/country/data/widgets-config.json';
 
 import * as actions from './header-actions';
 import reducers, { initialState } from './header-reducers';
@@ -39,7 +40,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     widgetKeys.forEach(key => {
       widgetQueries[key] = encodeStateForUrl({
         ...decodeUrlForState(query[key]),
-        indicator: 'gadm28'
+        indicator: WIDGETS_CONFIG[key].settings.indicator
       });
     });
   }

--- a/app/javascript/pages/country/providers/country-data-provider/country-data-provider-actions.js
+++ b/app/javascript/pages/country/providers/country-data-provider/country-data-provider-actions.js
@@ -25,6 +25,8 @@ export const setRegionWhitelistLoading = createAction(
 );
 
 export const setCountries = createAction('setCountries');
+export const setFAOCountries = createAction('setFAOCountries');
+export const setGadmCountries = createAction('setGadmCountries');
 export const setRegions = createAction('setRegions');
 export const setSubRegions = createAction('setSubRegions');
 export const setGeostore = createAction('setGeostore');
@@ -44,6 +46,8 @@ export const getCountries = createThunkAction(
               [...gadm28Countries.data.rows, ...faoCountries.data.rows],
               'iso'
             );
+            dispatch(setGadmCountries(gadm28Countries.data.rows));
+            dispatch(setFAOCountries(faoCountries.data.rows));
             dispatch(setCountries(countries));
             dispatch(setCountriesLoading(false));
           })

--- a/app/javascript/pages/country/providers/country-data-provider/country-data-provider-reducers.js
+++ b/app/javascript/pages/country/providers/country-data-provider/country-data-provider-reducers.js
@@ -5,6 +5,8 @@ export const initialState = {
   isGeostoreLoading: false,
   isWhitelistLoading: false,
   countries: [],
+  gadmCountries: [],
+  faoCountries: [],
   regions: [],
   subRegions: [],
   countryWhitelist: {},
@@ -63,6 +65,16 @@ const setCountries = (state, { payload }) => ({
   countries: mapLocations(payload)
 });
 
+const setGadmCountries = (state, { payload }) => ({
+  ...state,
+  gadmCountries: mapLocations(payload)
+});
+
+const setFAOCountries = (state, { payload }) => ({
+  ...state,
+  faoCountries: mapLocations(payload)
+});
+
 const setRegions = (state, { payload }) => ({
   ...state,
   regions: mapLocations(payload)
@@ -100,6 +112,8 @@ export default {
   setCountryWhitelistLoading,
   setRegionWhitelistLoading,
   setCountries,
+  setFAOCountries,
+  setGadmCountries,
   setRegions,
   setSubRegions,
   setGeostore,

--- a/app/javascript/pages/country/reducers.js
+++ b/app/javascript/pages/country/reducers.js
@@ -22,6 +22,7 @@ import * as widgetPlantationAreaComponent from 'pages/country/widget/widgets/wid
 import * as widgetTotalAreaPlantationsComponent from 'pages/country/widget/widgets/widget-total-area-plantations';
 import * as widgetTreeCoverComponent from 'pages/country/widget/widgets/widget-tree-cover';
 import * as widgetIntactTreeCoverComponent from 'pages/country/widget/widgets/widget-intact-tree-cover';
+import * as widgetPrimaryTreeCoverComponent from 'pages/country/widget/widgets/widget-primary-tree-cover';
 import * as widgetTreeGainComponent from 'pages/country/widget/widgets/widget-tree-gain';
 import * as widgetTreeCoverLossAreasComponent from 'pages/country/widget/widgets/widget-tree-cover-loss-areas';
 import * as widgetTreeLocatedComponent from 'pages/country/widget/widgets/widget-tree-located';
@@ -44,6 +45,7 @@ const componentsReducers = {
   ),
   widgetTreeCover: handleActions(widgetTreeCoverComponent),
   widgetIntactTreeCover: handleActions(widgetIntactTreeCoverComponent),
+  widgetPrimaryTreeCover: handleActions(widgetPrimaryTreeCoverComponent),
   widgetTreeGain: handleActions(widgetTreeGainComponent),
   widgetTreeCoverLossAreas: handleActions(widgetTreeCoverLossAreasComponent),
   widgetTreeLocated: handleActions(widgetTreeLocatedComponent),

--- a/app/javascript/pages/country/root/root-selectors.js
+++ b/app/javascript/pages/country/root/root-selectors.js
@@ -14,6 +14,7 @@ const getAdminLevel = state => state.adminLevel || null;
 const getLocation = state => state.location || null;
 const getLocationOptions = state => state.locationOptions || null;
 const getIndicatorWhitelist = state => state.indicatorWhitelist || null;
+const getFAOCountries = state => state.faoCountries || null;
 
 // get lists selected
 export const getWidgets = createSelector([], () =>
@@ -30,14 +31,23 @@ export const filterWidgetsByCategory = createSelector(
 );
 
 export const checkWidgetNeedsLocations = createSelector(
-  [filterWidgetsByCategory, getLocationOptions, getAdminLevel],
-  (widgets, locations, adminLevel) => {
+  [
+    filterWidgetsByCategory,
+    getLocationOptions,
+    getAdminLevel,
+    getFAOCountries,
+    getLocation
+  ],
+  (widgets, locations, adminLevel, faoCountries, location) => {
     if (isEmpty(locations)) return null;
     const adminCheck = adminLevel === 'country' ? 'regions' : 'subRegions';
+    const isFaoCountry =
+      faoCountries.find(c => c.value === location.payload.country) || null;
     return widgets.filter(
       w =>
         w.config.admins.indexOf(adminLevel) > -1 &&
-        (!w.config.locationCheck || locations[adminCheck].length > 1)
+        (!w.config.locationCheck || locations[adminCheck].length > 1) &&
+        (w.config.type !== 'fao' || isFaoCountry)
     );
   }
 );

--- a/app/javascript/pages/country/root/root.js
+++ b/app/javascript/pages/country/root/root.js
@@ -44,8 +44,10 @@ const mapStateToProps = ({ root, countryData, location }) => {
     currentLocation:
       locationNames[adminLevel] && locationNames[adminLevel].label,
     widgets: filterWidgets({
+      faoCountries: countryData.faoCountries,
       category,
       adminLevel,
+      location,
       locationOptions,
       indicatorWhitelist: location.payload.region
         ? regionWhitelist

--- a/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-styles.scss
+++ b/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-styles.scss
@@ -43,13 +43,13 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    width: rem(20px);
-    min-width: rem(20px);
-    height: rem(20px);
-    min-height: rem(20px);
+    width: rem(24px);
+    min-width: rem(24px);
+    height: rem(24px);
+    min-height: rem(24px);
     color: $white;
     font-weight: 500;
-    border-radius: 100%;
+    border-radius: 50%;
     margin-right: rem(10px);
   }
 }

--- a/app/javascript/pages/country/widget/widget-actions.js
+++ b/app/javascript/pages/country/widget/widget-actions.js
@@ -7,6 +7,7 @@ import { encodeStateForUrl, decodeUrlForState } from 'utils/stateToUrl';
 import * as treeLossActions from 'pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-actions';
 import * as treeCoverActions from 'pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-actions';
 import * as intactTreeCoverActions from 'pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-actions';
+import * as primaryTreeCoverActions from 'pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-actions';
 import * as treeLocatedActions from 'pages/country/widget/widgets/widget-tree-located/widget-tree-located-actions';
 import * as treeGainActions from 'pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-actions';
 import * as FAOReforestationActions from 'pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-actions';
@@ -16,6 +17,7 @@ const widgetActions = {
   ...treeLossActions.default,
   ...treeCoverActions.default,
   ...intactTreeCoverActions.default,
+  ...primaryTreeCoverActions.default,
   ...treeLocatedActions.default,
   ...treeGainActions.default,
   ...FAOReforestationActions.default,

--- a/app/javascript/pages/country/widget/widget-component.jsx
+++ b/app/javascript/pages/country/widget/widget-component.jsx
@@ -10,6 +10,7 @@ import WidgetHeader from 'pages/country/widget/components/widget-header';
 
 import WidgetTreeCover from 'pages/country/widget/widgets/widget-tree-cover';
 import WidgetIntactTreeCover from 'pages/country/widget/widgets/widget-intact-tree-cover';
+import WidgetPrimaryTreeCover from 'pages/country/widget/widgets/widget-primary-tree-cover';
 import WidgetTreeLocated from 'pages/country/widget/widgets/widget-tree-located';
 import WidgetTreeLoss from 'pages/country/widget/widgets/widget-tree-loss';
 import WidgetTotalAreaPlantations from 'pages/country/widget/widgets/widget-total-area-plantations';
@@ -24,6 +25,7 @@ import './widget-tooltip-styles.scss';
 const widgets = {
   WidgetTreeCover,
   WidgetIntactTreeCover,
+  WidgetPrimaryTreeCover,
   WidgetTreeGain,
   WidgetTreeLocated,
   WidgetTreeLoss,

--- a/app/javascript/pages/country/widget/widget.js
+++ b/app/javascript/pages/country/widget/widget.js
@@ -64,7 +64,10 @@ const mapStateToProps = (state, ownProps) => {
     activeLocation: widgetSelectors.getActiveAdmin({
       location: location.payload
     }),
-    activeIndicator: widgetSelectors.getActiveIndicator(settings.indicator),
+    activeIndicator:
+      settings &&
+      settings.indicator &&
+      widgetSelectors.getActiveIndicator(settings.indicator),
     location: location.payload,
     title,
     loading,

--- a/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-actions.js
@@ -15,7 +15,14 @@ const getFAOReforestationData = createThunkAction(
       getFAOExtent({ ...params })
         .then(response => {
           const data = response.data.rows;
-          const mappedData = data.length ? { countries: data } : {};
+          let mappedData = {};
+          const hasCountryData =
+            (data.length &&
+              data.find(d => d.iso === state().location.payload.country)) ||
+            null;
+          if (hasCountryData) {
+            mappedData = { countries: data };
+          }
           dispatch(setFAOReforestationData(mappedData));
         })
         .catch(error => {

--- a/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-actions.js
@@ -1,0 +1,88 @@
+import { createAction } from 'redux-actions';
+import { createThunkAction } from 'utils/redux';
+import { getExtent } from 'services/forest-data';
+import axios from 'axios';
+
+const setPrimaryTreeCoverLoading = createAction('setPrimaryTreeCoverLoading');
+const setPrimaryTreeCoverData = createAction('setPrimaryTreeCoverData');
+const setPrimaryTreeCoverSettings = createAction('setPrimaryTreeCoverSettings');
+
+export const getPrimaryTreeCover = createThunkAction(
+  'getPrimaryTreeCover',
+  params => (dispatch, state) => {
+    if (!state().widgetPrimaryTreeCover.loading) {
+      const { countryWhitelist, regionWhitelist } = state().countryData;
+      const { region } = state().location.payload;
+      const whitelist = Object.keys(
+        region ? regionWhitelist : countryWhitelist
+      );
+      dispatch(setPrimaryTreeCoverLoading({ loading: true, error: false }));
+      axios
+        .all([
+          getExtent({ ...params, indicator: 'gadm28' }),
+          getExtent({ ...params })
+        ])
+        .then(
+          axios.spread((gadm28Response, iflResponse) => {
+            const gadmExtent = gadm28Response.data && gadm28Response.data.data;
+            const primaryExtent = iflResponse.data && iflResponse.data.data;
+            let totalArea = 0;
+            let totalExtent = 0;
+            let extent = 0;
+            let plantations = 0;
+            let data = {};
+            if (primaryExtent.length && gadmExtent.length) {
+              totalArea = gadmExtent[0].total_area;
+              totalExtent = gadmExtent[0].value;
+              extent = primaryExtent[0].value;
+              data = {
+                totalArea,
+                totalExtent,
+                extent,
+                plantations
+              };
+            }
+            if (whitelist.indexOf('plantations') === -1) {
+              dispatch(setPrimaryTreeCoverData(data));
+            } else {
+              let polyname = 'plantations';
+              if (params.indicator === 'primary_forest__wdpa') {
+                polyname = 'plantations__wdpa';
+              } else if (params.indicator === 'primary_forest__mining') {
+                polyname = 'plantations__mining';
+              } else if (params.indicator === 'primary_forest__landmark') {
+                polyname = 'plantations__landmark';
+              }
+              getExtent({ ...params, indicator: polyname }).then(
+                plantationsResponse => {
+                  const plantationsData =
+                    plantationsResponse.data && plantationsResponse.data.data;
+                  plantations = plantationsData.length
+                    ? plantationsData[0].value
+                    : 0;
+                  if (primaryExtent.length && gadmExtent.length) {
+                    data = {
+                      ...data,
+                      plantations
+                    };
+                  }
+                  dispatch(setPrimaryTreeCoverData(data));
+                }
+              );
+            }
+          })
+        )
+        .catch(error => {
+          dispatch(setPrimaryTreeCoverLoading({ loading: false, error: true }));
+          console.info(error);
+        });
+    }
+  }
+);
+
+export default {
+  setPrimaryTreeCoverLoading,
+  setPrimaryTreeCoverData,
+  getPrimaryTreeCover,
+  setPrimaryTreeCoverSettings
+};

--- a/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-component.js
@@ -1,0 +1,49 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import WidgetPieChart from 'pages/country/widget/components/widget-pie-chart';
+import WidgetPieChartLegend from 'pages/country/widget/components/widget-pie-chart-legend';
+import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
+
+import './widget-primary-tree-cover-styles.scss';
+
+class WidgetPrimaryTreeCover extends PureComponent {
+  render() {
+    const { parsedData, settings, sentence } = this.props;
+
+    return (
+      <div className="c-widget-primary-tree-cover">
+        {parsedData && (
+          <div>
+            <WidgetDynamicSentence sentence={sentence} />
+            <div className="pie-chart-container">
+              <WidgetPieChartLegend
+                className="cover-legend"
+                data={parsedData}
+                config={{
+                  ...settings,
+                  format: '.3s',
+                  unit: 'ha',
+                  key: 'value'
+                }}
+              />
+              <WidgetPieChart
+                className="cover-pie-chart"
+                data={parsedData}
+                maxSize={140}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+WidgetPrimaryTreeCover.propTypes = {
+  parsedData: PropTypes.array,
+  settings: PropTypes.object.isRequired,
+  sentence: PropTypes.string
+};
+
+export default WidgetPrimaryTreeCover;

--- a/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-reducers.js
+++ b/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-reducers.js
@@ -1,0 +1,33 @@
+import WIDGETS_CONFIG from 'pages/country/data/widgets-config.json';
+
+export const initialState = {
+  loading: false,
+  error: false,
+  data: {},
+  ...WIDGETS_CONFIG.primaryTreeCover
+};
+
+const setPrimaryTreeCoverLoading = (state, { payload }) => ({
+  ...state,
+  ...payload
+});
+
+const setPrimaryTreeCoverData = (state, { payload }) => ({
+  ...state,
+  loading: false,
+  data: payload
+});
+
+const setPrimaryTreeCoverSettings = (state, { payload }) => ({
+  ...state,
+  settings: {
+    ...state.settings,
+    ...payload
+  }
+});
+
+export default {
+  setPrimaryTreeCoverLoading,
+  setPrimaryTreeCoverData,
+  setPrimaryTreeCoverSettings
+};

--- a/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-selectors.js
@@ -1,0 +1,71 @@
+import { createSelector } from 'reselect';
+import COLORS from 'pages/country/data/colors.json';
+import isEmpty from 'lodash/isEmpty';
+
+// get list data
+const getData = state => state.data;
+const getSettings = state => state.settings;
+const getLocationNames = state => state.locationNames;
+const getActiveIndicator = state => state.activeIndicator;
+const getIndicatorWhitelist = state => state.whitelist;
+
+// get lists selected
+export const getPrimaryTreeCoverData = createSelector(
+  [getData, getSettings, getIndicatorWhitelist],
+  (data, settings, whitelist) => {
+    if (isEmpty(data) || isEmpty(whitelist)) return null;
+    const { totalArea, totalExtent, extent, plantations } = data;
+    const hasPlantations = Object.keys(whitelist).indexOf('plantations') > -1;
+    const parsedData = [
+      {
+        label: 'Primary Forest',
+        value: extent,
+        color: COLORS.darkGreen,
+        percentage: extent / totalArea * 100
+      },
+      {
+        label: hasPlantations ? 'Secondary Forest' : 'Other Tree Cover',
+        value: totalExtent - extent - plantations,
+        color: COLORS.lightGreen,
+        percentage: (totalExtent - extent - plantations) / totalArea * 100
+      },
+      {
+        label: 'Non-Forest',
+        value: totalArea - totalExtent,
+        color: COLORS.nonForest,
+        percentage: (totalArea - totalExtent) / totalArea * 100
+      }
+    ];
+    if (hasPlantations) {
+      parsedData.splice(2, 0, {
+        label: 'Plantations',
+        value: plantations,
+        color: COLORS.mediumGreen,
+        percentage: plantations / totalArea * 100
+      });
+    }
+    return parsedData;
+  }
+);
+
+export const getSentence = createSelector(
+  [getPrimaryTreeCoverData, getSettings, getLocationNames, getActiveIndicator],
+  (data, settings, locationNames, indicator) => {
+    if (!data || !locationNames) return null;
+    const largestContrib = data.find(d => d.percentage >= 0.5);
+    const locationLabel = locationNames.current && locationNames.current.label;
+    const locationIntro = `${
+      indicator.value !== 'gadm28'
+        ? `For <b>${indicator.label}</b> in <b>${locationLabel}</b>,`
+        : `In <b>${locationLabel}</b>,`
+    }`;
+    const first = `${locationIntro} the majority of tree cover is found in <b>${
+      largestContrib.label
+    }</b>, `;
+    const second = `considering tree cover extent in <b>${
+      settings.extentYear
+    }</b> where tree canopy is greater than <b>${settings.threshold}%</b>.`;
+
+    return `${first} ${second}`;
+  }
+);

--- a/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-styles.scss
+++ b/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-styles.scss
@@ -1,0 +1,16 @@
+@import '~styles/settings.scss';
+
+.c-widget-primary-tree-cover {
+  padding-top: rem(15px);
+
+  .cover-legend {
+    min-width: 50%;
+  }
+
+  .pie-chart-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    padding-top: rem(40px);
+  }
+}

--- a/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover.js
@@ -1,0 +1,80 @@
+import { createElement, PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import isEqual from 'lodash/isEqual';
+
+import actions from './widget-primary-tree-cover-actions';
+import reducers, { initialState } from './widget-primary-tree-cover-reducers';
+import {
+  getPrimaryTreeCoverData,
+  getSentence
+} from './widget-primary-tree-cover-selectors';
+import WidgetPrimaryTreeCoverComponent from './widget-primary-tree-cover-component';
+
+const mapStateToProps = ({ widgetPrimaryTreeCover, countryData }, ownProps) => {
+  const {
+    isCountriesLoading,
+    isRegionsLoading,
+    countryWhitelist,
+    regions
+  } = countryData;
+  const { settings, loading, data } = widgetPrimaryTreeCover;
+  const { locationNames, activeIndicator } = ownProps;
+  const selectorData = {
+    data,
+    settings,
+    whitelist: countryWhitelist,
+    locationNames,
+    activeIndicator
+  };
+
+  return {
+    loading: loading || isCountriesLoading || isRegionsLoading,
+    regions,
+    data,
+    parsedData: getPrimaryTreeCoverData(selectorData),
+    sentence: getSentence(selectorData)
+  };
+};
+
+class WidgetPrimaryTreeCoverContainer extends PureComponent {
+  componentDidMount() {
+    const { location, settings, getPrimaryTreeCover } = this.props;
+    getPrimaryTreeCover({
+      ...location,
+      ...settings
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { settings, getPrimaryTreeCover, location } = nextProps;
+
+    if (
+      !isEqual(location, this.props.location) ||
+      !isEqual(settings, this.props.settings)
+    ) {
+      getPrimaryTreeCover({
+        ...location,
+        ...settings
+      });
+    }
+  }
+
+  render() {
+    return createElement(WidgetPrimaryTreeCoverComponent, {
+      ...this.props
+    });
+  }
+}
+
+WidgetPrimaryTreeCoverContainer.propTypes = {
+  settings: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  getPrimaryTreeCover: PropTypes.func.isRequired
+};
+
+export { actions, reducers, initialState };
+
+export default connect(mapStateToProps, actions)(
+  WidgetPrimaryTreeCoverContainer
+);

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
@@ -83,7 +83,7 @@ export const getFilteredData = createSelector(
 export const getSentence = createSelector(
   [getData, getSettings, getIndicator, getLocationNames],
   (data, settings, indicator, locationNames) => {
-    if (!data || !data.length) return null;
+    if (!data || !data.length || !locationNames) return null;
     const locationData = data.find(l => l.id === locationNames.current.value);
     const regionPhrase =
       indicator.value === 'gadm28'

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
@@ -90,7 +90,8 @@ export const getSentence = createSelector(
         ? '<span>region-wide</span>'
         : `in <span>${indicator && indicator.label.toLowerCase()}</span>`;
 
-    const areaPercent = format('.1f')(locationData.percentage);
+    const areaPercent =
+      (locationData && format('.1f')(locationData.percentage)) || 0;
     const firstSentence = `From 2001 to 2012, <span>${locationNames.current &&
       locationNames.current.label}</span> gained <strong>${
       locationData.gain ? format('.3s')(locationData.gain) : '0'


### PR DESCRIPTION
## Overview

As our old friend Optimus used to say "Always stay in your Prime!". Here at Vizzuality we say "Why stop at humans, why not forests too!?". Thats why we created the Primary Forests tree cover widget. So that YOU 👉  can ALWAYS keep track of your favourite countries most PRIME-est 🤖  of forests.

This widget simply extends the intactTreeCover widget with some small difference in calculations. If you are really keen you should check out the selectors file and the fetch file to see how it is done. Totes ma gotes worth a read.

BONUS ROUND: fixed a small bug with resetting the REFINE LOCATION dropdown in widgets when changing location in the header.

## Demo

![screen shot 2018-01-17 at 17 12 21](https://user-images.githubusercontent.com/20288774/35053139-9b758094-fba9-11e7-85da-974402535ce8.png)