### PR TITLE
Feature/meta data modals

### DIFF
--- a/app/assets/stylesheets/components/about/_c-about-body.scss
+++ b/app/assets/stylesheets/components/about/_c-about-body.scss
@@ -1,4 +1,4 @@
 html, body {
     max-width: 100%;
-    overflow-x: hidden;
+    // overflow-x: hidden;
 }

--- a/app/javascript/components/dropdown/dropdown-component.js
+++ b/app/javascript/components/dropdown/dropdown-component.js
@@ -33,7 +33,7 @@ class Dropdown extends PureComponent {
   };
 
   render() {
-    const { theme, label, infoAction } = this.props;
+    const { theme, label, infoAction, modalOpen, modalClosing } = this.props;
     return (
       <div className={`c-dropdown ${theme || 'theme-select-light'}`}>
         {label && (
@@ -41,14 +41,10 @@ class Dropdown extends PureComponent {
             {label}
             {infoAction && (
               <Button
-                disabled
                 className="theme-button-small square info-button"
+                onClick={infoAction}
               >
-                <Icon
-                  icon={infoIcon}
-                  className="info-icon"
-                  onClick={infoAction}
-                />
+                <Icon icon={infoIcon} className="info-icon" />
               </Button>
             )}
           </div>
@@ -57,6 +53,12 @@ class Dropdown extends PureComponent {
           iconRenderer={() => (
             <Icon icon={arrowDownIcon} className="icon icon-arrow-down" />
           )}
+          beforeClose={() => {
+            if (modalOpen || modalClosing) {
+              return false;
+            }
+            return true;
+          }}
           onSearch={this.handleSearch}
           {...this.props}
           options={this.state.options}
@@ -70,7 +72,9 @@ Dropdown.propTypes = {
   label: PropTypes.string,
   theme: PropTypes.string,
   options: PropTypes.array,
-  infoAction: PropTypes.func
+  infoAction: PropTypes.func,
+  modalOpen: PropTypes.bool,
+  modalClosing: PropTypes.bool
 };
 
 export default Dropdown;

--- a/app/javascript/components/dropdown/dropdown.js
+++ b/app/javascript/components/dropdown/dropdown.js
@@ -1,3 +1,10 @@
+import { connect } from 'react-redux';
+
 import Component from './dropdown-component';
 
-export default Component;
+const mapStateToProps = ({ modalMeta }) => ({
+  modalOpen: modalMeta.open,
+  modalClosing: modalMeta.closing
+});
+
+export default connect(mapStateToProps, null)(Component);

--- a/app/javascript/components/modal-meta/modal-meta-actions.js
+++ b/app/javascript/components/modal-meta/modal-meta-actions.js
@@ -1,0 +1,50 @@
+import { createAction } from 'redux-actions';
+import { createThunkAction } from 'utils/redux';
+import { getMeta } from 'services/meta';
+
+const setModalMetaData = createAction('setModalMetaData');
+const setModalMetaLoading = createAction('setModalMetaLoading');
+const setModalMetaClosing = createAction('setModalMetaClosing');
+
+const setModalMeta = createThunkAction(
+  'setModalMeta',
+  params => (dispatch, state) => {
+    if (!state().modalMeta.loading) {
+      dispatch(
+        setModalMetaLoading({ loading: true, error: false, open: true })
+      );
+      getMeta(params)
+        .then(response => {
+          let data = {};
+          if (response && response.data && typeof response.data !== 'string') {
+            data = response.data;
+          }
+          dispatch(setModalMetaData(data));
+        })
+        .catch(error => {
+          console.info(error);
+          dispatch(setModalMetaLoading({ loading: false, error: true }));
+        });
+    }
+  }
+);
+
+const setModalMetaClosed = createThunkAction(
+  'setModalMetaClosed',
+  () => dispatch => {
+    dispatch(
+      setModalMetaClosing({ loading: false, open: false, closing: true })
+    );
+    setTimeout(() => {
+      dispatch(setModalMetaClosing({ closing: false }));
+    }, 500);
+  }
+);
+
+export default {
+  setModalMeta,
+  setModalMetaData,
+  setModalMetaClosed,
+  setModalMetaLoading,
+  setModalMetaClosing
+};

--- a/app/javascript/components/modal-meta/modal-meta-component.jsx
+++ b/app/javascript/components/modal-meta/modal-meta-component.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import pick from 'lodash/pick';
 import isEmpty from 'lodash/isEmpty';
+import lowerCase from 'lodash/lowerCase';
 
 import Modal from 'components/modal';
 import Loader from 'components/loader';
@@ -52,7 +53,7 @@ class ModalMeta extends PureComponent {
                         <div key={key} className="table-row">
                           <div
                             className="title-column"
-                            dangerouslySetInnerHTML={{ __html: key }}
+                            dangerouslySetInnerHTML={{ __html: lowerCase(key) }}
                           />
                           <div
                             className="description-column"

--- a/app/javascript/components/modal-meta/modal-meta-component.jsx
+++ b/app/javascript/components/modal-meta/modal-meta-component.jsx
@@ -1,0 +1,125 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import pick from 'lodash/pick';
+import isEmpty from 'lodash/isEmpty';
+
+import Modal from 'components/modal';
+import Loader from 'components/loader';
+import NoContent from 'components/no-content';
+
+import './modal-meta-styles.scss';
+
+class ModalMeta extends PureComponent {
+  getContent() {
+    const { data, loading, error } = this.props;
+    const tableData = pick(data, [
+      'function',
+      'resolution',
+      'geographic_coverage',
+      'source',
+      'frequency_of_updates',
+      'date_of_content',
+      'cautions',
+      'license'
+    ]);
+
+    return (
+      <div className="c-modal-meta">
+        {loading && <Loader />}
+        {error &&
+          !loading && (
+            <NoContent message="There was a problem finding this info. Please try again later." />
+          )}
+        {!loading &&
+          isEmpty(data) &&
+          !error && (
+            <NoContent message="Sorry, we cannot find what you are looking for." />
+          )}
+        {!loading &&
+          !error &&
+          !isEmpty(data) && (
+            <div>
+              <h3 className="title">{data.title}</h3>
+              <p
+                className="tags"
+                dangerouslySetInnerHTML={{ __html: data.tags }}
+              />
+              <div className="meta-table">
+                {tableData &&
+                  Object.keys(tableData).map(
+                    key =>
+                      (tableData[key] ? (
+                        <div key={key} className="table-row">
+                          <div
+                            className="title-column"
+                            dangerouslySetInnerHTML={{ __html: key }}
+                          />
+                          <div
+                            className="description-column"
+                            dangerouslySetInnerHTML={{ __html: tableData[key] }}
+                          />
+                        </div>
+                      ) : null)
+                  )}
+              </div>
+              {data.overview && (
+                <div className="overview">
+                  <h4>Overview</h4>
+                  <p dangerouslySetInnerHTML={{ __html: data.overview }} />
+                </div>
+              )}
+              {data.citation && (
+                <div className="citation">
+                  <h5>Citation</h5>
+                  <p dangerouslySetInnerHTML={{ __html: data.citation }} />
+                </div>
+              )}
+            </div>
+          )}
+      </div>
+    );
+  }
+
+  render() {
+    const { open, setModalMetaClosed } = this.props;
+    return (
+      <Modal
+        isOpen={open}
+        onRequestClose={() => setModalMetaClosed(false)}
+        customStyles={{
+          overlay: {
+            zIndex: 10000,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            boxShadow: '0 5px 15px 0 rgba(71, 44, 184, 0.1)',
+            backgroundColor: 'rgba(17, 55, 80, 0.4)'
+          },
+          content: {
+            position: 'relative',
+            top: 'auto',
+            left: 'auto',
+            right: 'auto',
+            bottom: 'auto',
+            padding: '0',
+            border: 'none',
+            borderRadius: 0
+          }
+        }}
+        closeClass="c-modal-meta-close"
+      >
+        {this.getContent()}
+      </Modal>
+    );
+  }
+}
+
+ModalMeta.propTypes = {
+  open: PropTypes.bool,
+  setModalMetaClosed: PropTypes.func,
+  data: PropTypes.object,
+  loading: PropTypes.bool,
+  error: PropTypes.bool
+};
+
+export default ModalMeta;

--- a/app/javascript/components/modal-meta/modal-meta-component.jsx
+++ b/app/javascript/components/modal-meta/modal-meta-component.jsx
@@ -94,11 +94,14 @@ class ModalMeta extends PureComponent {
             alignItems: 'center',
             justifyContent: 'center',
             boxShadow: '0 5px 15px 0 rgba(71, 44, 184, 0.1)',
-            backgroundColor: 'rgba(17, 55, 80, 0.4)'
+            backgroundColor: 'rgba(17, 55, 80, 0.4)',
+            overflow: 'auto',
+            padding: '40px 0'
           },
           content: {
             position: 'relative',
             top: 'auto',
+            margin: 'auto',
             left: 'auto',
             right: 'auto',
             bottom: 'auto',

--- a/app/javascript/components/modal-meta/modal-meta-reducers.js
+++ b/app/javascript/components/modal-meta/modal-meta-reducers.js
@@ -1,0 +1,29 @@
+export const initialState = {
+  loading: false,
+  error: false,
+  open: false,
+  closing: false,
+  data: {}
+};
+
+const setModalMetaLoading = (state, { payload }) => ({
+  ...state,
+  ...payload
+});
+
+const setModalMetaData = (state, { payload }) => ({
+  ...state,
+  data: payload,
+  loading: false
+});
+
+const setModalMetaClosing = (state, { payload }) => ({
+  ...state,
+  ...payload
+});
+
+export default {
+  setModalMetaData,
+  setModalMetaClosing,
+  setModalMetaLoading
+};

--- a/app/javascript/components/modal-meta/modal-meta-styles.scss
+++ b/app/javascript/components/modal-meta/modal-meta-styles.scss
@@ -41,6 +41,7 @@ $modal-padding: rem(30px);
     justify-content: space-between;
     align-items: flex-start;
     border-bottom: solid 1px $border;
+    width: 100%;
 
     &:nth-child(even) {
       background-color: $grey-light;
@@ -61,6 +62,7 @@ $modal-padding: rem(30px);
       font-size: rem(13px);
       line-height: 1.5;
       color: $slate;
+      width: calc(100% - 100px);
     }
   }
 

--- a/app/javascript/components/modal-meta/modal-meta-styles.scss
+++ b/app/javascript/components/modal-meta/modal-meta-styles.scss
@@ -1,0 +1,108 @@
+@import '~styles/settings.scss';
+$modal-padding: rem(30px);
+
+.c-modal-meta {
+  padding: $modal-padding $modal-padding;
+  min-width: rem(320px);
+  min-height: rem(320px);
+  width: rem(600px);
+  color: $slate;
+
+  .title {
+    font-weight: 500;
+    font-size: rem(16px);
+    text-transform: uppercase;
+    color: $slate;
+    line-height: 1.25;
+  }
+
+  .tags {
+    margin-top: rem(5px);
+    font-size: rem(13px);
+    line-height: 1.2;
+    color: $warm-grey;
+    margin-bottom: $modal-padding;
+  }
+
+  .meta-table {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
+    border-top: solid 1px $border;
+    margin: 0 rem(-30px);
+    width: auto;
+    margin-bottom: rem(30px);
+  }
+
+  .table-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+    border-bottom: solid 1px $border;
+
+    &:nth-child(even) {
+      background-color: $grey-light;
+    }
+
+    .title-column {
+      font-weight: 500;
+      font-size: rem(11px);
+      text-transform: uppercase;
+      padding: rem(15px) $modal-padding;
+      color: $slate;
+      width: rem(100px);
+    }
+
+    .description-column {
+      padding: rem(13px) $modal-padding;
+      font-weight: 300;
+      font-size: rem(13px);
+      line-height: 1.5;
+      color: $slate;
+    }
+  }
+
+  .overview {
+    margin-bottom: rem(30px);
+
+    h4 {
+      font-size: rem(16px);
+      font-weight: 500;
+    }
+
+    p {
+      font-size: rem(13px);
+      font-weight: 300;
+    }
+  }
+
+  .citation {
+    h5 {
+      font-size: rem(12px);
+      font-weight: 500;
+    }
+
+    p {
+      font-size: rem(12px);
+      color: #aaa;
+      font-weight: 300;
+    }
+  }
+
+  a {
+    color: $green-gfw;
+
+    &:hover {
+      color: darken($green-gfw, 10%);
+    }
+  }
+}
+
+.c-modal-meta-close {
+  right: rem(13px);
+  top: rem(13px);
+  cursor: pointer;
+  z-index: 10;
+}

--- a/app/javascript/components/modal-meta/modal-meta-styles.scss
+++ b/app/javascript/components/modal-meta/modal-meta-styles.scss
@@ -52,6 +52,7 @@ $modal-padding: rem(30px);
       font-size: rem(11px);
       text-transform: uppercase;
       padding: rem(15px) $modal-padding;
+      padding-right: rem(5px);
       color: $slate;
       width: rem(100px);
     }

--- a/app/javascript/components/modal-meta/modal-meta.js
+++ b/app/javascript/components/modal-meta/modal-meta.js
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux';
+
+import actions from './modal-meta-actions';
+import reducers, { initialState } from './modal-meta-reducers';
+import ModalMetaComponent from './modal-meta-component';
+
+const mapStateToProps = ({ modalMeta }) => ({
+  open: modalMeta.open,
+  data: modalMeta.data,
+  loading: modalMeta.loading
+});
+
+export { actions, reducers, initialState };
+
+export default connect(mapStateToProps, actions)(ModalMetaComponent);

--- a/app/javascript/components/modal/modal-styles.scss
+++ b/app/javascript/components/modal/modal-styles.scss
@@ -13,3 +13,8 @@ $close-position: 25px;
   border: none;
   outline: none;
 }
+
+html,
+body {
+  overflow-x: visible !important;
+}

--- a/app/javascript/components/share/share-component.jsx
+++ b/app/javascript/components/share/share-component.jsx
@@ -119,7 +119,7 @@ class Share extends PureComponent {
         onRequestClose={() => setShareOpen(false)}
         customStyles={{
           overlay: {
-            zIndex: 20,
+            zIndex: 300,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',

--- a/app/javascript/pages/country/data/indicators.json
+++ b/app/javascript/pages/country/data/indicators.json
@@ -1,66 +1,82 @@
 [
   {
     "label": "All of {location}",
-    "value": "gadm28"
+    "value": "gadm28",
+    "metaKey": ""
   },
   {
     "label": "Biomes",
-    "value": "bra_biomes"
+    "value": "bra_biomes",
+    "metaKey": ""
   },
   {
     "label": "Mining",
-    "value": "mining"
+    "value": "mining",
+    "metaKey": "gfw_mining"
   },
   {
     "label": "Protected Areas",
-    "value": "wdpa"
+    "value": "wdpa",
+    "metaKey": "wdpa_protected_areas"
   },
   {
     "label": "Primary Forests",
-    "value": "primary_forest"
+    "value": "primary_forest",
+    "metaKey": ""
   },
   {
     "label": "Mining in Primary Forests",
-    "value": "primary_forest__mining"
+    "value": "primary_forest__mining",
+    "metaKey": ""
   },
   {
     "label": "Protected Areas in Primary Forests",
-    "value": "primary_forest__wdpa"
+    "value": "primary_forest__wdpa",
+    "metaKey": ""
   },
   {
     "label": "Intact Forest Landscapes",
-    "value": "ifl_2013"
+    "value": "ifl_2013",
+    "metaKey": "intact_forest_landscapes_change"
   },
   {
     "label": "Protected Areas in Intact Forest Landscapes",
-    "value": "ifl_2013__wdpa"
+    "value": "ifl_2013__wdpa",
+    "metaKey": ""
   },
   {
     "label": "Mining in Intact Forest Landscapes",
-    "value": "ifl_2013__mining"
+    "value": "ifl_2013__mining",
+    "metaKey": ""
   },
   {
     "label": "Indigenous Lands",
-    "value": "landmark"
+    "value": "landmark",
+    "metaKey": "gfw_land_rights"
   },
   {
     "label": "Indigenous Lands in Primary Forests",
-    "value": "primary_forest__landmark"
+    "value": "primary_forest__landmark",
+    "metaKey": ""
   },
   {
     "label": "Plantations",
-    "value": "plantations"
+    "value": "plantations",
+    "metaKey": "gfw_plantations"
   },
   {
     "label": "Mining in Plantation Areas",
-    "value": "plantations__mining"
+    "value": "plantations__mining",
+    "metaKey": ""
   },
   {
     "label": "Protected areas in Plantations",
-    "value": "plantations__wdpa"
+    "value": "plantations__wdpa",
+    "metaKey": ""
   },
   {
     "label": "Indigenous Lands in Plantations",
-    "value": "plantations__landmark"
+    "value": "plantations__landmark",
+    "metaKey": ""
   }
 ]

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -2,7 +2,7 @@
   "treeCover": {
     "title": "Tree cover extent",
     "config": {
-      "gridWidth": 6,
+      "size": "small",
       "indicators": ["gadm28", "mining", "landmark", "wdpa", "plantations"],
       "categories": ["summary", "land-cover"],
       "admins": ["country", "region", "subRegion"],
@@ -21,7 +21,7 @@
   "intactTreeCover": {
     "title": "Intact forest extent",
     "config": {
-      "gridWidth": 6,
+      "size": "small",
       "indicators": ["ifl_2013", "ifl_2013__wdpa", "ifl_2013__mining"],
       "categories": ["land-cover"],
       "admins": ["country", "region", "subRegion"],
@@ -39,7 +39,7 @@
   "primaryTreeCover": {
     "title": "Primary forest extent",
     "config": {
-      "gridWidth": 6,
+      "size": "small",
       "indicators": ["primary_forest", "primary_forest__mining", "primary_forest__wdpa", "primary_forest__landmark"],
       "categories": ["land-cover"],
       "admins": ["country", "region", "subRegion"],
@@ -57,7 +57,7 @@
   "treeLocated": {
     "title": "Where are the forests located",
     "config": {
-      "gridWidth": 12,
+      "size": "large",
       "indicators": ["gadm28", "ifl_2013", "wdpa",
                       "ifl_2013__wdpa", "ifl_2013__mining",
                       "primary_forest", "primary_forest__landmark",
@@ -83,7 +83,7 @@
   "relativeTreeCover": {
     "title": "Which regions are the most forest-covered",
     "config": {
-      "gridWidth": 6,
+      "size": "small",
       "indicators": ["gadm28", "ifl_2013", "wdpa",
                       "ifl_2013__wdpa", "ifl_2013__mining",
                       "primary_forest", "primary_forest__landmark",
@@ -109,7 +109,7 @@
   "treeLoss": {
     "title": "Tree cover loss",
     "config": {
-      "gridWidth": 12,
+      "size": "large",
       "indicators": ["gadm28", "wdpa", "ifl_2013",
                      "ifl_2013__wdpa", "ifl_2013__mining",
                      "primary_forests","primary_forest__landmark",
@@ -133,7 +133,7 @@
   "treeLossPlantations": {
     "title": "Tree cover loss for plantations",
     "config": {
-      "gridWidth": 12,
+      "size": "large",
       "showIndicators": ["plantations"],
       "categories": ["forest-change", "land-use"],
       "admins": ["country", "region", "subRegion"],
@@ -154,7 +154,7 @@
   "treeGain": {
     "title": "Tree cover gain",
     "config": {
-      "gridWidth": 6,
+      "size": "small",
       "indicators": ["gadm28", "wdpa", "primary_forests", "plantations", "ifl_2013"],
       "categories": ["summary", "forest-change"],
       "admins": ["country", "region", "subRegion"],
@@ -173,7 +173,7 @@
   "FAOReforestation": {
     "title": "FAO reforestation",
     "config": {
-      "gridWidth": 6,
+      "size": "small",
       "categories": ["summary", "forest-change"],
       "admins": ["country"],
       "selectors": ["periods"],
@@ -189,7 +189,7 @@
   "FAOCover": {
     "title": "Forest cover",
     "config": {
-      "gridWidth": 6,
+      "size": "small",
       "categories": ["land-cover"],
       "admins": ["country"],
       "type": "fao",

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -8,7 +8,8 @@
       "admins": ["country", "region", "subRegion"],
       "selectors": ["indicators", "thresholds", "extentYears"],
       "showIndicators": ["mining", "landmark", "wdpa", "plantations"],
-      "type": "extent"
+      "type": "extent",
+      "metaKey": "widget_tree_cover"
     },
     "settings": {
       "indicator": "gadm28",
@@ -25,7 +26,8 @@
       "categories": ["land-cover"],
       "admins": ["country", "region", "subRegion"],
       "selectors": ["indicators", "thresholds", "extentYears"],
-      "type": "extent"
+      "type": "extent",
+      "metaKey": "widget_ifl"
     },
     "settings": {
       "indicator": "ifl_2013",
@@ -42,7 +44,8 @@
       "categories": ["land-cover"],
       "admins": ["country", "region", "subRegion"],
       "selectors": ["indicators", "thresholds", "extentYears"],
-      "type": "extent"
+      "type": "extent",
+      "metaKey": "widget_primary_forest"
     },
     "settings": {
       "indicator": "primary_forest",
@@ -64,7 +67,8 @@
       "admins": ["country", "region"],
       "selectors": ["indicators", "thresholds", "units", "extentYears"],
       "locationCheck": true,
-      "type": "extent"
+      "type": "extent",
+      "metaKey": "widget_forest_location"
     },
     "settings": {
       "indicator": "gadm28",
@@ -89,7 +93,8 @@
       "admins": ["country", "region"],
       "selectors": ["indicators", "thresholds", "extentYears"],
       "locationCheck": true,
-      "type": "extent"
+      "type": "extent",
+      "metaKey": ""
     },
     "settings": {
       "indicator": "gadm28",
@@ -113,7 +118,8 @@
       "categories": ["summary", "forest-change"],
       "admins": ["country", "region", "subRegion"],
       "selectors": ["indicators", "startYears", "endYears", "thresholds", "extentYears"],
-      "type": "loss"
+      "type": "loss",
+      "metaKey": "widget_tree_cover_loss"
     },
     "settings": {
       "indicator": "gadm28",
@@ -133,7 +139,8 @@
       "admins": ["country", "region", "subRegion"],
       "selectors": ["startYears", "endYears", "thresholds", "extentYears"],
       "yearRange": ["2013", "2016"],
-      "type": "loss"
+      "type": "loss",
+      "metaKey": ""
     },
     "settings": {
       "indicator": "plantations",
@@ -152,7 +159,8 @@
       "categories": ["summary", "forest-change"],
       "admins": ["country", "region", "subRegion"],
       "selectors": ["indicators", "thresholds", "extentYears", "units"],
-      "type": "gain"
+      "type": "gain",
+      "metaKey": "widget_tree_cover_gain"
     },
     "settings": {
       "indicator": "gadm28",
@@ -169,7 +177,8 @@
       "categories": ["summary", "forest-change"],
       "admins": ["country"],
       "selectors": ["periods"],
-      "type": "fao"
+      "type": "fao",
+      "metaKey": "widget_rate_of_restoration_fao"
     },
     "settings": {
       "period": 2010,
@@ -183,7 +192,8 @@
       "gridWidth": 6,
       "categories": ["land-cover"],
       "admins": ["country"],
-      "type": "fao"
+      "type": "fao",
+      "metaKey": "widget_forest_cover_fao"
     },
     "active": true
   }

--- a/app/javascript/pages/country/embed/embed-component.js
+++ b/app/javascript/pages/country/embed/embed-component.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Widget from 'pages/country/widget';
 import Share from 'components/share';
 import CountryDataProvider from 'pages/country/providers/country-data-provider';
+import ModalMeta from 'components/modal-meta';
 
 import './embed-styles.scss';
 
@@ -17,6 +18,7 @@ class Embed extends PureComponent {
           <Widget widget={widgetKey} embed />
         </div>
         <Share />
+        <ModalMeta />
         <CountryDataProvider />
       </div>
     );

--- a/app/javascript/pages/country/providers/country-data-provider/country-data-provider-actions.js
+++ b/app/javascript/pages/country/providers/country-data-provider/country-data-provider-actions.js
@@ -98,10 +98,10 @@ export const getSubRegions = createThunkAction(
 
 export const getGeostore = createThunkAction(
   'getGeostore',
-  (country, region) => (dispatch, state) => {
+  (country, region, subRegion) => (dispatch, state) => {
     if (!state().countryData.isGeostoreLoading) {
       dispatch(setGeostoreLoading(true));
-      getGeostoreProvider(country, region)
+      getGeostoreProvider(country, region, subRegion)
         .then(response => {
           const { areaHa, bbox } = response.data.data.attributes;
           dispatch(

--- a/app/javascript/pages/country/providers/country-data-provider/country-data-provider.js
+++ b/app/javascript/pages/country/providers/country-data-provider/country-data-provider.js
@@ -63,6 +63,7 @@ class CountryDataProvider extends PureComponent {
     }
 
     if (hasSubRegionChanged) {
+      getGeostore(country, region, subRegion);
       getRegionWhitelist(country, region, subRegion);
     }
   }

--- a/app/javascript/pages/country/reducers.js
+++ b/app/javascript/pages/country/reducers.js
@@ -14,6 +14,7 @@ const countryReducers = {
 
 // Components
 import * as ShareComponent from 'components/share';
+import * as ModalMetaComponent from 'components/modal-meta';
 import * as mapComponent from 'components/map';
 import * as storiesComponent from 'pages/country/stories';
 import * as headerComponent from 'pages/country/header';
@@ -37,6 +38,7 @@ import * as countryDataProviderComponent from 'pages/country/providers/country-d
 
 const componentsReducers = {
   share: handleActions(ShareComponent),
+  modalMeta: handleActions(ModalMetaComponent),
   map: handleActions(mapComponent),
   stories: handleActions(storiesComponent),
   header: handleActions(headerComponent),

--- a/app/javascript/pages/country/root/root-component.js
+++ b/app/javascript/pages/country/root/root-component.js
@@ -15,6 +15,7 @@ import NoContent from 'components/no-content';
 import Loader from 'components/loader';
 import Button from 'components/button';
 import Icon from 'components/icon';
+import ModalMeta from 'components/modal-meta';
 
 import mapIcon from 'assets/icons/map-button.svg';
 import closeIcon from 'assets/icons/close.svg';
@@ -126,6 +127,7 @@ class Root extends PureComponent {
         <Stories />
         <Footer />
         <Share />
+        <ModalMeta />
         <CountryDataProvider />
       </div>
     );

--- a/app/javascript/pages/country/root/root-component.js
+++ b/app/javascript/pages/country/root/root-component.js
@@ -63,36 +63,21 @@ class Root extends PureComponent {
               checkActive
             />
             <div className="widgets">
-              <div className="row">
-                {loading && (
-                  <div className="columns small-12">
-                    <Loader className="widgets-loader" />
-                  </div>
+              {loading && <Loader className="widgets-loader large" />}
+              {!loading &&
+                widgets &&
+                widgets.length > 0 &&
+                widgets.map(widget => (
+                  <Widget key={widget.name} widget={widget.name} />
+                ))}
+              {!loading &&
+                (!widgets || widgets.length === 0) && (
+                  <NoContent
+                    className="no-widgets-message large"
+                    message={`No ${category} data available for ${currentLocation}`}
+                    icon
+                  />
                 )}
-                {!loading &&
-                  widgets &&
-                  widgets.length > 0 &&
-                  widgets.map(widget => (
-                    <div
-                      key={widget.name}
-                      className={`columns large-${
-                        widget.config.gridWidth
-                      } small-12 widget`}
-                    >
-                      <Widget widget={widget.name} />
-                    </div>
-                  ))}
-                {!loading &&
-                  (!widgets || widgets.length === 0) && (
-                    <div className="columns small-12">
-                      <NoContent
-                        className="no-widgets-message"
-                        message={`No ${category} data available for ${currentLocation}`}
-                        icon
-                      />
-                    </div>
-                  )}
-              </div>
             </div>
           </div>
           <div className={`map-panel ${showMapMobile ? '-open-mobile' : ''}`}>

--- a/app/javascript/pages/country/root/root-styles.scss
+++ b/app/javascript/pages/country/root/root-styles.scss
@@ -128,18 +128,31 @@ $black-tabs: #404040;
   }
 
   .widgets {
-    padding-top: rem(20px);
-    padding-bottom: rem(30px);
+    padding: rem(20px) $mobile-gutter rem(30px);
     position: relative;
     min-height: rem(400px);
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-gap: 30px;
+    grid-auto-flow: dense;
+
+    @media screen and (min-width: $screen-m) {
+      padding-left: $desktop-gutter;
+      padding-right: $desktop-gutter;
+    }
 
     @media screen and (min-width: $screen-l) {
       padding-top: rem(50px);
       padding-right: rem(30px);
+      grid-template-columns: 1fr 1fr;
+
+      .large {
+        grid-column-end: span 2;
+      }
     }
 
     @media screen and (min-width: $screen-xl) {
-      padding-left: calc(100% - (#{$max-width} * 0.7));
+      padding-left: calc(100% - (#{$max-width} * 0.7) + #{$desktop-gutter});
     }
 
     .widget {

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
@@ -12,6 +12,13 @@ import infoIcon from 'assets/icons/info.svg';
 import './widget-header-styles.scss';
 
 class WidgetHeader extends PureComponent {
+  constructor() {
+    super();
+    this.state = {
+      tooltipOpen: false
+    };
+  }
+
   render() {
     const {
       title,
@@ -20,8 +27,12 @@ class WidgetHeader extends PureComponent {
       widget,
       embed,
       shareData,
-      setShareModal
+      setShareModal,
+      setModalMeta,
+      modalOpen,
+      modalClosing
     } = this.props;
+    const { tooltipOpen } = this.state;
 
     return (
       <div className="c-widget-header">
@@ -30,7 +41,10 @@ class WidgetHeader extends PureComponent {
         }`}</div>
         <div className="options">
           <div className="small-options">
-            <Button className="theme-button-small square" disabled>
+            <Button
+              className="theme-button-small square"
+              onClick={() => setModalMeta(settingsConfig.config.metaKey)}
+            >
               <Icon icon={infoIcon} />
             </Button>
             {!embed &&
@@ -42,13 +56,21 @@ class WidgetHeader extends PureComponent {
                   offset={-95}
                   trigger="click"
                   interactive
+                  onRequestClose={() => {
+                    if (!modalClosing && !modalOpen) {
+                      this.setState({ tooltipOpen: false });
+                    }
+                  }}
+                  onShow={() => this.setState({ tooltipOpen: true })}
                   arrow
                   useContext
+                  open={tooltipOpen}
                   html={
                     <WidgetSettings
                       {...settingsConfig}
                       widget={widget}
                       locationNames={locationNames}
+                      setModalMeta={setModalMeta}
                     />
                   }
                 >
@@ -77,7 +99,10 @@ WidgetHeader.propTypes = {
   locationNames: PropTypes.object,
   embed: PropTypes.bool,
   setShareModal: PropTypes.func.isRequired,
-  shareData: PropTypes.object.isRequired
+  shareData: PropTypes.object.isRequired,
+  setModalMeta: PropTypes.func.isRequired,
+  modalOpen: PropTypes.bool,
+  modalClosing: PropTypes.bool
 };
 
 export default WidgetHeader;

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header.js
@@ -32,7 +32,7 @@ const mapStateToProps = ({ location, modalMeta }, ownProps) => {
       shareUrl: `${window.location.href}#${widget}`,
       embedUrl,
       embedSettings:
-        settingsConfig.config.gridWidth === 6
+        settingsConfig.config.size === 'small'
           ? { width: 315, height: 460 }
           : { width: 670, height: 490 }
     }

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header.js
@@ -2,9 +2,12 @@ import { connect } from 'react-redux';
 import compact from 'lodash/compact';
 
 import shareActions from 'components/share/share-actions';
+import modalMetaActions from 'components/modal-meta/modal-meta-actions';
 import WidgetHeaderComponent from './widget-header-component';
 
-const mapStateToProps = ({ location }, ownProps) => {
+const actions = { ...shareActions, ...modalMetaActions };
+
+const mapStateToProps = ({ location, modalMeta }, ownProps) => {
   const { locationNames, widget, title, settingsConfig } = ownProps;
   const locationUrl = compact(
     Object.keys(location.payload).map(key => location.payload[key])
@@ -19,6 +22,8 @@ const mapStateToProps = ({ location }, ownProps) => {
 
   return {
     location,
+    modalOpen: modalMeta.open,
+    modalClosing: modalMeta.closing,
     shareData: {
       title: 'Share this widget',
       subtitle: `${title} in ${
@@ -34,4 +39,4 @@ const mapStateToProps = ({ location }, ownProps) => {
   };
 };
 
-export default connect(mapStateToProps, shareActions)(WidgetHeaderComponent);
+export default connect(mapStateToProps, actions)(WidgetHeaderComponent);

--- a/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-component.jsx
@@ -29,7 +29,7 @@ class WidgetNumberedList extends PureComponent {
         <ul className="list">
           {data.length > 0 &&
             pageData.map((item, index) => (
-              <li key={item.label}>
+              <li key={`${item.label}-${item.id}`}>
                 <Link
                   className={`list-item ${linksDisabled ? 'disabled' : ''}`}
                   to={item.path}

--- a/app/javascript/pages/country/widget/components/widget-settings/widget-settings-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-settings/widget-settings-component.jsx
@@ -51,7 +51,7 @@ class WidgetSettings extends PureComponent {
                 {option.label}
                 <Button
                   className="theme-button-small square info-button"
-                  onClick={() => setModalMeta(option.value)}
+                  onClick={() => setModalMeta(option.metaKey)}
                 >
                   <Icon icon={infoIcon} className="info-icon" />
                 </Button>
@@ -69,7 +69,7 @@ class WidgetSettings extends PureComponent {
             onChange={option =>
               onSettingsChange({ value: { extentYear: option.value }, widget })
             }
-            infoAction={() => setModalMeta('tree_cover_extent')}
+            infoAction={() => setModalMeta('widget_tree_cover_extent')}
           />
         )}
         {units && (
@@ -137,7 +137,7 @@ class WidgetSettings extends PureComponent {
               onSettingsChange({ value: { threshold: option.value }, widget })
             }
             disabled={loading}
-            infoAction={() => setModalMeta('canopy_density')}
+            infoAction={() => setModalMeta('widget_canopy_density')}
           />
         )}
       </div>

--- a/app/javascript/pages/country/widget/components/widget-settings/widget-settings-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-settings/widget-settings-component.jsx
@@ -14,7 +14,8 @@ class WidgetSettings extends PureComponent {
       loading,
       locationNames,
       onSettingsChange,
-      widget
+      widget,
+      setModalMeta
     } = this.props;
     const {
       units,
@@ -49,8 +50,8 @@ class WidgetSettings extends PureComponent {
               >
                 {option.label}
                 <Button
-                  disabled
                   className="theme-button-small square info-button"
+                  onClick={() => setModalMeta(option.value)}
                 >
                   <Icon icon={infoIcon} className="info-icon" />
                 </Button>
@@ -68,7 +69,7 @@ class WidgetSettings extends PureComponent {
             onChange={option =>
               onSettingsChange({ value: { extentYear: option.value }, widget })
             }
-            infoAction={() => console.info('open modal')}
+            infoAction={() => setModalMeta('tree_cover_extent')}
           />
         )}
         {units && (
@@ -136,7 +137,7 @@ class WidgetSettings extends PureComponent {
               onSettingsChange({ value: { threshold: option.value }, widget })
             }
             disabled={loading}
-            infoAction={() => console.info('open modal')}
+            infoAction={() => setModalMeta('canopy_density')}
           />
         )}
       </div>
@@ -156,7 +157,8 @@ WidgetSettings.propTypes = {
   locationNames: PropTypes.object,
   options: PropTypes.object,
   onSettingsChange: PropTypes.func,
-  widget: PropTypes.string
+  widget: PropTypes.string,
+  setModalMeta: PropTypes.func
 };
 
 export default WidgetSettings;

--- a/app/javascript/pages/country/widget/widget-component.jsx
+++ b/app/javascript/pages/country/widget/widget-component.jsx
@@ -54,7 +54,10 @@ class Widget extends PureComponent {
     } = this.props;
     const WidgetComponent = widgets[`Widget${upperFirst(camelCase(widget))}`];
     return (
-      <div className="c-widget" id={widget}>
+      <div
+        className={`c-widget ${settingsConfig.config.size || ''}`}
+        id={widget}
+      >
         <WidgetHeader
           widget={widget}
           title={title}

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-styles.scss
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-styles.scss
@@ -1,6 +1,8 @@
 @import '~styles/settings.scss';
 
 .c-widget-relative-tree-cover {
+  padding-top: rem(15px);
+
   .locations-container {
     margin-top: rem(30px);
   }

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-component.js
@@ -13,28 +13,27 @@ class WidgetTreeCoverGain extends PureComponent {
 
     return (
       <div className="c-widget-tree-cover-gain">
-        {data &&
-          data.length > 0 && (
-            <div className="gain-data">
-              <WidgetDynamicSentence sentence={sentence} />
-              <WidgetNumberedList
-                className="ranking-list"
-                data={data}
-                settings={settings}
-                colorRange={[COLORS.darkGreen, COLORS.nonForest]}
-                handlePageChange={() => {}}
-              />
-            </div>
-          )}
+        {data && (
+          <div className="gain-data">
+            {sentence && <WidgetDynamicSentence sentence={sentence} />}
+            <WidgetNumberedList
+              className="ranking-list"
+              data={data}
+              settings={settings}
+              colorRange={[COLORS.darkGreen, COLORS.nonForest]}
+              handlePageChange={() => {}}
+            />
+          </div>
+        )}
       </div>
     );
   }
 }
 
 WidgetTreeCoverGain.propTypes = {
-  data: PropTypes.array.isRequired,
+  data: PropTypes.array,
   settings: PropTypes.object.isRequired,
-  sentence: PropTypes.string.isRequired
+  sentence: PropTypes.string
 };
 
 export default WidgetTreeCoverGain;

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
@@ -84,19 +84,22 @@ export const getSentence = createSelector(
   [getData, getSettings, getIndicator, getLocationNames],
   (data, settings, indicator, locationNames) => {
     if (!data || !data.length || !locationNames) return null;
-    const locationData = data.find(l => l.id === locationNames.current.value);
+    const locationData =
+      locationNames.current &&
+      data.find(l => l.id === locationNames.current.value);
     const regionPhrase =
-      indicator.value === 'gadm28'
+      indicator && indicator.value === 'gadm28'
         ? '<span>region-wide</span>'
         : `in <span>${indicator && indicator.label.toLowerCase()}</span>`;
 
     const areaPercent =
       (locationData && format('.1f')(locationData.percentage)) || 0;
+    const gain = locationData && locationData.gain;
     const firstSentence = `From 2001 to 2012, <span>${locationNames.current &&
       locationNames.current.label}</span> gained <strong>${
-      locationData.gain ? format('.3s')(locationData.gain) : '0'
+      gain ? format('.3s')(gain) : '0'
     }ha</strong> of tree cover ${regionPhrase}`;
-    const secondSentence = locationData.gain
+    const secondSentence = gain
       ? `, equivalent to a <strong>${areaPercent}%</strong> increase relative to <b>${
         settings.extentYear
       }</b> tree cover extent.`

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
@@ -33,8 +33,8 @@ const mapStateToProps = (
   };
 
   return {
-    data: getFilteredData(selectorData) || [],
-    sentence: getSentence(selectorData) || ''
+    data: getFilteredData(selectorData),
+    sentence: getSentence(selectorData)
   };
 };
 

--- a/app/javascript/services/geostore.js
+++ b/app/javascript/services/geostore.js
@@ -2,8 +2,10 @@ import axios from 'axios';
 
 const REQUEST_URL = `${process.env.RESOURCE_WATCH_API_URL}/geostore/admin/`;
 
-export const getGeostoreProvider = (country, region) => {
-  const url = `${REQUEST_URL}${country}${region ? `/${region}` : ''}`;
+export const getGeostoreProvider = (country, region, subRegion) => {
+  const url = `${REQUEST_URL}${country}${region ? `/${region}` : ''}${
+    subRegion ? `/${subRegion}` : ''
+  }`;
   return axios.get(url);
 };
 

--- a/app/javascript/services/meta.js
+++ b/app/javascript/services/meta.js
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+const REQUEST_URL = `${process.env.GFW_API_HOST_PROD}/gfw-metadata`;
+
+export const getMeta = slug => {
+  const url = `${REQUEST_URL}/${slug}`;
+  return axios.get(url);
+};
+
+export default {
+  getMeta
+};


### PR DESCRIPTION
## Overview

A long needed PR to introduce the metadata modal to the React part of the application. This is a fairly straight forward PR:
- Add a new component <ModalMeta /> which can be included in any page you wish
- Add actions for the modal to fetch data from `/gfw-metadata` service and render it in the same format as the map
- Add interaction props to the modal for persistence when stacking multiple windows or click interactions
- Enable all the `i` buttons on the country page
- Handle errors and no data returned for the modal

BONUS:
- admin2 region when selected now zoom on the map
- grid sort ordering for widgets when there is whitespace (display: grid using css grid!)

## Demo

![jan-18-2018 20-50-28](https://user-images.githubusercontent.com/20288774/35118199-5af617ac-fc91-11e7-816f-4a29a6aca930.gif)

## Notes

It is possible an update is needed once the service has all the correct meta data.

## Testing

Interactions with dropdowns and tooltips have been accounted for behind the scenes.

