### PR TITLE
Feature/conversion for biomass tons

### DIFF
--- a/app/javascript/pages/country/header/header.js
+++ b/app/javascript/pages/country/header/header.js
@@ -8,6 +8,7 @@ import remove from 'lodash/remove';
 import { decodeUrlForState, encodeStateForUrl } from 'utils/stateToUrl';
 import { format } from 'd3-format';
 import WIDGETS_CONFIG from 'pages/country/data/widgets-config.json';
+import { biomassToCO2 } from 'utils/calculations';
 
 import * as actions from './header-actions';
 import reducers, { initialState } from './header-reducers';
@@ -105,7 +106,9 @@ class HeaderContainer extends PureComponent {
       data.totalLoss.area - (data.plantationsLoss.area || 0)
     );
     const emissionsWithoutPlantations = format('.2s')(
-      data.totalLoss.emissions - (data.plantationsLoss.emissions || 0)
+      biomassToCO2(
+        data.totalLoss.emissions - (data.plantationsLoss.emissions || 0)
+      )
     );
     const location = locationNames.current && locationNames.current.label;
     let firstSentence = '';

--- a/app/javascript/pages/country/root/root-selectors.js
+++ b/app/javascript/pages/country/root/root-selectors.js
@@ -55,21 +55,18 @@ export const checkWidgetNeedsLocations = createSelector(
 export const filterWidgets = createSelector(
   [checkWidgetNeedsLocations, getIndicatorWhitelist],
   (widgets, whitelist) => {
-    const witelistKeys = !isEmpty(whitelist) ? Object.keys(whitelist) : null;
+    const whitelistKeys = !isEmpty(whitelist) ? Object.keys(whitelist) : null;
+
     return widgets.filter(widget => {
       // filter by showIndicators
       let showByIndicators = true;
-      if (
-        widget.config.showIndicators &&
-        widget.config.indicators &&
-        whitelist
-      ) {
+      if (widget.config.showIndicators && whitelist) {
         const totalIndicators = concat(
           widget.config.showIndicators,
-          witelistKeys
+          whitelistKeys
         ).length;
         const reducedIndicators = uniq(
-          concat(widget.config.showIndicators, witelistKeys)
+          concat(widget.config.showIndicators, whitelistKeys)
         ).length;
         showByIndicators = totalIndicators !== reducedIndicators;
       }

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss-plantations/widget-tree-loss-plantations-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss-plantations/widget-tree-loss-plantations-selectors.js
@@ -2,6 +2,7 @@ import { createSelector } from 'reselect';
 import sumBy from 'lodash/sumBy';
 import groupBy from 'lodash/groupBy';
 import { format } from 'd3-format';
+import { biomassToCO2 } from 'utils/calculations';
 
 // get list data
 const getLoss = state => state.loss || null;
@@ -41,7 +42,7 @@ export const getSentence = createSelector(
     const locationLabel = locationNames.current && locationNames.current.label;
     const totalLoss = sumBy(data, 'areaLoss') || 0;
     const totalOutsideLoss = sumBy(data, 'outsideAreaLoss') || 0;
-    const totalEmissions = sumBy(data, 'emissions') || 0;
+    const totalEmissions = biomassToCO2(sumBy(data, 'emissions')) || 0;
     const lossPhrase = totalLoss > totalOutsideLoss ? 'inside' : 'outside';
 
     return `The majority of tree cover loss from <span>${startYear}</span> to <span>${endYear}</span> in <b>${locationLabel}</b> occured <b>${lossPhrase}</b> of plantations, considering tree cover with canopy density greater than <b>${threshold}%</b>.

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-selectors.js
@@ -2,6 +2,7 @@ import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import { format } from 'd3-format';
+import { biomassToCO2 } from 'utils/calculations';
 
 // get list data
 const getLoss = state => state.loss || null;
@@ -41,7 +42,7 @@ export const getSentence = createSelector(
     }`;
     const totalLoss = (data && data.length && sumBy(data, 'area')) || 0;
     const totalEmissions =
-      (data && data.length && sumBy(data, 'emissions')) || 0;
+      (data && data.length && biomassToCO2(sumBy(data, 'emissions'))) || 0;
     const percentageLoss =
       (totalLoss && extent && totalLoss / extent * 100) || 0;
 
@@ -51,8 +52,9 @@ export const getSentence = createSelector(
       totalLoss > 0
         ? ` This loss is equal to <b>${format('.1f')(percentageLoss)}
       %</b> of the regions tree cover extent in <b>${extentYear}</b>, 
-      and equivalent to <b>${format('.3s')(totalEmissions)}
-      tonnes</b> of CO\u2082 emissions`
+      and equivalent to <b>${format('.3s')(
+    totalEmissions
+  )}tonnes</b> of CO\u2082 emissions`
         : ''
     }
      with canopy density <span>> ${threshold}%</span>.`;

--- a/app/javascript/utils/calculations.js
+++ b/app/javascript/utils/calculations.js
@@ -1,0 +1,4 @@
+export const tonsToTonnes = value => value * 0.907185;
+
+export const biomassToCO2 = value =>
+  tonsToTonnes((value + 0.489 * value ** 0.89) * 0.47);


### PR DESCRIPTION
## Overview

Simple update to add a conversion helper for those pesky `tons` which should be `tonnes`. We had the issue that we are receiving biomass carbon above ground (in tons) and we want CO2 mass in tonnes (metric). Now we do.

BONUS: fix whitelists of plantations widgets when no data at regional level.

