### PR TITLE
Feature/color management

### DIFF
--- a/app/javascript/pages/country/data/colors.json
+++ b/app/javascript/pages/country/data/colors.json
@@ -13,28 +13,28 @@
   },
   "gain": {
     "darkBlue": "#6D6DE5",
-    "lightBlue": "#6D6DE5"
+    "lightBlue": "#90B1F1"
   },
   "plantations": {
     "species": {
-      "Oil palm": "#f44c43",
-      "Wood fiber / timber": "#0F3B82",
-      "Rubber": "#11002F",
-      "Fruit": "#b2b300",
-      "Others": "#9ECC49",
-      "Wood fiber / timber mix": "#246ee6",
-      "Oil palm mix": "#f7837d",
-      "Rubber mix": "#0FF",
-      "Fruit mix": "#FF0",
-      "Other mix": "#c1df8b",
-      "Unknown": "#b5b0b0",
-      "Recently cleared": "#A53ED5"
+      "Oil palm": "#F9A19D",
+      "Wood fiber / timber": "#889ABB",
+      "Rubber": "#898094",
+      "Fruit": "#D4D580",
+      "Others": "#CAE2A0",
+      "Wood fiber / timber mix": "#90B1F1",
+      "Oil palm mix": "#FBBBB9",
+      "Rubber mix": "#80FFFF",
+      "Fruit mix": "#FFFF83",
+      "Other mix": "#DCEDC0",
+      "Unknown": "#D6D3D3",
+      "Recently cleared": "#99D7FF"
     },
     "types": {
-      "Large industrial plantation": "#F84F40",
-      "Mosaic of medium-sized plantations": "#A53ED5",
-      "Mosaic of small-sized plantations": "#33A02C",
-      "Clearing/ very young plantation": "#a7652a"
+      "Large industrial plantation": "#FBA29C",
+      "Mosaic of medium-sized plantations": "#99D7FF",
+      "Mosaic of small-sized plantations": "#CAE2A0",
+      "Clearing/ very young plantation": "#898094"
     }
   }
 }

--- a/app/javascript/pages/country/data/colors.json
+++ b/app/javascript/pages/country/data/colors.json
@@ -20,7 +20,7 @@
       "Wood fiber / timber": "#98a7c4",
       "Rubber": "#9993a3",
       "Fruit": "#dada95",
-      "Others": "#d1e6ab",
+      "Other": "#d1e6ab",
       "Wood fiber / timber mix": "#9ebbf2",
       "Oil palm mix": "#fcc4c1",
       "Rubber mix": "#a4fdff",

--- a/app/javascript/pages/country/data/colors.json
+++ b/app/javascript/pages/country/data/colors.json
@@ -1,40 +1,39 @@
 {
-  "global": {
-    "nonForest": "#E2CF96",
-    "grey": "#d9d9dc"
-  },
   "extent": {
-    "darkGreen": "#1e5a00",
-    "lightGreen": "#959a00"
+    "green": "#a0c746",
+    "ramp": ["#364a08", "#506917", "#6b8729", "#84a637", "#a0c746", "#bcdb72", "#d4ed9a", "#e3f7b2", "#effcd2"],
+    "nonForest": "#e7e5a4"
   },
   "loss": {
-    "darkPink": "#fe6598",
-    "lightPink": "#FFC2E4"
+    "pink": "#fe6598",
+    "ramp": ["#510626", "#7a1e41", "#a4355c", "#d04d7a", "#fe6598", "#ff84ac", "#ffa0c0", "#ffbad4", "#ffd4e9"],
+    "noLoss": "#e7e5a4"
   },
   "gain": {
-    "darkBlue": "#6D6DE5",
-    "lightBlue": "#90B1F1"
+    "blue": "#6d6de5",
+    "ramp": ["#070752", "#231f74", "#3c3898", "#5452be", "#6d6de5", "#8a86ec", "#a49ff3", "#bdb9f9", "#d4d4ff"],
+    "noGain": "#e7e5a4"
   },
   "plantations": {
     "species": {
-      "Oil palm": "#F9A19D",
-      "Wood fiber / timber": "#889ABB",
-      "Rubber": "#898094",
-      "Fruit": "#D4D580",
-      "Others": "#CAE2A0",
-      "Wood fiber / timber mix": "#90B1F1",
-      "Oil palm mix": "#FBBBB9",
-      "Rubber mix": "#80FFFF",
-      "Fruit mix": "#FFFF83",
-      "Other mix": "#DCEDC0",
-      "Unknown": "#D6D3D3",
-      "Recently cleared": "#99D7FF"
+      "Oil palm": "#fdada9",
+      "Wood fiber / timber": "#98a7c4",
+      "Rubber": "#9993a3",
+      "Fruit": "#dada95",
+      "Others": "#d1e6ab",
+      "Wood fiber / timber mix": "#9ebbf2",
+      "Oil palm mix": "#fcc4c1",
+      "Rubber mix": "#a4fdff",
+      "Fruit mix": "#fefe97",
+      "Other mix": "#e1efc8",
+      "Unknown": "#dcd9d9",
+      "Recently cleared": "#d5a6ea"
     },
     "types": {
-      "Large industrial plantation": "#FBA29C",
-      "Mosaic of medium-sized plantations": "#99D7FF",
-      "Mosaic of small-sized plantations": "#CAE2A0",
-      "Clearing/ very young plantation": "#898094"
+      "Large industrial plantation": "#fdada9",
+      "Mosaic of medium-sized plantations": "#d5a6ea",
+      "Mosaic of small-sized plantations": "#a6d19f",
+      "Clearing/ very young plantation": "#d5b7a0"
     }
   }
 }

--- a/app/javascript/pages/country/data/colors.json
+++ b/app/javascript/pages/country/data/colors.json
@@ -1,7 +1,40 @@
 {
-  "darkGreen": "#1e5a00",
-  "mediumGreen": "#2d8700",
-  "lightGreen": "#959a00",
-  "nonForest": "#E2CF96",
-  "grey": "#d9d9dc"
+  "global": {
+    "nonForest": "#E2CF96",
+    "grey": "#d9d9dc"
+  },
+  "extent": {
+    "darkGreen": "#1e5a00",
+    "lightGreen": "#959a00"
+  },
+  "loss": {
+    "darkPink": "#fe6598",
+    "lightPink": "#FFC2E4"
+  },
+  "gain": {
+    "darkBlue": "#6D6DE5",
+    "lightBlue": "#6D6DE5"
+  },
+  "plantations": {
+    "species": {
+      "Oil palm": "#f44c43",
+      "Wood fiber / timber": "#0F3B82",
+      "Rubber": "#11002F",
+      "Fruit": "#b2b300",
+      "Others": "#9ECC49",
+      "Wood fiber / timber mix": "#246ee6",
+      "Oil palm mix": "#f7837d",
+      "Rubber mix": "#0FF",
+      "Fruit mix": "#FF0",
+      "Other mix": "#c1df8b",
+      "Unknown": "#b5b0b0",
+      "Recently cleared": "#A53ED5"
+    },
+    "types": {
+      "Large industrial plantation": "#F84F40",
+      "Mosaic of medium-sized plantations": "#A53ED5",
+      "Mosaic of small-sized plantations": "#33A02C",
+      "Clearing/ very young plantation": "#a7652a"
+    }
+  }
 }

--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -211,6 +211,9 @@
       "type": "fao",
       "metaKey": "widget_forest_cover_fao"
     },
+    "settings": {
+      "unit": "ha"
+    },
     "active": true
   }
 }

--- a/app/javascript/pages/country/widget/components/widget-bar-chart/widget-bar-chart-component.js
+++ b/app/javascript/pages/country/widget/components/widget-bar-chart/widget-bar-chart-component.js
@@ -18,8 +18,8 @@ import './widget-bar-chart-styles.scss';
 
 class WidgetBarChart extends PureComponent {
   render() {
-    const { data, xKey, yKeys, className } = this.props;
-    const { tooltip, colors, unit } = this.props.config;
+    const { data, className } = this.props;
+    const { tooltip, colors, unit, xKey, yKeys } = this.props.config;
     const dataMax = maxBy(data, yKeys[yKeys.length - 1])[
       yKeys[yKeys.length - 1]
     ];

--- a/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-component.jsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { format } from 'd3-format';
-import { getColorPalette } from 'utils/data';
 import Link from 'redux-first-router-link';
 
 import WidgetPaginate from 'pages/country/widget/components/widget-paginate';
@@ -15,14 +14,12 @@ class WidgetNumberedList extends PureComponent {
       data,
       settings,
       handlePageChange,
-      colorRange,
       linksDisabled
     } = this.props;
     const { page, pageSize, unit } = settings;
     const pageData = pageSize
       ? data.slice(page * pageSize, (page + 1) * pageSize)
       : data;
-    const COLORS = getColorPalette(colorRange, pageSize || pageData.length);
 
     return (
       <div className={`c-widget-numbered-list ${className}`}>
@@ -37,7 +34,7 @@ class WidgetNumberedList extends PureComponent {
                   <div className="item-label">
                     <div
                       className="item-bubble"
-                      style={{ backgroundColor: COLORS[index] }}
+                      style={{ backgroundColor: item.color }}
                     >
                       {item.rank || index + 1 + pageSize * page}
                     </div>

--- a/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-numbered-list/widget-numbered-list-component.jsx
@@ -65,7 +65,6 @@ WidgetNumberedList.propTypes = {
   data: PropTypes.array.isRequired,
   settings: PropTypes.object.isRequired,
   handlePageChange: PropTypes.func,
-  colorRange: PropTypes.array.isRequired,
   className: PropTypes.string,
   linksDisabled: PropTypes.bool
 };

--- a/app/javascript/pages/country/widget/components/widget-pie-chart-legend/widget-pie-chart-legend-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-pie-chart-legend/widget-pie-chart-legend-component.jsx
@@ -7,25 +7,34 @@ import './widget-pie-chart-legend-styles.scss';
 class WidgetPieChartLegend extends PureComponent {
   render() {
     const { data, config, className } = this.props;
+    let sizeClass = '';
+    if (data.length > 5) {
+      sizeClass = 'x-small';
+    } else if (data.length > 3) {
+      sizeClass = 'small';
+    }
 
     return (
-      <ul
-        className={`c-pie-chart-legend ${className} ${
-          data.length > 4 ? 'small' : ''
-        }`}
-      >
-        {data.map((item, index) => (
-          <li key={index.toString()}>
-            <div className="legend-title">
-              <span style={{ backgroundColor: item.color }}>{}</span>
-              <p>{item.label}</p>
-            </div>
-            <div className="legend-value" style={{ color: item.color }}>
-              {format(config.format)(item[config.key])}
-              {config.unit}
-            </div>
-          </li>
-        ))}
+      <ul className={`c-pie-chart-legend ${className} ${sizeClass}`}>
+        {data.map((item, index) => {
+          const value = `${format(config.format)(item[config.key])}${
+            config.unit
+          }`;
+          return (
+            <li className="legend-item" key={index.toString()}>
+              <div className="legend-title">
+                <span style={{ backgroundColor: item.color }}>{}</span>
+                <p>
+                  {item.label}
+                  {data.length > 5 && ` - ${value}`}
+                </p>
+              </div>
+              <div className="legend-value" style={{ color: item.color }}>
+                {value}
+              </div>
+            </li>
+          );
+        })}
       </ul>
     );
   }

--- a/app/javascript/pages/country/widget/components/widget-pie-chart-legend/widget-pie-chart-legend-styles.scss
+++ b/app/javascript/pages/country/widget/components/widget-pie-chart-legend/widget-pie-chart-legend-styles.scss
@@ -45,4 +45,18 @@
       margin-bottom: rem(10px);
     }
   }
+
+  &.x-small {
+    .legend-item {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-start;
+      align-items: flex-start;
+      margin-bottom: rem(5px);
+    }
+
+    .legend-value {
+      display: none;
+    }
+  }
 }

--- a/app/javascript/pages/country/widget/components/widget-settings/widget-settings-component.jsx
+++ b/app/javascript/pages/country/widget/components/widget-settings/widget-settings-component.jsx
@@ -63,7 +63,7 @@ class WidgetSettings extends PureComponent {
         {types && (
           <Dropdown
             theme="theme-select-light"
-            label="PLANTATION TYPES"
+            label="DISPLAY TREES BY"
             value={settings.type}
             options={types}
             disabled={loading}

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-component.js
@@ -20,10 +20,10 @@ class WidgetFAOCover extends PureComponent {
               <WidgetPieChartLegend
                 className="pie-chart-legend"
                 data={data}
-                settings={{
-                  unit: '%',
-                  format: '.1f',
-                  key: 'percentage'
+                config={{
+                  unit: 'ha',
+                  format: '.3s',
+                  key: 'value'
                 }}
               />
               <WidgetPieChart

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-selectors.js
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import { format } from 'd3-format';
+import { getColorPalette } from 'utils/data';
 
 // get list data
 const getData = state => state.data || null;
@@ -19,7 +20,10 @@ export const getFAOCoverData = createSelector(
       forest_primary,
       forest_regenerated
     } = data;
-
+    const colorRange = getColorPalette(
+      [colors.darkGreen, colors.lightGreen],
+      3
+    );
     const naturallyRegenerated = extent / 100 * forest_regenerated;
     const primaryForest = extent / 100 * forest_primary;
     const plantedForest = extent / 100 * forest_planted;
@@ -32,19 +36,19 @@ export const getFAOCoverData = createSelector(
         label: 'Naturally regenerated Forest',
         value: naturallyRegenerated,
         percentage: naturallyRegenerated / total * 100,
-        color: colors.darkGreen
+        color: colorRange[0]
       },
       {
         label: 'Primary Forest',
         value: primaryForest,
         percentage: primaryForest / total * 100,
-        color: colors.mediumGreen
+        color: colorRange[1]
       },
       {
         label: 'Planted Forest',
         value: plantedForest,
         percentage: plantedForest / total * 100,
-        color: colors.lightGreen
+        color: colorRange[2]
       },
       {
         label: 'Non-Forest',

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-selectors.js
@@ -1,16 +1,16 @@
 import { createSelector } from 'reselect';
-import COLORS from 'pages/country/data/colors.json';
 import isEmpty from 'lodash/isEmpty';
 import { format } from 'd3-format';
 
 // get list data
 const getData = state => state.data || null;
 const getLocationNames = state => state.locationNames || null;
+const getColors = state => state.colors || null;
 
 // get lists selected
 export const getFAOCoverData = createSelector(
-  [getData, getLocationNames],
-  (data, locationNames) => {
+  [getData, getLocationNames, getColors],
+  (data, locationNames, colors) => {
     if (isEmpty(data) || !locationNames) return null;
     const {
       area_ha,
@@ -32,25 +32,25 @@ export const getFAOCoverData = createSelector(
         label: 'Naturally regenerated Forest',
         value: naturallyRegenerated,
         percentage: naturallyRegenerated / total * 100,
-        color: COLORS.darkGreen
+        color: colors.darkGreen
       },
       {
         label: 'Primary Forest',
         value: primaryForest,
         percentage: primaryForest / total * 100,
-        color: COLORS.mediumGreen
+        color: colors.mediumGreen
       },
       {
         label: 'Planted Forest',
         value: plantedForest,
         percentage: plantedForest / total * 100,
-        color: COLORS.lightGreen
+        color: colors.lightGreen
       },
       {
         label: 'Non-Forest',
         value: nonForest,
         percentage: nonForest / total * 100,
-        color: COLORS.nonForest
+        color: colors.nonForest
       }
     ];
   }

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-selectors.js
@@ -20,10 +20,7 @@ export const getFAOCoverData = createSelector(
       forest_primary,
       forest_regenerated
     } = data;
-    const colorRange = getColorPalette(
-      [colors.darkGreen, colors.lightGreen],
-      3
-    );
+    const colorRange = getColorPalette(colors.ramp, 3);
     const naturallyRegenerated = extent / 100 * forest_regenerated;
     const primaryForest = extent / 100 * forest_primary;
     const plantedForest = extent / 100 * forest_planted;

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover.js
@@ -15,7 +15,7 @@ const mapStateToProps = ({ widgetFAOCover }, ownProps) => {
   const selectorData = {
     data,
     locationNames,
-    colors: { ...COLORS.extent, ...COLORS.global }
+    colors: COLORS.extent
   };
   return {
     data: getFAOCoverData(selectorData),

--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover.js
@@ -2,6 +2,7 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import COLORS from 'pages/country/data/colors.json';
 
 import actions from './widget-fao-cover-actions';
 import reducers, { initialState } from './widget-fao-cover-reducers';
@@ -13,7 +14,8 @@ const mapStateToProps = ({ widgetFAOCover }, ownProps) => {
   const { locationNames } = ownProps;
   const selectorData = {
     data,
-    locationNames
+    locationNames,
+    colors: { ...COLORS.extent, ...COLORS.global }
   };
   return {
     data: getFAOCoverData(selectorData),

--- a/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-component.js
@@ -8,7 +8,7 @@ import './widget-fao-reforestation-styles.scss';
 
 class WidgetFAOReforestation extends PureComponent {
   render() {
-    const { sentence, data, settings, colors, embed } = this.props;
+    const { sentence, data, settings, embed } = this.props;
 
     return (
       <div className="c-widget-fao-reforestation">
@@ -19,7 +19,6 @@ class WidgetFAOReforestation extends PureComponent {
               className="locations-list"
               data={data}
               settings={settings}
-              colorRange={[colors.darkGreen, colors.nonForest]}
               linksDisabled={embed}
             />
           )}
@@ -32,7 +31,6 @@ WidgetFAOReforestation.propTypes = {
   sentence: PropTypes.string,
   data: PropTypes.array,
   settings: PropTypes.object,
-  colors: PropTypes.object.isRequired,
   embed: PropTypes.bool
 };
 

--- a/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import uniqBy from 'lodash/uniqBy';
 import findIndex from 'lodash/findIndex';
-import { sortByKey, getColorPalette } from 'utils/data';
+import { sortByKey } from 'utils/data';
 import { format } from 'd3-format';
 import { getActiveFilter } from 'pages/country/widget/widget-selectors';
 import { ordinalSuffixOf } from 'utils/calculations';
@@ -36,14 +36,10 @@ export const getFilteredData = createSelector(
       trimEnd = data.length;
     }
     const dataTrimmed = data.slice(trimStart, trimEnd);
-    const colorRange = getColorPalette(
-      [colors.darkBlue, colors.lightBlue],
-      dataTrimmed.length
-    );
-    return dataTrimmed.map((d, index) => ({
+    return dataTrimmed.map(d => ({
       ...d,
       label: d.name,
-      color: colorRange[index],
+      color: colors.blue,
       path: `/country/${d.iso}`,
       value: d.rate * 1000
     }));

--- a/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation-selectors.js
@@ -37,7 +37,7 @@ export const getFilteredData = createSelector(
     }
     const dataTrimmed = data.slice(trimStart, trimEnd);
     const colorRange = getColorPalette(
-      [colors.darkGreen, colors.lightGreen],
+      [colors.darkBlue, colors.lightBlue],
       dataTrimmed.length
     );
     return dataTrimmed.map((d, index) => ({

--- a/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation.js
@@ -17,7 +17,7 @@ const mapStateToProps = ({ widgetFAOReforestation, location }, ownProps) => {
   const selectorData = {
     data: data.countries,
     location: location.payload,
-    colors: { ...COLORS.gain, ...COLORS.global },
+    colors: COLORS.gain,
     settings,
     options: ownProps.settingsConfig.options
   };

--- a/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-reforestation/widget-fao-reforestation.js
@@ -17,7 +17,7 @@ const mapStateToProps = ({ widgetFAOReforestation, location }, ownProps) => {
   const selectorData = {
     data: data.countries,
     location: location.payload,
-    colors: COLORS,
+    colors: { ...COLORS.gain, ...COLORS.global },
     settings,
     options: ownProps.settingsConfig.options
   };
@@ -25,7 +25,7 @@ const mapStateToProps = ({ widgetFAOReforestation, location }, ownProps) => {
     loading: loading || ownProps.isMetaLoading,
     data: getFilteredData(selectorData),
     sentence: getSentence(selectorData),
-    colors: COLORS
+    colors: { ...COLORS.gain, ...COLORS.global }
   };
 };
 

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
@@ -17,10 +17,7 @@ export const getIntactTreeCoverData = createSelector(
     if (isEmpty(data) || isEmpty(whitelist)) return null;
     const { totalArea, totalExtent, extent, plantations } = data;
     const hasPlantations = Object.keys(whitelist).indexOf('plantations') > -1;
-    const colorRange = getColorPalette(
-      [colors.darkGreen, colors.lightGreen],
-      hasPlantations ? 3 : 2
-    );
+    const colorRange = getColorPalette(colors.ramp, hasPlantations ? 3 : 2);
     const parsedData = [
       {
         label: 'Intact Forest',
@@ -31,7 +28,7 @@ export const getIntactTreeCoverData = createSelector(
       {
         label: hasPlantations ? 'Degraded Forest' : 'Other Tree Cover',
         value: totalExtent - extent - plantations,
-        color: hasPlantations ? colorRange[2] : colorRange[1],
+        color: colorRange[1],
         percentage: (totalExtent - extent - plantations) / totalArea * 100
       },
       {
@@ -45,7 +42,7 @@ export const getIntactTreeCoverData = createSelector(
       parsedData.splice(2, 0, {
         label: 'Plantations',
         value: plantations,
-        color: colorRange[1],
+        color: colorRange[2],
         percentage: plantations / totalArea * 100
       });
     }

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
@@ -17,19 +17,21 @@ export const getIntactTreeCoverData = createSelector(
     if (isEmpty(data) || isEmpty(whitelist)) return null;
     const { totalArea, totalExtent, extent, plantations } = data;
     const hasPlantations = Object.keys(whitelist).indexOf('plantations') > -1;
-    const colorRange = getColorPalette([colors.darkGreen, colors.lightGreen], 4);
-
+    const colorRange = getColorPalette(
+      [colors.darkGreen, colors.lightGreen],
+      hasPlantations ? 3 : 2
+    );
     const parsedData = [
       {
         label: 'Intact Forest',
         value: extent,
-        color: colorRange.darkGreen,
+        color: colorRange[0],
         percentage: extent / totalArea * 100
       },
       {
         label: hasPlantations ? 'Degraded Forest' : 'Other Tree Cover',
         value: totalExtent - extent - plantations,
-        color: colorRange.lightGreen,
+        color: hasPlantations ? colorRange[2] : colorRange[1],
         percentage: (totalExtent - extent - plantations) / totalArea * 100
       },
       {
@@ -43,7 +45,7 @@ export const getIntactTreeCoverData = createSelector(
       parsedData.splice(2, 0, {
         label: 'Plantations',
         value: plantations,
-        color: colorRange.mediumGreen,
+        color: colorRange[1],
         percentage: plantations / totalArea * 100
       });
     }

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
@@ -1,38 +1,41 @@
 import { createSelector } from 'reselect';
-import COLORS from 'pages/country/data/colors.json';
 import isEmpty from 'lodash/isEmpty';
+import { getColorPalette } from 'utils/data';
 
 // get list data
 const getData = state => state.data;
 const getSettings = state => state.settings;
 const getLocationNames = state => state.locationNames;
 const getActiveIndicator = state => state.activeIndicator;
+const getColors = state => state.colors;
 const getIndicatorWhitelist = state => state.whitelist;
 
 // get lists selected
 export const getIntactTreeCoverData = createSelector(
-  [getData, getSettings, getIndicatorWhitelist],
-  (data, settings, whitelist) => {
+  [getData, getSettings, getIndicatorWhitelist, getColors],
+  (data, settings, whitelist, colors) => {
     if (isEmpty(data) || isEmpty(whitelist)) return null;
     const { totalArea, totalExtent, extent, plantations } = data;
     const hasPlantations = Object.keys(whitelist).indexOf('plantations') > -1;
+    const colorRange = getColorPalette([colors.darkGreen, colors.lightGreen], 4);
+
     const parsedData = [
       {
         label: 'Intact Forest',
         value: extent,
-        color: COLORS.darkGreen,
+        color: colorRange.darkGreen,
         percentage: extent / totalArea * 100
       },
       {
         label: hasPlantations ? 'Degraded Forest' : 'Other Tree Cover',
         value: totalExtent - extent - plantations,
-        color: COLORS.lightGreen,
+        color: colorRange.lightGreen,
         percentage: (totalExtent - extent - plantations) / totalArea * 100
       },
       {
         label: 'Non-Forest',
         value: totalArea - totalExtent,
-        color: COLORS.nonForest,
+        color: colors.nonForest,
         percentage: (totalArea - totalExtent) / totalArea * 100
       }
     ];
@@ -40,7 +43,7 @@ export const getIntactTreeCoverData = createSelector(
       parsedData.splice(2, 0, {
         label: 'Plantations',
         value: plantations,
-        color: COLORS.mediumGreen,
+        color: colorRange.mediumGreen,
         percentage: plantations / totalArea * 100
       });
     }

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover.js
@@ -2,6 +2,7 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import COLORS from 'pages/country/data/colors.json';
 
 import actions from './widget-intact-tree-cover-actions';
 import reducers, { initialState } from './widget-intact-tree-cover-reducers';
@@ -25,7 +26,8 @@ const mapStateToProps = ({ widgetIntactTreeCover, countryData }, ownProps) => {
     settings,
     whitelist: countryWhitelist,
     locationNames,
-    activeIndicator
+    activeIndicator,
+    colors: { ...COLORS.extent, ...COLORS.global }
   };
 
   return {

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover.js
@@ -27,7 +27,7 @@ const mapStateToProps = ({ widgetIntactTreeCover, countryData }, ownProps) => {
     whitelist: countryWhitelist,
     locationNames,
     activeIndicator,
-    colors: { ...COLORS.extent, ...COLORS.global }
+    colors: COLORS.extent
   };
 
   return {

--- a/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-selectors.js
@@ -17,10 +17,7 @@ export const getPrimaryTreeCoverData = createSelector(
     if (isEmpty(data) || isEmpty(whitelist)) return null;
     const { totalArea, totalExtent, extent, plantations } = data;
     const hasPlantations = Object.keys(whitelist).indexOf('plantations') > -1;
-    const colorRange = getColorPalette(
-      [colors.darkGreen, colors.lightGreen],
-      hasPlantations ? 3 : 2
-    );
+    const colorRange = getColorPalette(colors.ramp, hasPlantations ? 3 : 2);
     const parsedData = [
       {
         label: 'Primary Forest',
@@ -31,7 +28,7 @@ export const getPrimaryTreeCoverData = createSelector(
       {
         label: hasPlantations ? 'Secondary Forest' : 'Other Tree Cover',
         value: totalExtent - extent - plantations,
-        color: hasPlantations ? colorRange[2] : colorRange[1],
+        color: colorRange[1],
         percentage: (totalExtent - extent - plantations) / totalArea * 100
       },
       {
@@ -45,7 +42,7 @@ export const getPrimaryTreeCoverData = createSelector(
       parsedData.splice(2, 0, {
         label: 'Plantations',
         value: plantations,
-        color: colorRange[1],
+        color: colorRange[2],
         percentage: plantations / totalArea * 100
       });
     }

--- a/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-selectors.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
+import { getColorPalette } from 'utils/data';
 
 // get list data
 const getData = state => state.data;
@@ -16,17 +17,21 @@ export const getPrimaryTreeCoverData = createSelector(
     if (isEmpty(data) || isEmpty(whitelist)) return null;
     const { totalArea, totalExtent, extent, plantations } = data;
     const hasPlantations = Object.keys(whitelist).indexOf('plantations') > -1;
+    const colorRange = getColorPalette(
+      [colors.darkGreen, colors.lightGreen],
+      hasPlantations ? 3 : 2
+    );
     const parsedData = [
       {
         label: 'Primary Forest',
         value: extent,
-        color: colors.darkGreen,
+        color: colorRange[0],
         percentage: extent / totalArea * 100
       },
       {
         label: hasPlantations ? 'Secondary Forest' : 'Other Tree Cover',
         value: totalExtent - extent - plantations,
-        color: colors.lightGreen,
+        color: hasPlantations ? colorRange[2] : colorRange[1],
         percentage: (totalExtent - extent - plantations) / totalArea * 100
       },
       {
@@ -40,7 +45,7 @@ export const getPrimaryTreeCoverData = createSelector(
       parsedData.splice(2, 0, {
         label: 'Plantations',
         value: plantations,
-        color: colors.mediumGreen,
+        color: colorRange[1],
         percentage: plantations / totalArea * 100
       });
     }

--- a/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-selectors.js
@@ -1,5 +1,4 @@
 import { createSelector } from 'reselect';
-import COLORS from 'pages/country/data/colors.json';
 import isEmpty from 'lodash/isEmpty';
 
 // get list data
@@ -8,11 +7,12 @@ const getSettings = state => state.settings;
 const getLocationNames = state => state.locationNames;
 const getActiveIndicator = state => state.activeIndicator;
 const getIndicatorWhitelist = state => state.whitelist;
+const getColors = state => state.colors;
 
 // get lists selected
 export const getPrimaryTreeCoverData = createSelector(
-  [getData, getSettings, getIndicatorWhitelist],
-  (data, settings, whitelist) => {
+  [getData, getSettings, getIndicatorWhitelist, getColors],
+  (data, settings, whitelist, colors) => {
     if (isEmpty(data) || isEmpty(whitelist)) return null;
     const { totalArea, totalExtent, extent, plantations } = data;
     const hasPlantations = Object.keys(whitelist).indexOf('plantations') > -1;
@@ -20,19 +20,19 @@ export const getPrimaryTreeCoverData = createSelector(
       {
         label: 'Primary Forest',
         value: extent,
-        color: COLORS.darkGreen,
+        color: colors.darkGreen,
         percentage: extent / totalArea * 100
       },
       {
         label: hasPlantations ? 'Secondary Forest' : 'Other Tree Cover',
         value: totalExtent - extent - plantations,
-        color: COLORS.lightGreen,
+        color: colors.lightGreen,
         percentage: (totalExtent - extent - plantations) / totalArea * 100
       },
       {
         label: 'Non-Forest',
         value: totalArea - totalExtent,
-        color: COLORS.nonForest,
+        color: colors.nonForest,
         percentage: (totalArea - totalExtent) / totalArea * 100
       }
     ];
@@ -40,7 +40,7 @@ export const getPrimaryTreeCoverData = createSelector(
       parsedData.splice(2, 0, {
         label: 'Plantations',
         value: plantations,
-        color: COLORS.mediumGreen,
+        color: colors.mediumGreen,
         percentage: plantations / totalArea * 100
       });
     }

--- a/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover.js
@@ -27,7 +27,7 @@ const mapStateToProps = ({ widgetPrimaryTreeCover, countryData }, ownProps) => {
     whitelist: countryWhitelist,
     locationNames,
     activeIndicator,
-    colors: { ...COLORS.extent, ...COLORS.global }
+    colors: COLORS.extent
   };
 
   return {

--- a/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover.js
@@ -2,6 +2,7 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import COLORS from 'pages/country/data/colors.json';
 
 import actions from './widget-primary-tree-cover-actions';
 import reducers, { initialState } from './widget-primary-tree-cover-reducers';
@@ -25,7 +26,8 @@ const mapStateToProps = ({ widgetPrimaryTreeCover, countryData }, ownProps) => {
     settings,
     whitelist: countryWhitelist,
     locationNames,
-    activeIndicator
+    activeIndicator,
+    colors: { ...COLORS.extent, ...COLORS.global }
   };
 
   return {

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-component.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import WidgetNumberedList from 'pages/country/widget/components/widget-numbered-list';
 import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
-import COLORS from 'pages/country/data/colors.json';
 
 import './widget-relative-tree-cover-styles.scss';
 
@@ -22,7 +21,6 @@ class WidgetRelativeTreeCover extends PureComponent {
                 data={data}
                 settings={settings}
                 handlePageChange={handlePageChange}
-                colorRange={[COLORS.darkGreen, COLORS.nonForest]}
                 linksDisabled={embed}
               />
             </div>

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-selectors.js
@@ -21,9 +21,6 @@ export const getSortedData = createSelector(
   (data, settings, location, meta, colors) => {
     if (!data || isEmpty(data) || !meta || isEmpty(meta)) return null;
     const dataMapped = [];
-    const nonZeroData = remove(data, d => d.extent);
-    console.log(colors);
-    const colorRange = getColorPalette([colors.darkGreen, colors.lightGreen], nonZeroData.length);
     data.forEach(d => {
       const region = meta.find(l => d.id === l.value);
       if (region) {
@@ -38,10 +35,17 @@ export const getSortedData = createSelector(
         });
       }
     });
-    return sortByKey(uniqBy(dataMapped, 'label'), 'value', true).map((d, i) => ({
-      ...d,
-      color: d.value ? colorRange[i] : colors.nonForest
-    }));
+    const nonZeroData = remove([...dataMapped], d => d.extent);
+    const colorRange = getColorPalette(
+      [colors.darkGreen, colors.lightGreen],
+      nonZeroData.length
+    );
+    return sortByKey(uniqBy(dataMapped, 'label'), 'value', true).map(
+      (d, i) => ({
+        ...d,
+        color: d.value ? colorRange[i] : colors.nonForest
+      })
+    );
   }
 );
 

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-selectors.js
@@ -2,7 +2,8 @@ import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import uniqBy from 'lodash/uniqBy';
 import sumBy from 'lodash/sumBy';
-import { sortByKey } from 'utils/data';
+import remove from 'lodash/remove';
+import { sortByKey, getColorPalette } from 'utils/data';
 import { format } from 'd3-format';
 
 // get list data
@@ -13,12 +14,16 @@ const getIndicator = state => state.indicator || null;
 const getLocation = state => state.location || null;
 const getLocationsMeta = state => state.meta || null;
 const getLocationNames = state => state.locationNames || null;
+const getColors = state => state.colors || null;
 
 export const getSortedData = createSelector(
-  [getData, getSettings, getLocation, getLocationsMeta],
-  (data, settings, location, meta) => {
+  [getData, getSettings, getLocation, getLocationsMeta, getColors],
+  (data, settings, location, meta, colors) => {
     if (!data || isEmpty(data) || !meta || isEmpty(meta)) return null;
     const dataMapped = [];
+    const nonZeroData = remove(data, d => d.extent);
+    console.log(colors);
+    const colorRange = getColorPalette([colors.darkGreen, colors.lightGreen], nonZeroData.length);
     data.forEach(d => {
       const region = meta.find(l => d.id === l.value);
       if (region) {
@@ -33,7 +38,10 @@ export const getSortedData = createSelector(
         });
       }
     });
-    return sortByKey(uniqBy(dataMapped, 'label'), 'value', true);
+    return sortByKey(uniqBy(dataMapped, 'label'), 'value', true).map((d, i) => ({
+      ...d,
+      color: d.value ? colorRange[i] : colors.nonForest
+    }));
   }
 );
 

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover-selectors.js
@@ -2,8 +2,7 @@ import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import uniqBy from 'lodash/uniqBy';
 import sumBy from 'lodash/sumBy';
-import remove from 'lodash/remove';
-import { sortByKey, getColorPalette } from 'utils/data';
+import { sortByKey } from 'utils/data';
 import { format } from 'd3-format';
 
 // get list data
@@ -31,21 +30,12 @@ export const getSortedData = createSelector(
           value: settings.unit === 'ha' ? d.extent : d.percentage,
           path: `/country/${location.country}/${
             location.region ? `${location.region}/` : ''
-          }${d.id}`
+          }${d.id}`,
+          color: d.extent ? colors.green : colors.nonForest
         });
       }
     });
-    const nonZeroData = remove([...dataMapped], d => d.extent);
-    const colorRange = getColorPalette(
-      [colors.darkGreen, colors.lightGreen],
-      nonZeroData.length
-    );
-    return sortByKey(uniqBy(dataMapped, 'label'), 'value', true).map(
-      (d, i) => ({
-        ...d,
-        color: d.value ? colorRange[i] : colors.nonForest
-      })
-    );
+    return sortByKey(uniqBy(dataMapped, 'label'), 'value', true);
   }
 );
 

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover.js
@@ -2,6 +2,7 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import COLORS from 'pages/country/data/colors.json';
 
 import actions from './widget-relative-tree-cover-actions';
 import reducers, { initialState } from './widget-relative-tree-cover-reducers';
@@ -26,8 +27,10 @@ const mapStateToProps = (
     meta: countryData[!payload.region ? 'regions' : 'subRegions'],
     location: payload,
     indicator: activeIndicator,
-    locationNames: ownProps.locationNames
+    locationNames: ownProps.locationNames,
+    colors: { ...COLORS.extent, ...COLORS.global }
   };
+  console.log(selectorData);
   return {
     regions: countryData.regions,
     loading: loading || isCountriesLoading || isRegionsLoading,

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover.js
@@ -28,7 +28,7 @@ const mapStateToProps = (
     location: payload,
     indicator: activeIndicator,
     locationNames: ownProps.locationNames,
-    colors: { ...COLORS.extent, ...COLORS.global }
+    colors: COLORS.extent
   };
 
   return {

--- a/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-relative-tree-cover/widget-relative-tree-cover.js
@@ -30,7 +30,7 @@ const mapStateToProps = (
     locationNames: ownProps.locationNames,
     colors: { ...COLORS.extent, ...COLORS.global }
   };
-  console.log(selectorData);
+
   return {
     regions: countryData.regions,
     loading: loading || isCountriesLoading || isRegionsLoading,

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover-plantations/widget-tree-cover-plantations-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover-plantations/widget-tree-cover-plantations-selectors.js
@@ -1,5 +1,4 @@
 import { createSelector } from 'reselect';
-import COLORS from 'pages/country/data/colors.json';
 import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import { getColorPalette, sortByKey } from 'utils/data';
@@ -10,16 +9,17 @@ const getData = state => state.data;
 const getSettings = state => state.settings;
 const getLocationNames = state => state.locationNames;
 const getIndicatorWhitelist = state => state.whitelist;
+const getColors = state => state.colors;
 
 // get lists selected
 export const getTreeCoverPlantationsData = createSelector(
-  [getData, getSettings, getIndicatorWhitelist],
-  (data, settings, whitelist) => {
+  [getData, getSettings, getIndicatorWhitelist, getColors],
+  (data, settings, whitelist, colors) => {
     if (isEmpty(data) || isEmpty(whitelist)) return null;
     const { plantations } = data;
     const totalPlantations = sumBy(plantations, 'plantation_extent');
     const colorRange = getColorPalette(
-      [COLORS.darkGreen, COLORS.nonForest],
+      [colors.darkGreen, colors.lightGreen],
       plantations.length
     );
     return sortByKey(

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover-plantations/widget-tree-cover-plantations-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover-plantations/widget-tree-cover-plantations-selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
-import { getColorPalette, sortByKey } from 'utils/data';
+import { sortByKey } from 'utils/data';
 import { format } from 'd3-format';
 
 // get list data
@@ -18,15 +18,12 @@ export const getTreeCoverPlantationsData = createSelector(
     if (isEmpty(data) || isEmpty(whitelist)) return null;
     const { plantations } = data;
     const totalPlantations = sumBy(plantations, 'plantation_extent');
-    const colorRange = getColorPalette(
-      [colors.darkGreen, colors.lightGreen],
-      plantations.length
-    );
+
     return sortByKey(
-      plantations.map((d, i) => ({
+      plantations.map(d => ({
         label: d[settings.type],
         value: d.plantation_extent,
-        color: colorRange[i],
+        color: colors[d[settings.type]],
         percentage: d.plantation_extent / totalPlantations * 100
       })),
       'value',

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover-plantations/widget-tree-cover-plantations.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover-plantations/widget-tree-cover-plantations.js
@@ -2,6 +2,7 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import COLORS from 'pages/country/data/colors.json';
 
 import actions from './widget-tree-cover-plantations-actions';
 import reducers, {
@@ -30,7 +31,8 @@ const mapStateToProps = (
     settings,
     whitelist: countryWhitelist,
     locationNames,
-    activeIndicator
+    activeIndicator,
+    colors: COLORS.extent
   };
 
   return {

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover-plantations/widget-tree-cover-plantations.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover-plantations/widget-tree-cover-plantations.js
@@ -33,7 +33,6 @@ const mapStateToProps = (
     locationNames,
     activeIndicator,
     colors: {
-      ...COLORS.extent,
       ...COLORS.plantations.types,
       ...COLORS.plantations.species
     }

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover-plantations/widget-tree-cover-plantations.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover-plantations/widget-tree-cover-plantations.js
@@ -32,7 +32,11 @@ const mapStateToProps = (
     whitelist: countryWhitelist,
     locationNames,
     activeIndicator,
-    colors: COLORS.extent
+    colors: {
+      ...COLORS.extent,
+      ...COLORS.plantations.types,
+      ...COLORS.plantations.species
+    }
   };
 
   return {

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-selectors.js
@@ -1,5 +1,4 @@
 import { createSelector } from 'reselect';
-import COLORS from 'pages/country/data/colors.json';
 import isEmpty from 'lodash/isEmpty';
 
 // get list data
@@ -8,11 +7,12 @@ const getSettings = state => state.settings;
 const getLocationNames = state => state.locationNames;
 const getActiveIndicator = state => state.activeIndicator;
 const getIndicatorWhitelist = state => state.whitelist;
+const getColors = state => state.colors;
 
 // get lists selected
 export const getTreeCoverData = createSelector(
-  [getData, getSettings, getIndicatorWhitelist],
-  (data, settings, whitelist) => {
+  [getData, getSettings, getIndicatorWhitelist, getColors],
+  (data, settings, whitelist, colors) => {
     if (isEmpty(data) || isEmpty(whitelist)) return null;
     const { totalArea, cover, plantations } = data;
     const { indicator } = settings;
@@ -24,13 +24,13 @@ export const getTreeCoverData = createSelector(
             ? 'Natural Forest'
             : 'Tree cover',
         value: cover - plantations,
-        color: COLORS.darkGreen,
+        color: colors.darkGreen,
         percentage: (cover - plantations) / totalArea * 100
       },
       {
         label: 'Non-Forest',
         value: totalArea - cover,
-        color: COLORS.nonForest,
+        color: colors.nonForest,
         percentage: (totalArea - cover) / totalArea * 100
       }
     ];
@@ -38,7 +38,7 @@ export const getTreeCoverData = createSelector(
       parsedData.splice(1, 0, {
         label: 'Tree plantations',
         value: plantations,
-        color: COLORS.mediumGreen,
+        color: colors.lightGreen,
         percentage: plantations / totalArea * 100
       });
     }

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover-selectors.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
+import { getColorPalette } from 'utils/data';
 
 // get list data
 const getData = state => state.data;
@@ -17,6 +18,7 @@ export const getTreeCoverData = createSelector(
     const { totalArea, cover, plantations } = data;
     const { indicator } = settings;
     const hasPlantations = Object.keys(whitelist).indexOf('plantations') > -1;
+    const colorRange = getColorPalette(colors.ramp, hasPlantations ? 2 : 1);
     const parsedData = [
       {
         label:
@@ -24,7 +26,7 @@ export const getTreeCoverData = createSelector(
             ? 'Natural Forest'
             : 'Tree cover',
         value: cover - plantations,
-        color: colors.darkGreen,
+        color: colorRange[0],
         percentage: (cover - plantations) / totalArea * 100
       },
       {
@@ -38,7 +40,7 @@ export const getTreeCoverData = createSelector(
       parsedData.splice(1, 0, {
         label: 'Tree plantations',
         value: plantations,
-        color: colors.lightGreen,
+        color: colorRange[1],
         percentage: plantations / totalArea * 100
       });
     }

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover.js
@@ -24,7 +24,7 @@ const mapStateToProps = ({ widgetTreeCover, countryData }, ownProps) => {
     whitelist: countryWhitelist,
     locationNames,
     activeIndicator,
-    colors: { ...COLORS.extent, ...COLORS.global }
+    colors: COLORS.extent
   };
 
   return {

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover.js
@@ -2,6 +2,7 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import COLORS from 'pages/country/data/colors.json';
 
 import actions from './widget-tree-cover-actions';
 import reducers, { initialState } from './widget-tree-cover-reducers';
@@ -22,7 +23,8 @@ const mapStateToProps = ({ widgetTreeCover, countryData }, ownProps) => {
     settings,
     whitelist: countryWhitelist,
     locationNames,
-    activeIndicator
+    activeIndicator,
+    colors: { ...COLORS.extent, ...COLORS.global }
   };
 
   return {

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-component.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
 import WidgetNumberedList from 'pages/country/widget/components/widget-numbered-list';
-import COLORS from 'pages/country/data/colors.json';
 
 import './widget-tree-gain-styles.scss';
 
@@ -20,7 +19,6 @@ class WidgetTreeCoverGain extends PureComponent {
               className="ranking-list"
               data={data}
               settings={settings}
-              colorRange={[COLORS.darkGreen, COLORS.nonForest]}
               handlePageChange={() => {}}
             />
           </div>

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import uniqBy from 'lodash/uniqBy';
 import findIndex from 'lodash/findIndex';
-import { sortByKey, getColorPalette } from 'utils/data';
+import { sortByKey } from 'utils/data';
 import { format } from 'd3-format';
 import { ordinalSuffixOf } from 'utils/calculations';
 
@@ -55,11 +55,7 @@ export const getFilteredData = createSelector(
       trimEnd = data.length;
     }
     const dataTrimmed = data.slice(trimStart, trimEnd);
-    const colorRange = getColorPalette(
-      [colors.darkBlue, colors.lightBlue],
-      dataTrimmed.length
-    );
-    return dataTrimmed.map((d, index) => {
+    return dataTrimmed.map(d => {
       const locationData = meta.find(l => d.id === l.value);
       let path = '/country/';
       if (location.subRegion) {
@@ -73,7 +69,7 @@ export const getFilteredData = createSelector(
       return {
         ...d,
         label: (locationData && locationData.label) || '',
-        color: colorRange[index],
+        color: colors.blue,
         path,
         value: settings.unit === 'ha' ? d.gain : d.percentage
       };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain-selectors.js
@@ -56,7 +56,7 @@ export const getFilteredData = createSelector(
     }
     const dataTrimmed = data.slice(trimStart, trimEnd);
     const colorRange = getColorPalette(
-      [colors.darkGreen, colors.lightGreen],
+      [colors.darkBlue, colors.lightBlue],
       dataTrimmed.length
     );
     return dataTrimmed.map((d, index) => {

--- a/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-gain/widget-tree-gain.js
@@ -27,7 +27,7 @@ const mapStateToProps = (
     settings,
     location: location.payload,
     meta,
-    colors: COLORS,
+    colors: COLORS.gain,
     indicator: activeIndicator,
     locationNames
   };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-component.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import WidgetPieChart from 'pages/country/widget/components/widget-pie-chart';
 import WidgetNumberedList from 'pages/country/widget/components/widget-numbered-list';
 import WidgetDynamicSentence from 'pages/country/widget/components/widget-dynamic-sentence';
-import COLORS from 'pages/country/data/colors.json';
 
 import './widget-tree-located-styles.scss';
 
@@ -36,7 +35,6 @@ class WidgetTreeLocated extends PureComponent {
                 data={data}
                 settings={settings}
                 handlePageChange={handlePageChange}
-                colorRange={[COLORS.darkGreen, COLORS.nonForest]}
                 linksDisabled={embed}
               />
             </div>

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-selectors.js
@@ -38,7 +38,7 @@ export const getSortedData = createSelector(
     });
     const sortedData = sortByKey(uniqBy(dataMapped, 'label'), 'value', true);
     const colorRange = getColorPalette(
-      [colors.darkGreen, colors.lightGreen],
+      colors.ramp,
       sortedData.length < 10 ? sortedData.length : 10
     );
     return sortedData.map((o, i) => ({

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located-selectors.js
@@ -16,8 +16,8 @@ const getLocationNames = state => state.locationNames || null;
 const getColors = state => state.colors || null;
 
 export const getSortedData = createSelector(
-  [getData, getSettings, getLocation, getLocationsMeta],
-  (data, settings, location, meta) => {
+  [getData, getSettings, getLocation, getLocationsMeta, getColors],
+  (data, settings, location, meta, colors) => {
     if (!data || isEmpty(data) || !meta || isEmpty(meta)) return null;
     const dataMapped = [];
     const totalExtent = sumBy(data, 'extent');
@@ -36,37 +36,34 @@ export const getSortedData = createSelector(
         });
       }
     });
-    return sortByKey(uniqBy(dataMapped, 'label'), 'value', true);
-  }
-);
-
-export const getChartData = createSelector(
-  [getSortedData, getColors],
-  (data, colors) => {
-    if (!data || !data.length) return null;
-    const topRegions = data.length > 10 ? data.slice(0, 10) : data;
-    const totalExtent = sumBy(data, 'extent');
-    const otherRegions = data.length > 10 ? data.slice(10) : [];
-    const othersExtent = otherRegions.length && sumBy(otherRegions, 'extent');
+    const sortedData = sortByKey(uniqBy(dataMapped, 'label'), 'value', true);
     const colorRange = getColorPalette(
-      [colors.darkGreen, colors.nonForest],
-      data.length > 10 ? topRegions.length + 1 : data.length
+      [colors.darkGreen, colors.lightGreen],
+      sortedData.length < 10 ? sortedData.length : 10
     );
-    const topChartData = topRegions.map((d, index) => ({
-      ...d,
-      color: colorRange[index]
+    return sortedData.map((o, i) => ({
+      ...o,
+      color: o.extent ? colorRange[i] || colorRange[9] : colors.nonForest
     }));
-    const otherRegionsData = otherRegions.length
-      ? {
-        label: 'Other regions',
-        percentage: othersExtent ? othersExtent / totalExtent * 100 : 0,
-        color: colorRange[topRegions.length]
-      }
-      : {};
-
-    return [...topChartData, otherRegionsData];
   }
 );
+
+export const getChartData = createSelector([getSortedData], data => {
+  if (!data || !data.length) return null;
+  const topRegions = data.length > 10 ? data.slice(0, 10) : data;
+  const totalExtent = sumBy(data, 'extent');
+  const otherRegions = data.length > 10 ? data.slice(10) : [];
+  const othersExtent = otherRegions.length && sumBy(otherRegions, 'extent');
+  const otherRegionsData = otherRegions.length
+    ? {
+      label: 'Other regions',
+      percentage: othersExtent ? othersExtent / totalExtent * 100 : 0,
+      color: otherRegions[0].color
+    }
+    : {};
+
+  return [...topRegions, otherRegionsData];
+});
 
 export const getSentence = createSelector(
   [

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located.js
@@ -27,7 +27,7 @@ const mapStateToProps = (
     options: settingsConfig.options,
     meta: countryData[!payload.region ? 'regions' : 'subRegions'],
     location: payload,
-    colors: COLORS,
+    colors: { ...COLORS.extent, ...COLORS.global },
     indicator: activeIndicator,
     locationNames: ownProps.locationNames
   };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-located/widget-tree-located.js
@@ -27,7 +27,7 @@ const mapStateToProps = (
     options: settingsConfig.options,
     meta: countryData[!payload.region ? 'regions' : 'subRegions'],
     location: payload,
-    colors: { ...COLORS.extent, ...COLORS.global },
+    colors: COLORS.extent,
     indicator: activeIndicator,
     locationNames: ownProps.locationNames
   };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss-plantations/widget-tree-loss-plantations-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss-plantations/widget-tree-loss-plantations-component.js
@@ -8,37 +8,13 @@ import './widget-tree-loss-plantations-styles.scss';
 
 class WidgetTreeLossPlantations extends PureComponent {
   render() {
-    const { data, sentence } = this.props;
+    const { data, config, sentence } = this.props;
 
     return (
       <div className="c-widget-tree-loss-plantations">
         {sentence && <WidgetDynamicSentence sentence={sentence} />}
         {data && (
-          <WidgetBarChart
-            className="loss-chart"
-            data={data}
-            xKey="year"
-            yKeys={['areaLoss', 'outsideAreaLoss']}
-            config={{
-              colors: {
-                areaLoss: '#fe6598',
-                outsideAreaLoss: '#FFC2E4'
-              },
-              unit: 'ha',
-              tooltip: [
-                {
-                  key: 'outsideAreaLoss',
-                  unit: 'ha',
-                  label: 'outsideLossLabel'
-                },
-                {
-                  key: 'areaLoss',
-                  unit: 'ha',
-                  label: 'lossLabel'
-                }
-              ]
-            }}
-          />
+          <WidgetBarChart className="loss-chart" data={data} config={config} />
         )}
       </div>
     );
@@ -47,6 +23,7 @@ class WidgetTreeLossPlantations extends PureComponent {
 
 WidgetTreeLossPlantations.propTypes = {
   data: PropTypes.array,
+  config: PropTypes.object,
   sentence: PropTypes.string
 };
 

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss-plantations/widget-tree-loss-plantations-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss-plantations/widget-tree-loss-plantations-selectors.js
@@ -3,6 +3,7 @@ import sumBy from 'lodash/sumBy';
 import groupBy from 'lodash/groupBy';
 import { format } from 'd3-format';
 import { biomassToCO2 } from 'utils/calculations';
+import { getColorPalette } from 'utils/data';
 
 // get list data
 const getLoss = state => state.loss || null;
@@ -33,27 +34,30 @@ export const chartData = createSelector(
   }
 );
 
-export const chartConfig = createSelector([getColors], colors => ({
-  xKey: 'year',
-  yKeys: ['areaLoss', 'outsideAreaLoss'],
-  colors: {
-    areaLoss: colors.darkPink,
-    outsideAreaLoss: colors.lightPink
-  },
-  unit: 'ha',
-  tooltip: [
-    {
-      key: 'outsideAreaLoss',
-      unit: 'ha',
-      label: 'outsideLossLabel'
+export const chartConfig = createSelector([getColors], colors => {
+  const colorRange = getColorPalette(colors.ramp, 2);
+  return {
+    xKey: 'year',
+    yKeys: ['areaLoss', 'outsideAreaLoss'],
+    colors: {
+      areaLoss: colorRange[0],
+      outsideAreaLoss: colorRange[1]
     },
-    {
-      key: 'areaLoss',
-      unit: 'ha',
-      label: 'lossLabel'
-    }
-  ]
-}));
+    unit: 'ha',
+    tooltip: [
+      {
+        key: 'outsideAreaLoss',
+        unit: 'ha',
+        label: 'outsideLossLabel'
+      },
+      {
+        key: 'areaLoss',
+        unit: 'ha',
+        label: 'lossLabel'
+      }
+    ]
+  };
+});
 
 export const getSentence = createSelector(
   [chartData, getSettings, getLocationNames],

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss-plantations/widget-tree-loss-plantations-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss-plantations/widget-tree-loss-plantations-selectors.js
@@ -9,9 +9,10 @@ const getLoss = state => state.loss || null;
 const getTotalLoss = state => state.totalLoss || null;
 const getSettings = state => state.settings || null;
 const getLocationNames = state => state.locationNames || null;
+const getColors = state => state.colors || null;
 
 // get lists selected
-export const filterData = createSelector(
+export const chartData = createSelector(
   [getLoss, getTotalLoss, getSettings],
   (loss, totalLoss, settings) => {
     if (!loss || !totalLoss) return null;
@@ -32,8 +33,30 @@ export const filterData = createSelector(
   }
 );
 
+export const chartConfig = createSelector([getColors], colors => ({
+  xKey: 'year',
+  yKeys: ['areaLoss', 'outsideAreaLoss'],
+  colors: {
+    areaLoss: colors.darkPink,
+    outsideAreaLoss: colors.lightPink
+  },
+  unit: 'ha',
+  tooltip: [
+    {
+      key: 'outsideAreaLoss',
+      unit: 'ha',
+      label: 'outsideLossLabel'
+    },
+    {
+      key: 'areaLoss',
+      unit: 'ha',
+      label: 'lossLabel'
+    }
+  ]
+}));
+
 export const getSentence = createSelector(
-  [filterData, getSettings, getLocationNames],
+  [chartData, getSettings, getLocationNames],
   (data, settings, locationNames) => {
     if (!data) return null;
     const { startYear, endYear, threshold } = settings;

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss-plantations/widget-tree-loss-plantations.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss-plantations/widget-tree-loss-plantations.js
@@ -2,13 +2,15 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import COLORS from 'pages/country/data/colors.json';
 
 import actions from './widget-tree-loss-plantations-actions';
 import reducers, {
   initialState
 } from './widget-tree-loss-plantations-reducers';
 import {
-  filterData,
+  chartData,
+  chartConfig,
   getSentence
 } from './widget-tree-loss-plantations-selectors';
 import WidgetTreeLossPlantationsComponent from './widget-tree-loss-plantations-component';
@@ -21,10 +23,12 @@ const mapStateToProps = ({ widgetTreeLossPlantations }, ownProps) => {
     totalLoss: data.totalLoss,
     settings,
     locationNames,
-    activeIndicator
+    activeIndicator,
+    colors: COLORS.loss
   };
   return {
-    data: filterData(selectorData),
+    data: chartData(selectorData),
+    config: chartConfig(selectorData),
     sentence: getSentence(selectorData)
   };
 };

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-component.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-component.js
@@ -8,38 +8,13 @@ import './widget-tree-loss-styles.scss';
 
 class WidgetTreeLoss extends PureComponent {
   render() {
-    const { data, sentence } = this.props;
+    const { data, config, sentence } = this.props;
 
     return (
       <div className="c-widget-tree-loss">
         {sentence && <WidgetDynamicSentence sentence={sentence} />}
         {data && (
-          <WidgetBarChart
-            className="loss-chart"
-            data={data}
-            xKey="year"
-            yKeys={['area']}
-            config={{
-              colors: {
-                area: '#fe6598'
-              },
-              unit: 'ha',
-              tooltip: [
-                {
-                  key: 'year',
-                  unit: null
-                },
-                {
-                  key: 'area',
-                  unit: 'ha'
-                },
-                {
-                  key: 'percentage',
-                  unit: '%'
-                }
-              ]
-            }}
-          />
+          <WidgetBarChart className="loss-chart" data={data} config={config} />
         )}
       </div>
     );
@@ -48,6 +23,7 @@ class WidgetTreeLoss extends PureComponent {
 
 WidgetTreeLoss.propTypes = {
   data: PropTypes.array,
+  config: PropTypes.object,
   sentence: PropTypes.string
 };
 

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-selectors.js
@@ -10,9 +10,10 @@ const getExtent = state => state.extent || null;
 const getSettings = state => state.settings || null;
 const getLocationNames = state => state.locationNames || null;
 const getActiveIndicator = state => state.activeIndicator || null;
+const getColors = state => state.colors || null;
 
 // get lists selected
-export const filterData = createSelector(
+export const chartData = createSelector(
   [getLoss, getExtent, getSettings],
   (data, extent, settings) => {
     if (!data || isEmpty(data)) return null;
@@ -29,8 +30,31 @@ export const filterData = createSelector(
   }
 );
 
+export const chartConfig = createSelector([getColors], colors => ({
+  xKey: 'year',
+  yKeys: ['area'],
+  colors: {
+    area: colors.darkPink
+  },
+  unit: 'ha',
+  tooltip: [
+    {
+      key: 'year',
+      unit: null
+    },
+    {
+      key: 'area',
+      unit: 'ha'
+    },
+    {
+      key: 'percentage',
+      unit: '%'
+    }
+  ]
+}));
+
 export const getSentence = createSelector(
-  [filterData, getExtent, getSettings, getLocationNames, getActiveIndicator],
+  [chartData, getExtent, getSettings, getLocationNames, getActiveIndicator],
   (data, extent, settings, locationNames, indicator) => {
     if (!data) return null;
     const { startYear, endYear, extentYear, threshold } = settings;
@@ -51,7 +75,7 @@ export const getSentence = createSelector(
     )(totalLoss)}ha</b> of tree cover${totalLoss ? '.' : ','} ${
       totalLoss > 0
         ? ` This loss is equal to <b>${format('.1f')(percentageLoss)}
-      %</b> of the regions tree cover extent in <b>${extentYear}</b>, 
+      %</b> of the regions tree cover extent in <b>${extentYear}</b>,
       and equivalent to <b>${format('.3s')(
     totalEmissions
   )}t</b> of CO\u2082 emissions`

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss-selectors.js
@@ -34,7 +34,7 @@ export const chartConfig = createSelector([getColors], colors => ({
   xKey: 'year',
   yKeys: ['area'],
   colors: {
-    area: colors.darkPink
+    area: colors.pink
   },
   unit: 'ha',
   tooltip: [

--- a/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-loss/widget-tree-loss.js
@@ -2,10 +2,15 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import COLORS from 'pages/country/data/colors.json';
 
 import actions from './widget-tree-loss-actions';
 import reducers, { initialState } from './widget-tree-loss-reducers';
-import { filterData, getSentence } from './widget-tree-loss-selectors';
+import {
+  chartData,
+  chartConfig,
+  getSentence
+} from './widget-tree-loss-selectors';
 import WidgetTreeLossComponent from './widget-tree-loss-component';
 
 const mapStateToProps = ({ widgetTreeLoss }, ownProps) => {
@@ -16,10 +21,12 @@ const mapStateToProps = ({ widgetTreeLoss }, ownProps) => {
     extent: data.extent,
     settings,
     locationNames,
-    activeIndicator
+    activeIndicator,
+    colors: COLORS.loss
   };
   return {
-    data: filterData(selectorData),
+    data: chartData(selectorData),
+    config: chartConfig(selectorData),
     sentence: getSentence(selectorData)
   };
 };

--- a/app/javascript/utils/data.js
+++ b/app/javascript/utils/data.js
@@ -18,7 +18,7 @@ export const sortByKey = (array, key, isAsc) =>
   });
 
 export const getColorPalette = (colorRange, quantity) => {
-  const trim = 0.5 / (quantity - 0.75);
+  const trim = 0.5 / (quantity - 0.6);
   return chroma
     .scale(colorRange)
     .padding(trim)

--- a/app/javascript/utils/data.js
+++ b/app/javascript/utils/data.js
@@ -17,5 +17,10 @@ export const sortByKey = (array, key, isAsc) =>
     return 0;
   });
 
-export const getColorPalette = (colorRange, quantity) =>
-  chroma.scale(colorRange).colors(quantity);
+export const getColorPalette = (colorRange, quantity) => {
+  const trim = 0.5 / (quantity - 0.75);
+  return chroma
+    .scale(colorRange)
+    .padding(trim)
+    .colors(quantity);
+};


### PR DESCRIPTION
## Overview

NOTE: extends PR for plantations loss widget due to breaking features that would be created on country-page-rebase: https://github.com/Vizzuality/gfw/pull/3214.

Currently we are not using the correct colors for the widgets, nor are we calculating them correctly for forest, non-forest and plantations. This PR provides a starting point for managing colors within the React app of GFW and provides a flexible method within reselect of assigning them.

- Create color constants file and import into components when needed
- Update selectors to use uniform selector method for caching
- Apply this to the plantations widget
- Apply correct logic to all widget for non-forest or variable extent to keep consistency