### PR TITLE
Allow whitelisting of meta data in modal

### DIFF
--- a/app/javascript/components/modal-meta/modal-meta-actions.js
+++ b/app/javascript/components/modal-meta/modal-meta-actions.js
@@ -8,18 +8,20 @@ const setModalMetaClosing = createAction('setModalMetaClosing');
 
 const setModalMeta = createThunkAction(
   'setModalMeta',
-  params => (dispatch, state) => {
+  (metaKey, metaWhitelist, tableWhitelist) => (dispatch, state) => {
     if (!state().modalMeta.loading) {
       dispatch(
         setModalMetaLoading({ loading: true, error: false, open: true })
       );
-      getMeta(params)
+      getMeta(metaKey)
         .then(response => {
           let data = {};
           if (response && response.data && typeof response.data !== 'string') {
             data = response.data;
           }
-          dispatch(setModalMetaData(data));
+          dispatch(
+            setModalMetaData({ ...data, metaWhitelist, tableWhitelist })
+          );
         })
         .catch(error => {
           console.info(error);

--- a/app/javascript/components/modal-meta/modal-meta-styles.scss
+++ b/app/javascript/components/modal-meta/modal-meta-styles.scss
@@ -13,6 +13,7 @@ $desktop-padding: rem(50px);
 
   @media screen and (min-width: $screen-m) {
     padding: $desktop-padding $desktop-padding;
+    padding-top: rem(40px);
   }
 
   .title {

--- a/app/javascript/components/modal-meta/modal-meta.js
+++ b/app/javascript/components/modal-meta/modal-meta.js
@@ -5,12 +5,28 @@ import actions from './modal-meta-actions';
 import reducers, { initialState } from './modal-meta-reducers';
 import ModalMetaComponent from './modal-meta-component';
 
-const MASTER_TABLE_FIELDS = ['function', 'source'];
+const MASTER_META_FIELDS = ['title', 'subtitle', 'citation', 'overview'];
+const MASTER_TABLE_FIELDS = [
+  'function',
+  'resolution',
+  'geographic_coverage',
+  'source',
+  'frequency_of_updates',
+  'date_of_content',
+  'cautions',
+  'license'
+];
 
 const mapStateToProps = ({ modalMeta }) => ({
   open: modalMeta.open,
-  metaData: pick(modalMeta.data, ['title', 'subtitle', 'citation', 'overview']),
-  tableData: pick(modalMeta.data, MASTER_TABLE_FIELDS),
+  metaData: pick(
+    modalMeta.data,
+    modalMeta.data.metaWhitelist || MASTER_META_FIELDS
+  ),
+  tableData: pick(
+    modalMeta.data,
+    modalMeta.data.tableWhitelist || MASTER_TABLE_FIELDS
+  ),
   loading: modalMeta.loading
 });
 

--- a/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
+++ b/app/javascript/pages/country/widget/components/widget-header/widget-header-component.js
@@ -43,7 +43,13 @@ class WidgetHeader extends PureComponent {
           <div className="small-options">
             <Button
               className="theme-button-small square"
-              onClick={() => setModalMeta(settingsConfig.config.metaKey)}
+              onClick={() =>
+                setModalMeta(
+                  settingsConfig.config.metaKey,
+                  ['title', 'citation'],
+                  ['function', 'source']
+                )
+              }
             >
               <Icon icon={infoIcon} />
             </Button>


### PR DESCRIPTION
## Overview

We have a new case where when pushing meta data to the modal, for the widgets we only want to show a selection of the meta data, but for other cases we want to show everything. Instead of trying to manage each case inside the component, why not allow the parent to pass a whitelist of keys of what to show? Well now you can. If you don't pass a whitelist it just shows the full set as per the map.