### PR TITLE
updated intact and primary widgets in line with BC comments

### DIFF
--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -76,10 +76,11 @@
       "indicators": ["primary_forest", "primary_forest__mining", "primary_forest__wdpa", "primary_forest__landmark"],
       "categories": ["land-cover"],
       "admins": ["country", "region", "subRegion"],
-      "selectors": ["indicators", "thresholds", "extentYears"],
+      "customLocationWhitelist": ["IDN", "DRC"],
+      "selectors": ["indicators", "thresholds"],
       "type": "extent",
       "metaKey": "widget_primary_forest",
-      "layers": ["forest2000", "forest2010"],
+      "layers": ["forest2000"],
       "sortOrder": {
         "land-cover": 4
       }
@@ -87,8 +88,8 @@
     "settings": {
       "indicator": "primary_forest",
       "threshold": 30,
-      "extentYear": 2010,
-      "layers": ["forest2010"]
+      "extentYear": 2000,
+      "layers": ["forest2000"]
     },
     "enabled": true
   },

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-selectors.js
@@ -55,8 +55,14 @@ export const getSentence = createSelector(
   [getIntactTreeCoverData, getSettings, getLocationNames, getActiveIndicator],
   (parsedData, settings, locationNames, indicator) => {
     if (!parsedData || !locationNames) return null;
-    const intactPercentage = parsedData.find(d => d.label === 'Intact Forest')
-      .percentage;
+    const totalExtent = parsedData
+      .filter(d => d.label !== 'Non-Forest')
+      .map(d => d.value)
+      .reduce((sum, d) => sum + d);
+    const intactPercentage =
+      parsedData.find(d => d.label === 'Intact Forest').value /
+      totalExtent *
+      100;
     const locationLabel = locationNames.current && locationNames.current.label;
     let sentenceLocation;
 


### PR DESCRIPTION
## Overview

Changes in Intact forest and primary forest extent widgets in relation to various BC threads:
* [1](https://basecamp.com/3063126/projects/10727890/todos/340012070)
* [2](https://basecamp.com/3063126/projects/10727890/todos/340012462)
* [3](https://basecamp.com/3063126/projects/10727890/todos/340012348)

Changes include:
* Limit Primary forests to DRC and IDN
* Change dynamic sentence to show % of total tree cover for Intact and primary forests (rather than % relative to total area)
* Place logical test on Primary forests to catch a (hopefully short-term) bug in the data where the primary forest seems larger than total region forest
* Remove options from Primary forest widget, to make it show only with 2000 tree cover extent (as this is related to the original primary forest data)

