### PR TITLE
use colors when type loss key is needed

### DIFF
--- a/app/javascript/pages/country/data/widgets-config.json
+++ b/app/javascript/pages/country/data/widgets-config.json
@@ -379,7 +379,8 @@
       "categories": ["climate"],
       "admins": ["country"],
       "metaKey": "widget_historical_emissions",
-      "type": "emissions"
+      "type": "loss",
+      "colors": "emissions"
     },
     "enabled": true
   },
@@ -393,7 +394,8 @@
       "selectors": ["indicators", "startYears", "endYears", "metrics"],
       "yearRange": ["2001", "2016"],
       "metaKey": "widget_carbon_emissions_tree_cover_loss",
-      "type": "emissions"
+      "type": "loss",
+      "colors": "emissions"
     },
     "settings": {
       "indicator": "gadm28",

--- a/app/javascript/pages/country/widget/widget-selectors.js
+++ b/app/javascript/pages/country/widget/widget-selectors.js
@@ -115,6 +115,7 @@ export const getIndicators = createSelector(
       return null;
     }
     const whitelist = Object.keys(locationWhitelist);
+
     return sortByKey(
       sortByKey(
         INDICATORS.filter(

--- a/app/javascript/pages/country/widget/widget.js
+++ b/app/javascript/pages/country/widget/widget.js
@@ -85,7 +85,7 @@ const mapStateToProps = (state, ownProps) => {
     loading,
     error,
     data,
-    colors: COLORS[config.type] || COLORS,
+    colors: COLORS[config.colors || config.type] || COLORS,
     settingsConfig: {
       config,
       settings,


### PR DESCRIPTION
## Overview

HOT FIX: Use a colors prop if needed to use a type of loss for whitelisting in the indicators selector.