### PR TITLE
sync master layer menu with develop

### DIFF
--- a/app/assets/javascripts/map/templates/layersNav.handlebars
+++ b/app/assets/javascripts/map/templates/layersNav.handlebars
@@ -58,11 +58,23 @@
               <span class="layer-title">Tree cover gain<a href='#' data-source='tree_cover_gain' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
               <span class="layer-info">(12 years, 30m, global, Hansen/UMD/Google/USGS/NASA)</span>
             </li>
+            <li class="layer" data-layer="guyra">
+              <span class="onoffswitch"><span></span></span>
+              <span class="layer-title">Gran Chaco deforestation<a href='#' data-source='gran_chaco_deforestation' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
+              <span class="layer-info">(monthly, 30m, Gran Chaco, Guyra)</span>
+            </li>
+            <li class="layer" data-layer="prodes">
+              <span class="onoffswitch"><span></span></span>
+              <span class="layer-title">PRODES deforestation<a href='#' data-source='prodes' class='source'><svg><use xlink:href="#shape-info"></use></svg></a></span>
+              <span class="layer-info">(annual, 30m, Brazilian Amazon, INPE)</span>
+            </li>
+            {{#if staging}}
             <li class="layer" data-layer="per_minam_loss">
               <span class="onoffswitch"><span></span></span>
               <span class="layer-title"> Peru MINAM tree cover loss <a href='#' data-source='per_minam_loss' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
               <span class="layer-info"> ----- </span>
             </li>
+            {{/if}}
           </div>
         </ul>
       </div>
@@ -112,11 +124,13 @@
             <span class="layer-title">Aboveground live woody biomass density<a href='#' data-source='aboveground_biomass' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
             <span class="layer-info">(2000)</span>
           </li>
-          <li class="layer" data-layer="mangrove_2">
-            <span class="onoffswitch"><span></span></span>
-            <span class="layer-title">Mangrove change<a href='#' data-source='global_mangroves' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
-            <span class="layer-info"></span>
-          </li>
+          {{#if staging}}
+            <li class="layer" data-layer="mangrove_2">
+              <span class="onoffswitch"><span></span></span>
+              <span class="layer-title">Mangrove change<a href='#' data-source='global_mangroves' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
+              <span class="layer-info"></span>
+            </li>
+          {{/if}}
           <li class="layer" data-layer="mangrove_watch">
             <span class="onoffswitch"><span></span></span>
             <span class="layer-title">Mangrove forests <a href='#' data-source='mangrove_2010_gmw' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
@@ -218,10 +232,12 @@
             <span class="onoffswitch"><span></span></span>
             <span class="layer-title">Biodiversity hotspots<a href='#' data-source='biodiversity_hotspots' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
           </li>
-          <li class="layer" data-layer="wwf">
-            <span class="onoffswitch"><span></span></span>
-            <span class="layer-title">WWF Terrestrial Ecoregions of the World<a href='#' data-source='wwf_terrestrial_ecoregions' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
-          </li>
+          {{#if staging}}
+            <li class="layer" data-layer="wwf">
+              <span class="onoffswitch"><span></span></span>
+              <span class="layer-title">WWF Terrestrial Ecoregions of the World<a href='#' data-source='wwf_terrestrial_ecoregions' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
+            </li>
+          {{/if}}
           <li class="layer" data-layer="birdlife">
             <span class="onoffswitch"><span></span></span>
             <span class="layer-title">BirdLife Endemic Bird Areas<a href='#' data-source='endemic_bird_areas' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
@@ -234,11 +250,12 @@
             <span class="onoffswitch"><span></span></span>
             <span class="layer-title">Tiger Conservation Landscapes<a href='#' data-source='tiger_conservation_landscapes' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
           </li>
-
+          {{#if staging}}
           <li class="layer" data-layer="verified_carbon">
             <span class="onoffswitch"><span></span></span>
             <span class="layer-title">Verified Carbon Standard project areas<a href='#' data-source='verified_carbon_standard' class='source source-shape-info'><svg><use xlink:href="#shape-info"></use></svg></a></span>
-
+          </li>
+          {{/if}}
         </ul>
       </div>
     </li>

--- a/app/assets/javascripts/map/templates/legend/glad.handlebars
+++ b/app/assets/javascripts/map/templates/legend/glad.handlebars
@@ -15,10 +15,12 @@
     <p class="canopy"><a href="http://connect.wri.org/l/120942/2017-12-07/3mtt5w" target="_blank">Sign up for the PTW newsletter ➤</a></p>
   </div>
 </div>
-<div data-autotoggle="false" data-sublayer="uncurated_places_to_watch" data-parent="umd_as_it_happens" class="layer-sublayer js-toggle-sublayer">
-  <span class="onoffswitch" style="background-color:#f69;"><span></span></span>
-  <div class="sublayer-title">Uncurated Places to Watch</div>
-</div>
+{{#if staging}}
+  <div data-autotoggle="false" data-sublayer="uncurated_places_to_watch" data-parent="umd_as_it_happens" class="layer-sublayer js-toggle-sublayer">
+    <span class="onoffswitch" style="background-color:#f69;"><span></span></span>
+    <div class="sublayer-title">Uncurated Places to Watch</div>
+  </div>
+{{/if}}
 <div class="layer-sublayer layer-option js-toggle-layer-option" data-option="gladConfirmOnly">
   <span class="onoffswitch"><span></span></span>
   <div class="sublayer-title">

--- a/app/assets/javascripts/map/views/LayersNavView.js
+++ b/app/assets/javascripts/map/views/LayersNavView.js
@@ -50,7 +50,9 @@ define([
     },
 
     render: function() {
-      this.$el.html('').append(this.template());
+      this.$el.html('').append(this.template({
+        staging: window.gfw.config.FEATURE_ENV === 'staging'
+      }));
       this.cache();
       this.fixLegibility();
       // Initialize Country dropdown layers

--- a/app/assets/javascripts/map/views/LegendView.js
+++ b/app/assets/javascripts/map/views/LegendView.js
@@ -283,6 +283,7 @@ define([
             startYear: options.startYear,
             layerTitle: layer.title,
             layerSlug: layer.slug,
+            staging: window.gfw.config.FEATURE_ENV === 'staging'
           });
         }
 

--- a/app/views/shared/_js_config.html.erb
+++ b/app/views/shared/_js_config.html.erb
@@ -11,6 +11,7 @@
         GFW_API_HOST_PROD: "<%= ENV['GFW_API_HOST_PROD'] %>",
         GFW_MOBILE: 1000,
         AWS_HOST: "<%= ENV['AWS_HOST'] %>",
+        FEATURE_ENV: "<%= ENV['FEATURE_ENV'] %>"
       },
       cacheVersion: "<%= ENV['CACHE_VERSION'] %>",
       layer_spec: "<%= ENV['LAYER_SPEC'] %>"


### PR DESCRIPTION
## Overview

A much needed update to the process for showing layers on staging without showing them on production. A simple process:

- Sync the layers menu with master manually so that we look the same
- Add a new env variable `FEATURE_ENV` to allow handlebars templates to know if we are in staging
- Update handlebars template to only show menu items when on staging
