### PR TITLE
Fix/whitelist for water bodies

### DIFF
--- a/app/javascript/pages/country/providers/country-data-provider/country-data-provider-actions.js
+++ b/app/javascript/pages/country/providers/country-data-provider/country-data-provider-actions.js
@@ -8,8 +8,6 @@ import {
   getFAOCountriesProvider,
   getRegionsProvider,
   getSubRegionsProvider,
-  getCountryWhitelistProvider,
-  getRegionWhitelistProvider,
   getCountryLinksProvider
 } from 'services/country';
 import { getGeostoreProvider } from 'services/geostore';
@@ -19,12 +17,6 @@ export const setRegionsLoading = createAction('setRegionsLoading');
 export const setSubRegionsLoading = createAction('setSubRegionsLoading');
 export const setGeostoreLoading = createAction('setGeostoreLoading');
 export const setCountryLinksLoading = createAction('setCountryLinksLoading');
-export const setCountryWhitelistLoading = createAction(
-  'setCountryWhitelistLoading'
-);
-export const setRegionWhitelistLoading = createAction(
-  'setRegionWhitelistLoading'
-);
 
 export const setCountries = createAction('setCountries');
 export const setFAOCountries = createAction('setFAOCountries');
@@ -32,9 +24,7 @@ export const setGadmCountries = createAction('setGadmCountries');
 export const setRegions = createAction('setRegions');
 export const setSubRegions = createAction('setSubRegions');
 export const setGeostore = createAction('setGeostore');
-export const setCountryWhitelist = createAction('setCountryWhitelist');
 export const setCountryLinks = createAction('setCountryLinks');
-export const setRegionWhitelist = createAction('setRegionWhitelist');
 
 export const getCountries = createThunkAction(
   'getCountries',
@@ -119,62 +109,6 @@ export const getGeostore = createThunkAction(
         })
         .catch(error => {
           dispatch(setGeostoreLoading(false));
-          console.info(error);
-        });
-    }
-  }
-);
-
-export const getCountryWhitelist = createThunkAction(
-  'getCountryWhitelist',
-  country => (dispatch, state) => {
-    if (!state().countryData.isRegionWhitelistLoading) {
-      dispatch(setCountryWhitelistLoading(true));
-      getCountryWhitelistProvider(country)
-        .then(response => {
-          const data = {};
-          if (response.data && response.data.data.length) {
-            response.data.data.forEach(d => {
-              data[d.polyname] = {
-                extent_2000: d.total_extent_2000,
-                extent_2010: d.total_extent_2010,
-                loss: d.total_loss,
-                gain: d.total_gain
-              };
-            });
-          }
-          dispatch(setCountryWhitelist(data));
-        })
-        .catch(error => {
-          dispatch(setCountryWhitelistLoading(false));
-          console.info(error);
-        });
-    }
-  }
-);
-
-export const getRegionWhitelist = createThunkAction(
-  'getRegionWhitelist',
-  (country, region, subRegion) => (dispatch, state) => {
-    if (!state().countryData.isRegionWhitelistLoading) {
-      dispatch(setRegionWhitelistLoading(true));
-      getRegionWhitelistProvider(country, region, subRegion)
-        .then(response => {
-          const data = {};
-          if (response.data && response.data.data.length) {
-            response.data.data.forEach(d => {
-              data[d.polyname] = {
-                extent_2000: d.total_extent_2000,
-                extent_2010: d.total_extent_2010,
-                loss: d.total_loss,
-                gain: d.total_gain
-              };
-            });
-          }
-          dispatch(setRegionWhitelist(data));
-        })
-        .catch(error => {
-          dispatch(setRegionWhitelistLoading(false));
           console.info(error);
         });
     }

--- a/app/javascript/pages/country/providers/country-data-provider/country-data-provider-reducers.js
+++ b/app/javascript/pages/country/providers/country-data-provider/country-data-provider-reducers.js
@@ -3,14 +3,11 @@ export const initialState = {
   isRegionsLoading: false,
   isSubRegionsLoading: false,
   isGeostoreLoading: false,
-  isWhitelistLoading: false,
   countries: [],
   gadmCountries: [],
   faoCountries: [],
   regions: [],
   subRegions: [],
-  countryWhitelist: {},
-  regionWhitelist: {},
   countryLinks: {},
   geostore: {
     hash: '',
@@ -52,16 +49,6 @@ const setGeostoreLoading = (state, { payload }) => ({
   isGeostoreLoading: payload
 });
 
-const setCountryWhitelistLoading = (state, { payload }) => ({
-  ...state,
-  isCountryWhitelistLoading: payload
-});
-
-const setRegionWhitelistLoading = (state, { payload }) => ({
-  ...state,
-  isRegionWhitelistLoading: payload
-});
-
 const setCountries = (state, { payload }) => ({
   ...state,
   countries: mapLocations(payload)
@@ -87,18 +74,6 @@ const setSubRegions = (state, { payload }) => ({
   subRegions: mapLocations(payload)
 });
 
-const setCountryWhitelist = (state, { payload }) => ({
-  ...state,
-  isCountryWhitelistLoading: false,
-  countryWhitelist: payload
-});
-
-const setRegionWhitelist = (state, { payload }) => ({
-  ...state,
-  isRegionWhitelistLoading: false,
-  regionWhitelist: payload
-});
-
 const setCountryLinks = (state, { payload }) => ({
   ...state,
   isCountryLinksLoading: false,
@@ -117,15 +92,11 @@ export default {
   setRegionsLoading,
   setSubRegionsLoading,
   setGeostoreLoading,
-  setCountryWhitelistLoading,
-  setRegionWhitelistLoading,
   setCountries,
   setFAOCountries,
   setGadmCountries,
   setRegions,
   setSubRegions,
   setGeostore,
-  setCountryWhitelist,
-  setRegionWhitelist,
   setCountryLinks
 };

--- a/app/javascript/pages/country/providers/country-data-provider/country-data-provider.js
+++ b/app/javascript/pages/country/providers/country-data-provider/country-data-provider.js
@@ -17,8 +17,6 @@ class CountryDataProvider extends PureComponent {
       getRegions,
       getSubRegions,
       getGeostore,
-      getCountryWhitelist,
-      getRegionWhitelist,
       getCountryLinks
     } = this.props;
     getCountries();
@@ -27,22 +25,12 @@ class CountryDataProvider extends PureComponent {
       getSubRegions(location.country, location.region);
     }
     getGeostore(location.country, location.region, location.subRegion);
-    getCountryWhitelist(location.country);
-    if (location.region) {
-      getRegionWhitelist(location.country, location.region, location.subRegion);
-    }
     getCountryLinks();
   }
 
   componentWillReceiveProps(nextProps) {
     const { country, region, subRegion } = nextProps.location;
-    const {
-      getRegions,
-      getSubRegions,
-      getGeostore,
-      getCountryWhitelist,
-      getRegionWhitelist
-    } = this.props;
+    const { getRegions, getSubRegions, getGeostore } = this.props;
     const hasCountryChanged = country !== this.props.location.country;
     const hasRegionChanged = region !== this.props.location.region;
     const hasSubRegionChanged = subRegion !== this.props.location.subRegion;
@@ -53,7 +41,6 @@ class CountryDataProvider extends PureComponent {
         getSubRegions(country, region);
       }
       getGeostore(country, region, subRegion);
-      getCountryWhitelist(country);
     }
 
     if (hasRegionChanged) {
@@ -61,12 +48,10 @@ class CountryDataProvider extends PureComponent {
         getSubRegions(country, region);
       }
       getGeostore(country, region);
-      getRegionWhitelist(country, region, subRegion);
     }
 
     if (hasSubRegionChanged) {
       getGeostore(country, region, subRegion);
-      getRegionWhitelist(country, region, subRegion);
     }
   }
 
@@ -81,8 +66,6 @@ CountryDataProvider.propTypes = {
   getRegions: PropTypes.func.isRequired,
   getSubRegions: PropTypes.func.isRequired,
   getGeostore: PropTypes.func.isRequired,
-  getCountryWhitelist: PropTypes.func.isRequired,
-  getRegionWhitelist: PropTypes.func.isRequired,
   getCountryLinks: PropTypes.func.isRequired
 };
 

--- a/app/javascript/pages/country/providers/whitelists-provider/whitelists-provider-actions.js
+++ b/app/javascript/pages/country/providers/whitelists-provider/whitelists-provider-actions.js
@@ -1,0 +1,100 @@
+import { createAction } from 'redux-actions';
+import { createThunkAction } from 'utils/redux';
+import groupBy from 'lodash/groupBy';
+
+import {
+  getCountryWhitelistProvider,
+  getRegionWhitelistProvider,
+  getWaterBodiesBlacklistProvider
+} from 'services/whitelists';
+
+export const setCountryWhitelistLoading = createAction(
+  'setCountryWhitelistLoading'
+);
+export const setRegionWhitelistLoading = createAction(
+  'setRegionWhitelistLoading'
+);
+export const setWaterBodiesWhitelistLoading = createAction(
+  'setWaterBodiesWhitelistLoading'
+);
+
+export const setCountryWhitelist = createAction('setCountryWhitelist');
+export const setRegionWhitelist = createAction('setRegionWhitelist');
+export const setWaterBodiesWhitelist = createAction('setWaterBodiesWhitelist');
+
+export const getCountryWhitelist = createThunkAction(
+  'getCountryWhitelist',
+  country => (dispatch, state) => {
+    if (!state().whitelists.countryWhitelistLoading) {
+      dispatch(setCountryWhitelistLoading(true));
+      getCountryWhitelistProvider(country)
+        .then(response => {
+          const data = {};
+          if (response.data && response.data.data.length) {
+            response.data.data.forEach(d => {
+              data[d.polyname] = {
+                extent_2000: d.total_extent_2000,
+                extent_2010: d.total_extent_2010,
+                loss: d.total_loss,
+                gain: d.total_gain
+              };
+            });
+          }
+          dispatch(setCountryWhitelist(data));
+        })
+        .catch(error => {
+          dispatch(setCountryWhitelistLoading(false));
+          console.info(error);
+        });
+    }
+  }
+);
+
+export const getRegionWhitelist = createThunkAction(
+  'getRegionWhitelist',
+  (country, region, subRegion) => (dispatch, state) => {
+    if (!state().whitelists.regionWhitelistLoading) {
+      dispatch(setRegionWhitelistLoading(true));
+      getRegionWhitelistProvider(country, region, subRegion)
+        .then(response => {
+          const data = {};
+          if (response.data && response.data.data.length) {
+            response.data.data.forEach(d => {
+              data[d.polyname] = {
+                extent_2000: d.total_extent_2000,
+                extent_2010: d.total_extent_2010,
+                loss: d.total_loss,
+                gain: d.total_gain
+              };
+            });
+          }
+          dispatch(setRegionWhitelist(data));
+        })
+        .catch(error => {
+          dispatch(setRegionWhitelistLoading(false));
+          console.info(error);
+        });
+    }
+  }
+);
+
+export const getWaterBodiesWhitelist = createThunkAction(
+  'getWaterBodiesWhitelist',
+  () => (dispatch, state) => {
+    if (!state().whitelists.waterBodiesWhitelistLoading) {
+      dispatch(setWaterBodiesWhitelistLoading(true));
+      getWaterBodiesBlacklistProvider()
+        .then(response => {
+          let data = [];
+          if (response.data && response.data.rows.length) {
+            data = groupBy(response.data.rows, 'iso');
+          }
+          dispatch(setWaterBodiesWhitelist(data));
+        })
+        .catch(error => {
+          dispatch(setWaterBodiesWhitelistLoading(false));
+          console.info(error);
+        });
+    }
+  }
+);

--- a/app/javascript/pages/country/providers/whitelists-provider/whitelists-provider-actions.js
+++ b/app/javascript/pages/country/providers/whitelists-provider/whitelists-provider-actions.js
@@ -80,21 +80,18 @@ export const getRegionWhitelist = createThunkAction(
 
 export const getWaterBodiesWhitelist = createThunkAction(
   'getWaterBodiesWhitelist',
-  () => (dispatch, state) => {
-    if (!state().whitelists.waterBodiesWhitelistLoading) {
-      dispatch(setWaterBodiesWhitelistLoading(true));
-      getWaterBodiesBlacklistProvider()
-        .then(response => {
-          let data = [];
-          if (response.data && response.data.rows.length) {
-            data = groupBy(response.data.rows, 'iso');
-          }
-          dispatch(setWaterBodiesWhitelist(data));
-        })
-        .catch(error => {
-          dispatch(setWaterBodiesWhitelistLoading(false));
-          console.info(error);
-        });
-    }
+  () => dispatch => {
+    getWaterBodiesBlacklistProvider()
+      .then(response => {
+        let data = [];
+        if (response.data && response.data.rows.length) {
+          data = groupBy(response.data.rows, 'iso');
+        }
+        dispatch(setWaterBodiesWhitelist(data));
+      })
+      .catch(error => {
+        dispatch(setWaterBodiesWhitelistLoading(false));
+        console.info(error);
+      });
   }
 );

--- a/app/javascript/pages/country/providers/whitelists-provider/whitelists-provider-reducers.js
+++ b/app/javascript/pages/country/providers/whitelists-provider/whitelists-provider-reducers.js
@@ -1,7 +1,7 @@
 export const initialState = {
   countryWhitelistLoading: false,
   regionWhitelistLoading: false,
-  waterBodiesWhitelistLoading: false,
+  waterBodiesWhitelistLoading: true,
   countryWhitelist: {},
   regionWhitelist: {},
   waterBodiesWhitelist: {}

--- a/app/javascript/pages/country/providers/whitelists-provider/whitelists-provider-reducers.js
+++ b/app/javascript/pages/country/providers/whitelists-provider/whitelists-provider-reducers.js
@@ -1,0 +1,50 @@
+export const initialState = {
+  countryWhitelistLoading: false,
+  regionWhitelistLoading: false,
+  waterBodiesWhitelistLoading: false,
+  countryWhitelist: {},
+  regionWhitelist: {},
+  waterBodiesWhitelist: {}
+};
+
+const setCountryWhitelistLoading = (state, { payload }) => ({
+  ...state,
+  countryWhitelistLoading: payload
+});
+
+const setRegionWhitelistLoading = (state, { payload }) => ({
+  ...state,
+  regionWhitelistLoading: payload
+});
+
+const setWaterBodiesWhitelistLoading = (state, { payload }) => ({
+  ...state,
+  waterBodiesWhitelistLoading: payload
+});
+
+const setCountryWhitelist = (state, { payload }) => ({
+  ...state,
+  countryWhitelistLoading: false,
+  countryWhitelist: payload
+});
+
+const setRegionWhitelist = (state, { payload }) => ({
+  ...state,
+  regionWhitelistLoading: false,
+  regionWhitelist: payload
+});
+
+const setWaterBodiesWhitelist = (state, { payload }) => ({
+  ...state,
+  waterBodiesWhitelistLoading: false,
+  waterBodiesWhitelist: payload
+});
+
+export default {
+  setCountryWhitelistLoading,
+  setRegionWhitelistLoading,
+  setWaterBodiesWhitelistLoading,
+  setCountryWhitelist,
+  setRegionWhitelist,
+  setWaterBodiesWhitelist
+};

--- a/app/javascript/pages/country/providers/whitelists-provider/whitelists-provider.js
+++ b/app/javascript/pages/country/providers/whitelists-provider/whitelists-provider.js
@@ -1,0 +1,56 @@
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import * as actions from './whitelists-provider-actions';
+import reducers, { initialState } from './whitelists-provider-reducers';
+
+const mapStateToProps = state => ({
+  location: state.location.payload
+});
+
+class CountryDataProvider extends PureComponent {
+  componentWillMount() {
+    const {
+      location,
+      getCountryWhitelist,
+      getRegionWhitelist,
+      getWaterBodiesWhitelist
+    } = this.props;
+    getCountryWhitelist(location.country);
+    if (location.region) {
+      getRegionWhitelist(location.country, location.region, location.subRegion);
+    }
+    getWaterBodiesWhitelist();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { country, region, subRegion } = nextProps.location;
+    const { getCountryWhitelist, getRegionWhitelist } = this.props;
+    const hasCountryChanged = country !== this.props.location.country;
+    const hasRegionChanged = region !== this.props.location.region;
+    const hasSubRegionChanged = subRegion !== this.props.location.subRegion;
+
+    if (hasCountryChanged) {
+      getCountryWhitelist(country);
+    }
+
+    if (hasRegionChanged || hasSubRegionChanged) {
+      getRegionWhitelist(country, region, subRegion);
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+CountryDataProvider.propTypes = {
+  location: PropTypes.object.isRequired,
+  getCountryWhitelist: PropTypes.func.isRequired,
+  getRegionWhitelist: PropTypes.func.isRequired,
+  getWaterBodiesWhitelist: PropTypes.func.isRequired
+};
+
+export { actions, reducers, initialState };
+export default connect(mapStateToProps, actions)(CountryDataProvider);

--- a/app/javascript/pages/country/reducers.js
+++ b/app/javascript/pages/country/reducers.js
@@ -40,7 +40,9 @@ import * as widgetForestryEmploymentComponent from 'pages/country/widget/widgets
 
 // Providers
 import * as countryDataProviderComponent from 'pages/country/providers/country-data-provider';
+import * as whitelistsProviderComponent from 'pages/country/providers/whitelists-provider';
 
+// Component Reducers
 const componentsReducers = {
   share: handleActions(ShareComponent),
   modalMeta: handleActions(ModalMetaComponent),
@@ -72,8 +74,10 @@ const componentsReducers = {
   widgetForestryEmployment: handleActions(widgetForestryEmploymentComponent)
 };
 
+// Provider Reducers
 const providersReducers = {
-  countryData: handleActions(countryDataProviderComponent)
+  countryData: handleActions(countryDataProviderComponent),
+  whitelists: handleActions(whitelistsProviderComponent)
 };
 
 export default combineReducers({

--- a/app/javascript/pages/country/root/root-component.js
+++ b/app/javascript/pages/country/root/root-component.js
@@ -3,12 +3,16 @@ import PropTypes from 'prop-types';
 import { SCREEN_M } from 'utils/constants';
 import upperFirst from 'lodash/upperFirst';
 
+import CountryDataProvider from 'pages/country/providers/country-data-provider';
+import WhitelistsProvider from 'pages/country/providers/whitelists-provider';
+
 import Widget from 'pages/country/widget';
-import Share from 'components/share';
+import Meta from 'pages/country/meta';
 import Header from 'pages/country/header';
+
+import Share from 'components/share';
 import Map from 'components/map';
 import Sticky from 'components/sticky';
-import CountryDataProvider from 'pages/country/providers/country-data-provider';
 import SubNavMenu from 'components/subnav-menu';
 import NoContent from 'components/no-content';
 import Loader from 'components/loader';
@@ -16,7 +20,6 @@ import Button from 'components/button';
 import Icon from 'components/icon';
 import ModalMeta from 'components/modal-meta';
 import ScrollTo from 'components/scroll-to';
-import Meta from 'pages/country/meta';
 
 import mapIcon from 'assets/icons/map-button.svg';
 import closeIcon from 'assets/icons/close.svg';
@@ -129,6 +132,7 @@ class Root extends PureComponent {
         <ModalMeta />
         {widgetAnchor && <ScrollTo target={widgetAnchor} />}
         <CountryDataProvider />
+        <WhitelistsProvider />
         <Meta page={currentLocation} />
       </div>
     );

--- a/app/javascript/pages/country/root/root.js
+++ b/app/javascript/pages/country/root/root.js
@@ -51,6 +51,7 @@ const mapStateToProps = ({ root, countryData, whitelists, location }) => {
       ? regionWhitelist
       : countryWhitelist
   };
+
   return {
     gfwHeaderHeight: root.gfwHeaderHeight,
     isMapFixed: root.isMapFixed,

--- a/app/javascript/pages/country/root/root.js
+++ b/app/javascript/pages/country/root/root.js
@@ -15,12 +15,21 @@ import reducers, { initialState } from './root-reducers';
 import { filterWidgets, getLinks, getActiveWidget } from './root-selectors';
 import RootComponent from './root-component';
 
-const mapStateToProps = ({ root, countryData, location }) => {
+const mapStateToProps = ({ root, countryData, whitelists, location }) => {
   const category = (location.query && location.query.category) || 'summary';
+  const {
+    countryWhitelist,
+    regionWhitelist,
+    waterBodiesWhitelist,
+    countryWhitelistLoading,
+    regionWhitelistLoading,
+    waterBodiesWhitelistLoading
+  } = whitelists;
   const adminData = {
     countries: countryData.countries,
     regions: countryData.regions,
     subRegions: countryData.subRegions,
+    waterBodies: waterBodiesWhitelist,
     location: location.payload
   };
   const locationOptions = getAdminsOptions(adminData);
@@ -29,12 +38,6 @@ const mapStateToProps = ({ root, countryData, location }) => {
   const widgetHash =
     window.location.hash && replace(window.location.hash, '#', '');
   const widgetAnchor = document.getElementById(widgetHash);
-  const {
-    regionWhitelist,
-    countryWhitelist,
-    isCountryWhitelistLoading,
-    isRegionWhitelistLoading
-  } = countryData;
   const widgetData = {
     faoCountries: countryData.faoCountries,
     category,
@@ -63,7 +66,10 @@ const mapStateToProps = ({ root, countryData, location }) => {
       locationNames[adminLevel] && locationNames[adminLevel].label,
     widgets: filterWidgets(widgetData),
     locationGeoJson: countryData.geostore && countryData.geostore.geojson,
-    loading: isCountryWhitelistLoading || isRegionWhitelistLoading,
+    loading:
+      countryWhitelistLoading ||
+      regionWhitelistLoading ||
+      waterBodiesWhitelistLoading,
     activeWidget: getActiveWidget(widgetData)
   };
 };

--- a/app/javascript/pages/country/widget/widget-selectors.js
+++ b/app/javascript/pages/country/widget/widget-selectors.js
@@ -61,7 +61,10 @@ export const getAdminsOptions = createSelector(
       activeWaterBodies && activeWaterBodies.map(w => w.adm2);
 
     return {
-      countries: (countries && sortByKey(countries, 'label')) || null,
+      countries:
+        (countries &&
+          sortByKey(countries.filter(c => c.value !== 'XCA'), 'label')) ||
+        null,
       regions:
         (regions &&
           [{ label: 'All Regions', value: null }].concat(

--- a/app/javascript/pages/country/widget/widget-selectors.js
+++ b/app/javascript/pages/country/widget/widget-selectors.js
@@ -21,6 +21,7 @@ const getData = state => state.data || null;
 const getStartYear = state => state.startYear || null;
 const getEndYear = state => state.endYear || null;
 const getConfig = state => state.config || null;
+const getWaterBodies = state => state.waterBodies || null;
 const getLocationWhitelist = state =>
   (state.location.region ? state.regionWhitelist : state.countryWhitelist);
 
@@ -48,22 +49,38 @@ export const getLocationLabel = (location, indicator, indicators) => {
 
 // get lists selected
 export const getAdminsOptions = createSelector(
-  [getCountries, getRegions, getSubRegions],
-  (countries, regions, subRegions) => ({
-    countries: (countries && sortByKey(countries, 'label')) || null,
-    regions:
-      (regions &&
-        [{ label: 'All Regions', value: null }].concat(
-          sortByKey(regions, 'label')
-        )) ||
-      null,
-    subRegions:
-      (subRegions &&
-        [{ label: 'All Regions', value: null }].concat(
-          sortByKey(subRegions, 'label')
-        )) ||
-      null
-  })
+  [getAdmins, getCountries, getRegions, getSubRegions, getWaterBodies],
+  (location, countries, regions, subRegions, waterBodies) => {
+    const activeWaterBodies =
+      waterBodies &&
+      waterBodies[location.country] &&
+      waterBodies[location.country].filter(
+        w => w.adm1 === parseInt(location.region, 10)
+      );
+    const waterBodiesIds =
+      activeWaterBodies && activeWaterBodies.map(w => w.adm2);
+
+    return {
+      countries: (countries && sortByKey(countries, 'label')) || null,
+      regions:
+        (regions &&
+          [{ label: 'All Regions', value: null }].concat(
+            sortByKey(regions, 'label')
+          )) ||
+        null,
+      subRegions:
+        (subRegions &&
+          [{ label: 'All Regions', value: null }].concat(
+            sortByKey(
+              waterBodiesIds
+                ? subRegions.filter(s => waterBodiesIds.indexOf(s.value) === -1)
+                : subRegions,
+              'label'
+            )
+          )) ||
+        null
+    };
+  }
 );
 
 // get lists selected

--- a/app/javascript/pages/country/widget/widget.js
+++ b/app/javascript/pages/country/widget/widget.js
@@ -7,7 +7,7 @@ import Component from './widget-component';
 import actions from './widget-actions';
 
 const mapStateToProps = (state, ownProps) => {
-  const { location, countryData } = state;
+  const { location, countryData, whitelists } = state;
   const { title, config, settings, loading, data, error } = state[
     `widget${upperFirst(ownProps.widget)}`
   ];
@@ -15,10 +15,13 @@ const mapStateToProps = (state, ownProps) => {
     isCountriesLoading,
     isRegionsLoading,
     isSubRegionsLoading,
-    isCountryWhitelistLoading,
-    isRegionWhitelistLoading,
     isGeostoreLoading
   } = countryData;
+  const {
+    countryWhitelistLoading,
+    regionWhitelistLoading,
+    waterBodiesLoading
+  } = whitelists;
   const adminData = {
     location: location.payload,
     countries: countryData.countries,
@@ -34,7 +37,8 @@ const mapStateToProps = (state, ownProps) => {
           options[selector] = selectorFunc({
             config,
             location: location.payload,
-            ...countryData
+            ...countryData,
+            ...whitelists
           });
           break;
         case 'years':
@@ -68,8 +72,9 @@ const mapStateToProps = (state, ownProps) => {
       isCountriesLoading ||
       isRegionsLoading ||
       isSubRegionsLoading ||
-      isCountryWhitelistLoading ||
-      isRegionWhitelistLoading,
+      countryWhitelistLoading ||
+      regionWhitelistLoading ||
+      waterBodiesLoading,
     isGeostoreLoading,
     locationNames: widgetSelectors.getAdminsSelected(adminData),
     activeLocation: widgetSelectors.getActiveAdmin({

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-actions.js
@@ -13,7 +13,7 @@ export const getIntactTreeCover = createThunkAction(
   'getIntactTreeCover',
   params => (dispatch, state) => {
     if (!state().widgetIntactTreeCover.loading) {
-      const { countryWhitelist, regionWhitelist } = state().countryData;
+      const { countryWhitelist, regionWhitelist } = state().whitelists;
       const { region } = state().location.payload;
       const whitelist = Object.keys(
         region ? regionWhitelist : countryWhitelist

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover-actions.js
@@ -7,8 +7,6 @@ const setIntactTreeCoverLoading = createAction('setIntactTreeCoverLoading');
 const setIntactTreeCoverData = createAction('setIntactTreeCoverData');
 const setIntactTreeCoverSettings = createAction('setIntactTreeCoverSettings');
 
-const hardCodedPlantations = ['BRA', 'IDN', 'PER', 'LBR', 'COL', 'MYS', 'KHM'];
-
 export const getIntactTreeCover = createThunkAction(
   'getIntactTreeCover',
   params => (dispatch, state) => {
@@ -44,10 +42,7 @@ export const getIntactTreeCover = createThunkAction(
                 plantations
               };
             }
-            if (
-              whitelist.indexOf('plantations') === -1 &&
-              !hardCodedPlantations.includes(params.country)
-            ) {
+            if (whitelist.indexOf('plantations') === -1) {
               dispatch(setIntactTreeCoverData(data));
             } else {
               let polyname = 'plantations';

--- a/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-intact-tree-cover/widget-intact-tree-cover.js
@@ -11,19 +11,17 @@ import {
 } from './widget-intact-tree-cover-selectors';
 import WidgetIntactTreeCoverComponent from './widget-intact-tree-cover-component';
 
-const mapStateToProps = ({ widgetIntactTreeCover, countryData }, ownProps) => {
-  const {
-    isCountriesLoading,
-    isRegionsLoading,
-    countryWhitelist,
-    regions
-  } = countryData;
+const mapStateToProps = (
+  { widgetIntactTreeCover, countryData, whitelists },
+  ownProps
+) => {
+  const { isCountriesLoading, isRegionsLoading, regions } = countryData;
   const { settings, loading, data } = widgetIntactTreeCover;
   const { colors, locationNames, activeIndicator } = ownProps;
   const selectorData = {
     data,
     settings,
-    whitelist: countryWhitelist,
+    whitelist: whitelists.countryWhitelist,
     locationNames,
     activeIndicator,
     colors

--- a/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-actions.js
@@ -7,8 +7,6 @@ const setPrimaryTreeCoverLoading = createAction('setPrimaryTreeCoverLoading');
 const setPrimaryTreeCoverData = createAction('setPrimaryTreeCoverData');
 const setPrimaryTreeCoverSettings = createAction('setPrimaryTreeCoverSettings');
 
-const hardCodedPlantations = ['BRA', 'IDN', 'PER', 'LBR', 'COL', 'MYS', 'KHM'];
-
 export const getPrimaryTreeCover = createThunkAction(
   'getPrimaryTreeCover',
   params => (dispatch, state) => {
@@ -44,10 +42,7 @@ export const getPrimaryTreeCover = createThunkAction(
                 plantations
               };
             }
-            if (
-              whitelist.indexOf('plantations') === -1 &&
-              !hardCodedPlantations.includes(params.country)
-            ) {
+            if (whitelist.indexOf('plantations') === -1) {
               dispatch(setPrimaryTreeCoverData(data));
             } else {
               let polyname = 'plantations';

--- a/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-actions.js
+++ b/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover-actions.js
@@ -13,7 +13,7 @@ export const getPrimaryTreeCover = createThunkAction(
   'getPrimaryTreeCover',
   params => (dispatch, state) => {
     if (!state().widgetPrimaryTreeCover.loading) {
-      const { countryWhitelist, regionWhitelist } = state().countryData;
+      const { countryWhitelist, regionWhitelist } = state().whitelists;
       const { region } = state().location.payload;
       const whitelist = Object.keys(
         region ? regionWhitelist : countryWhitelist

--- a/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-primary-tree-cover/widget-primary-tree-cover.js
@@ -11,19 +11,17 @@ import {
 } from './widget-primary-tree-cover-selectors';
 import WidgetPrimaryTreeCoverComponent from './widget-primary-tree-cover-component';
 
-const mapStateToProps = ({ widgetPrimaryTreeCover, countryData }, ownProps) => {
-  const {
-    isCountriesLoading,
-    isRegionsLoading,
-    countryWhitelist,
-    regions
-  } = countryData;
+const mapStateToProps = (
+  { widgetPrimaryTreeCover, countryData, whitelists },
+  ownProps
+) => {
+  const { isCountriesLoading, isRegionsLoading, regions } = countryData;
   const { settings, loading, data } = widgetPrimaryTreeCover;
   const { colors, locationNames, activeIndicator } = ownProps;
   const selectorData = {
     data,
     settings,
-    whitelist: countryWhitelist,
+    whitelist: whitelists.countryWhitelist,
     locationNames,
     activeIndicator,
     colors

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover-plantations/widget-tree-cover-plantations.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover-plantations/widget-tree-cover-plantations.js
@@ -14,21 +14,16 @@ import {
 import WidgetTreeCoverPlantationsComponent from './widget-tree-cover-plantations-component';
 
 const mapStateToProps = (
-  { widgetTreeCoverPlantations, countryData },
+  { widgetTreeCoverPlantations, countryData, whitelists },
   ownProps
 ) => {
-  const {
-    isCountriesLoading,
-    isRegionsLoading,
-    countryWhitelist,
-    regions
-  } = countryData;
+  const { isCountriesLoading, isRegionsLoading, regions } = countryData;
   const { settings, loading, data } = widgetTreeCoverPlantations;
   const { colors, locationNames, activeIndicator } = ownProps;
   const selectorData = {
     data,
     settings,
-    whitelist: countryWhitelist,
+    whitelist: whitelists.countryWhitelist,
     locationNames,
     activeIndicator,
     colors: {

--- a/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover.js
+++ b/app/javascript/pages/country/widget/widgets/widget-tree-cover/widget-tree-cover.js
@@ -8,19 +8,17 @@ import reducers, { initialState } from './widget-tree-cover-reducers';
 import { getTreeCoverData, getSentence } from './widget-tree-cover-selectors';
 import WidgetTreeCoverComponent from './widget-tree-cover-component';
 
-const mapStateToProps = ({ widgetTreeCover, countryData }, ownProps) => {
-  const {
-    isCountriesLoading,
-    isRegionsLoading,
-    countryWhitelist,
-    regions
-  } = countryData;
+const mapStateToProps = (
+  { widgetTreeCover, countryData, whitelists },
+  ownProps
+) => {
+  const { isCountriesLoading, isRegionsLoading, regions } = countryData;
   const { settings, loading, data } = widgetTreeCover;
   const { colors, locationNames, activeIndicator } = ownProps;
   const selectorData = {
     data,
     settings,
-    whitelist: countryWhitelist,
+    whitelist: whitelists.countryWhitelist,
     locationNames,
     activeIndicator,
     colors

--- a/app/javascript/services/country.js
+++ b/app/javascript/services/country.js
@@ -1,8 +1,6 @@
 import axios from 'axios';
 
 const REQUEST_URL = `${process.env.CARTO_API_URL}/sql?q=`;
-const DATASET = process.env.COUNTRIES_PAGE_DATASET;
-const WHITELIST_URL = `${process.env.GFW_API_HOST_PROD}/query/${DATASET}?sql=`;
 const CARTO_REQUEST_URL = `${process.env.CARTO_API_URL}/sql?q=`;
 
 const SQL_QUERIES = {
@@ -14,20 +12,11 @@ const SQL_QUERIES = {
     "SELECT id_1 as id, name_1 as name FROM gadm28_adm1 WHERE iso = '{iso}' ORDER BY name ",
   getSubRegions:
     "SELECT id_2 as id, name_2 as name FROM gadm28_adm2 WHERE iso = '{iso}' AND id_1 = '{admin1}' ORDER BY name",
-  getCountryWhitelist:
-    "SELECT polyname, SUM(area_extent_2000) as total_extent_2000, SUM(area_extent) as total_extent_2010, SUM(area_gain) as total_gain, SUM(year_data.area_loss) as total_loss FROM data WHERE thresh = 0 AND iso = '{iso}' GROUP BY polyname",
-  getRegionWhitelist:
-    'SELECT polyname, SUM(area_extent_2000) as total_extent_2000, SUM(area_extent) as total_extent_2010, SUM(area_gain) as total_gain, SUM(year_data.area_loss) as total_loss FROM data WHERE thresh = 0 AND {location} GROUP BY polyname',
   getCountryLinks:
     'SELECT iso, external_links FROM external_links_gfw WHERE forest_atlas is true',
   getRanking:
     "WITH mytable AS (SELECT fao.iso, fao.name, fao.forest_primary, fao.extent forest_extent, a.land as area_ha FROM gfw2_countries as fao INNER JOIN umd_nat_staging as a ON fao.iso = a.iso WHERE fao.forest_primary > 0 AND a.year = 2001 AND a.thresh = 30), rank AS ( SELECT forest_extent * (forest_primary/100)/area_ha * 100 as percent_primary ,iso from mytable ORDER BY percent_primary DESC), item as (select percent_primary from rank where iso = '{country}') select count(*) as rank from rank WHERE percent_primary > (select percent_primary from item )"
 };
-
-const getLocationQuery = (country, region, subRegion) =>
-  `iso = '${country}'${region ? ` AND adm1 = ${region}` : ''}${
-    subRegion ? ` AND adm2 = ${subRegion}` : ''
-  }`;
 
 export const getCountriesProvider = () => {
   const url = `${REQUEST_URL}${SQL_QUERIES.getCountries}`;
@@ -51,22 +40,6 @@ export const getSubRegionsProvider = (admin0, admin1) => {
   const url = `${REQUEST_URL}${SQL_QUERIES.getSubRegions}`
     .replace('{iso}', admin0)
     .replace('{admin1}', admin1);
-  return axios.get(url);
-};
-
-export const getCountryWhitelistProvider = admin0 => {
-  const url = `${WHITELIST_URL}${SQL_QUERIES.getCountryWhitelist}`.replace(
-    '{iso}',
-    admin0
-  );
-  return axios.get(url);
-};
-
-export const getRegionWhitelistProvider = (admin0, admin1, admin2) => {
-  const url = `${WHITELIST_URL}${SQL_QUERIES.getRegionWhitelist}`.replace(
-    '{location}',
-    getLocationQuery(admin0, admin1, admin2)
-  );
   return axios.get(url);
 };
 

--- a/app/javascript/services/whitelists.js
+++ b/app/javascript/services/whitelists.js
@@ -1,0 +1,39 @@
+import axios from 'axios';
+
+const DATASET = process.env.COUNTRIES_PAGE_DATASET;
+const REQUEST_URL = `${process.env.GFW_API_HOST_PROD}/query/${DATASET}?sql=`;
+const CARTO_REQUEST_URL = `${process.env.CARTO_API_URL}/sql?q=`;
+
+const SQL_QUERIES = {
+  getCountryWhitelist:
+    "SELECT polyname, SUM(area_extent_2000) as total_extent_2000, SUM(area_extent) as total_extent_2010, SUM(area_gain) as total_gain, SUM(year_data.area_loss) as total_loss FROM data WHERE thresh = 0 AND iso = '{iso}' GROUP BY polyname",
+  getRegionWhitelist:
+    'SELECT polyname, SUM(area_extent_2000) as total_extent_2000, SUM(area_extent) as total_extent_2010, SUM(area_gain) as total_gain, SUM(year_data.area_loss) as total_loss FROM data WHERE thresh = 0 AND {location} GROUP BY polyname',
+  getWaterBodiesWhitelist: 'SELECT iso, adm1, adm2 from water_bodies_gadm28'
+};
+
+const getLocationQuery = (country, region, subRegion) =>
+  `iso = '${country}'${region ? ` AND adm1 = ${region}` : ''}${
+    subRegion ? ` AND adm2 = ${subRegion}` : ''
+  }`;
+
+export const getCountryWhitelistProvider = admin0 => {
+  const url = `${REQUEST_URL}${SQL_QUERIES.getCountryWhitelist}`.replace(
+    '{iso}',
+    admin0
+  );
+  return axios.get(url);
+};
+
+export const getRegionWhitelistProvider = (admin0, admin1, admin2) => {
+  const url = `${REQUEST_URL}${SQL_QUERIES.getRegionWhitelist}`.replace(
+    '{location}',
+    getLocationQuery(admin0, admin1, admin2)
+  );
+  return axios.get(url);
+};
+
+export const getWaterBodiesBlacklistProvider = () => {
+  const url = `${CARTO_REQUEST_URL}${SQL_QUERIES.getWaterBodiesWhitelist}`;
+  return axios.get(url);
+};


### PR DESCRIPTION
## Overview

We have the unique case within the country pages that we are using gadm28 and fao data in order to find the countries list. This contains admins that are potentially bodies of water (and correctly so). However in the case of the country pages we dont want the user to be able to select these areas as the data is pretty useless in widget form. This PR adds a new blacklist of admin2 water bodies by ISO and admin1.

This is the reference table: https://wri-01.carto.com/tables/water_bodies_gadm28/public/map
You can use this for testing values.
