### PR TITLE
feature/fix-image-layer-rescale

### DIFF
--- a/app/javascript/components/map/assets/layers/abstract/image-layer.js
+++ b/app/javascript/components/map/assets/layers/abstract/image-layer.js
@@ -65,8 +65,8 @@ class ImageLayer extends Overlay {
     let tileY = y;
     let tileZ = z;
     if (z > this.options.dataMaxZoom) {
-      tileX = Math.floor(x / (2 ** z - this.options.dataMaxZoom));
-      tileY = Math.floor(y / (2 ** z - this.options.dataMaxZoom));
+      tileX = Math.floor(x / 2 ** (z - this.options.dataMaxZoom));
+      tileY = Math.floor(y / 2 ** (z - this.options.dataMaxZoom));
       tileZ = this.options.dataMaxZoom;
     } else {
       tileY = y > 2 ** z ? y % 2 ** z : y;


### PR DESCRIPTION
## Overview

Now the image layers (like forest gain layer) rescale the tile properly after zoom 12.

## Demo

![kapture 2018-02-21 at 9 52 42](https://user-images.githubusercontent.com/1432880/36471001-2b057602-16ed-11e8-8375-c11c0735d796.gif)
