### PR TITLE
Allow selection of first day in GLADS calendar

### DIFF
--- a/app/assets/javascripts/abstract/timeline/TimelineDatePicker.js
+++ b/app/assets/javascripts/abstract/timeline/TimelineDatePicker.js
@@ -199,7 +199,11 @@ define(
 
       setMinMaxDate(data) {
         const tzOffset = new Date().getTimezoneOffset() + 60;
-        this.minDate = moment.utc(data.minDate).endOf('day');
+        if (this.layer.slug === 'umd_as_it_happens') {
+          this.minDate = moment.utc(data.minDate);
+        } else {
+          this.minDate = moment.utc(data.minDate).endOf('day');
+        }
         this.maxDate = moment.utc(data.maxDate);
         const minDate = this.minDate
           .clone()


### PR DESCRIPTION
HOTFIX for glads calendar not letting user select first day of data.