### PR TITLE
Feature: improved tooltips for components

### DIFF
--- a/app/javascript/components/button/button-component.jsx
+++ b/app/javascript/components/button/button-component.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'redux-first-router-link';
+import { isTouch } from 'utils/browser';
 
 import { Tooltip } from 'react-tippy';
+import Tip from 'components/tip';
 
 import './button-styles.scss';
 import 'styles/themes/button/button-light.scss'; // eslint-disable-line
@@ -26,6 +28,7 @@ const Button = props => {
   const classNames = `c-button ${theme || ''} ${className || ''} ${
     disabled ? 'disabled' : ''
   }`;
+  const isDeviceTouch = isTouch();
   const handleClick = () => {
     if (onClick) {
       onClick();
@@ -68,7 +71,18 @@ const Button = props => {
   }
 
   if (tooltip) {
-    return <Tooltip {...tooltip}>{button}</Tooltip>;
+    return (
+      <Tooltip
+        theme="tip"
+        position="top"
+        arrow
+        disabled={isDeviceTouch}
+        html={<Tip text={tooltip.text} />}
+        {...tooltip}
+      >
+        {button}
+      </Tooltip>
+    );
   }
   return button;
 };

--- a/app/javascript/components/dropdown/dropdown-component.js
+++ b/app/javascript/components/dropdown/dropdown-component.js
@@ -1,9 +1,13 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Select from 'react-select-me';
 import { deburrUpper } from 'utils/data';
+import { isTouch } from 'utils/browser';
+
+import Select from 'react-select-me';
 import Button from 'components/button';
 import Icon from 'components/icon';
+import { Tooltip } from 'react-tippy';
+import Tip from 'components/tip';
 
 import infoIcon from 'assets/icons/info.svg';
 import arrowDownIcon from 'assets/icons/arrow-down.svg';
@@ -33,8 +37,16 @@ class Dropdown extends PureComponent {
   };
 
   render() {
-    const { theme, label, infoAction, modalOpen, modalClosing } = this.props;
-    return (
+    const {
+      theme,
+      label,
+      infoAction,
+      modalOpen,
+      modalClosing,
+      tooltip
+    } = this.props;
+    const isDeviceTouch = isTouch();
+    const dropdown = (
       <div className={`c-dropdown ${theme || 'theme-select-light'}`}>
         {label && (
           <div className="label">
@@ -65,6 +77,22 @@ class Dropdown extends PureComponent {
         />
       </div>
     );
+
+    if (tooltip) {
+      return (
+        <Tooltip
+          theme="tip"
+          position="top"
+          arrow
+          disabled={isDeviceTouch}
+          html={<Tip text={tooltip.text} />}
+          {...tooltip}
+        >
+          {dropdown}
+        </Tooltip>
+      );
+    }
+    return dropdown;
   }
 }
 
@@ -74,7 +102,8 @@ Dropdown.propTypes = {
   options: PropTypes.array,
   infoAction: PropTypes.func,
   modalOpen: PropTypes.bool,
-  modalClosing: PropTypes.bool
+  modalClosing: PropTypes.bool,
+  tooltip: PropTypes.object
 };
 
 export default Dropdown;

--- a/app/javascript/pages/country/header/header-component.js
+++ b/app/javascript/pages/country/header/header-component.js
@@ -1,13 +1,10 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { isTouch } from 'utils/browser';
 
-import { Tooltip } from 'react-tippy';
 import Dropdown from 'components/dropdown';
 import Loader from 'components/loader';
 import Icon from 'components/icon';
 import Button from 'components/button';
-import Tip from 'components/tip';
 
 import arrowDownIcon from 'assets/icons/arrow-down.svg';
 import shareIcon from 'assets/icons/share.svg';
@@ -15,6 +12,13 @@ import downloadIcon from 'assets/icons/download.svg';
 import './header-styles.scss';
 
 class Header extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      disableTooltips: false
+    };
+  }
+
   render() {
     const {
       className,
@@ -31,7 +35,7 @@ class Header extends PureComponent {
       location,
       forestAtlasLink
     } = this.props;
-    const isDeviceTouch = isTouch();
+    const { disableTooltips } = this.state;
 
     return (
       <div className={`${className} c-header`}>
@@ -47,19 +51,12 @@ class Header extends PureComponent {
               ...location
             }}
             tooltip={{
-              theme: 'tip',
-              position: 'bottom',
-              arrow: true,
-              disabled: isDeviceTouch,
-              html: (
-                <Tip
-                  text={`Download the country data${
-                    locationNames.country
-                      ? ` for ${locationNames.country.label}`
-                      : ''
-                  }`}
-                />
-              )
+              text: `Download the country data${
+                locationNames.country
+                  ? ` for ${locationNames.country.label}`
+                  : ''
+              }`,
+              position: 'bottom'
             }}
           >
             <Icon icon={downloadIcon} />
@@ -68,11 +65,8 @@ class Header extends PureComponent {
             className="theme-button-small theme-button-grey square"
             onClick={() => setShareModal(shareData)}
             tooltip={{
-              theme: 'tip',
-              position: 'bottom',
-              arrow: true,
-              disabled: isDeviceTouch,
-              html: <Tip text="Share this page" />
+              text: 'Share this page',
+              position: 'bottom'
             }}
           >
             <Icon icon={shareIcon} />
@@ -80,76 +74,99 @@ class Header extends PureComponent {
         </div>
         <div className="row">
           <div className="columns small-12 large-6">
-            <Tooltip
-              theme="tip"
-              position="top"
-              arrow
-              disabled={isDeviceTouch}
-              html={
-                <Tip text="Choose the country and region you want to explore" />
-              }
-            >
-              <div className="select-container">
-                <div className="select">
-                  <Icon icon={arrowDownIcon} className="icon" />
-                  <Dropdown
-                    theme="theme-select-dark"
-                    placeholder="Country"
-                    noItemsFound="No country found"
-                    value={locationNames.country}
-                    options={locationOptions.countries}
-                    onChange={handleCountryChange}
-                    searchable
-                    disabled={loading}
-                  />
-                </div>
-                {locationOptions.regions &&
-                  locationOptions.regions.length > 1 && (
-                    <div className="select">
-                      <Icon icon={arrowDownIcon} className="icon" />
-                      <Dropdown
-                        theme="theme-select-dark"
-                        placeholder="Region"
-                        noItemsFound="No region found"
-                        value={locationNames.region}
-                        options={locationOptions.regions}
-                        onChange={region =>
-                          handleRegionChange(locationNames.country, region)
-                        }
-                        searchable
-                        disabled={loading}
-                      />
-                    </div>
-                  )}
-                {locationNames.region &&
-                  locationNames.region.value &&
-                  locationOptions.subRegions &&
-                  locationOptions.subRegions.length > 1 && (
-                    <div className="select">
-                      <Icon
-                        icon={arrowDownIcon}
-                        className="icon c-header__select-arrow"
-                      />
-                      <Dropdown
-                        theme="theme-select-dark"
-                        placeholder="Region"
-                        noItemsFound="No region found"
-                        value={locationNames.subRegion}
-                        options={locationOptions.subRegions}
-                        onChange={subRegion =>
-                          handleSubRegionChange(
-                            locationNames.country,
-                            locationNames.region,
-                            subRegion
-                          )
-                        }
-                        searchable
-                        disabled={loading}
-                      />
-                    </div>
-                  )}
+            <div className="select-container">
+              <div className="select">
+                <Icon icon={arrowDownIcon} className="icon" />
+                <Dropdown
+                  theme="theme-select-dark"
+                  placeholder="Country"
+                  noItemsFound="No country found"
+                  value={locationNames.country}
+                  options={locationOptions.countries}
+                  onChange={handleCountryChange}
+                  searchable
+                  disabled={loading}
+                  tooltip={{
+                    text: 'Choose the country you want to explore',
+                    delay: 1000,
+                    disabled: disableTooltips
+                  }}
+                  onOpen={() => {
+                    this.setState({ disableTooltips: true });
+                  }}
+                  onClose={() => {
+                    this.setState({ disableTooltips: false });
+                  }}
+                />
               </div>
-            </Tooltip>
+              {locationOptions.regions &&
+                locationOptions.regions.length > 1 && (
+                  <div className="select">
+                    <Icon icon={arrowDownIcon} className="icon" />
+                    <Dropdown
+                      theme="theme-select-dark"
+                      placeholder="Region"
+                      noItemsFound="No region found"
+                      value={locationNames.region}
+                      options={locationOptions.regions}
+                      onChange={region =>
+                        handleRegionChange(locationNames.country, region)
+                      }
+                      searchable
+                      disabled={loading}
+                      tooltip={{
+                        text: 'Choose the region you want to explore',
+                        delay: 1000,
+                        disabled: disableTooltips
+                      }}
+                      onOpen={() => {
+                        this.setState({ disableTooltips: true });
+                      }}
+                      onClose={() => {
+                        this.setState({ disableTooltips: false });
+                      }}
+                    />
+                  </div>
+                )}
+              {locationNames.region &&
+                locationNames.region.value &&
+                locationOptions.subRegions &&
+                locationOptions.subRegions.length > 1 && (
+                  <div className="select">
+                    <Icon
+                      icon={arrowDownIcon}
+                      className="icon c-header__select-arrow"
+                    />
+                    <Dropdown
+                      theme="theme-select-dark"
+                      placeholder="Region"
+                      noItemsFound="No region found"
+                      value={locationNames.subRegion}
+                      options={locationOptions.subRegions}
+                      onChange={subRegion =>
+                        handleSubRegionChange(
+                          locationNames.country,
+                          locationNames.region,
+                          subRegion
+                        )
+                      }
+                      searchable
+                      disabled={loading}
+                      tooltip={{
+                        text: 'Choose the region you want to explore',
+                        delay: 1000,
+                        disabled: disableTooltips
+                      }}
+                      onOpen={() => {
+                        this.setState({ disableTooltips: true });
+                      }}
+                      onClose={() => {
+                        this.setState({ disableTooltips: false });
+                      }}
+                    />
+                  </div>
+                )}
+            </div>
           </div>
           <div className="columns large-6 medium-12 small-12">
             <div className="description text -title-xs">


### PR DESCRIPTION
Improves the use of tooltips in buttons and dropdowns. Now both can accept a much simpler tooltip object:
``` { text: "my excellent message" }```

However if you would like more customisation then you can pass any option from react tippy props as well:
``` { text: "my message", delay: 3000 }```

This was to reduce the importing of the Tip component throughout the project when its application was always the same.

In addition a tooltip has been added for the Dropdown component to allow the header section of the dashboard to have individual tooltips without extra code.

FINALLY, I also added a state prop which prevent tooltips from being shown in the header when a dropdown is open. This makes the user a lot happier I think.