### PR TITLE
Updates FAO extent query to include countries with no primary forest

### DIFF
--- a/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-fao-cover/widget-fao-cover-selectors.js
@@ -22,7 +22,7 @@ export const getFAOCoverData = createSelector(
     } = data;
     const colorRange = getColorPalette(colors.ramp, 3);
     const naturallyRegenerated = extent / 100 * forest_regenerated;
-    const primaryForest = extent / 100 * forest_primary;
+    const primaryForest = forest_primary ? extent / 100 * forest_primary : 0;
     const plantedForest = extent / 100 * forest_planted;
     const nonForest =
       area_ha - (naturallyRegenerated + primaryForest + plantedForest);
@@ -64,15 +64,18 @@ export const getSentence = createSelector(
     const { area_ha, extent, forest_primary } = data;
     const primaryForest = extent / 100 * forest_primary;
     const sentence = `FAO data from 2015 shows that <strong>${locationNames.current &&
-      locationNames.current.label}</strong> contains ${
+      locationNames.current.label}</strong> contains <strong>${format('.3s')(
+      extent
+    )}Ha</strong> of forest, ${
       primaryForest > 0
-        ? ` <strong>${format('.3s')(
-          extent
-        )}Ha</strong> of forest, with Primary forest occupying 
+        ? ` with Primary forest occupying 
         <strong>${format('.1f')(
     primaryForest / area_ha * 100
   )}%</strong> of the country.`
-        : ''
+        : ` which occupies 
+        <strong>${format('.1f')(
+    extent / area_ha * 100
+  )}%</strong> of the country.`
     }`;
     return sentence;
   }

--- a/app/javascript/services/forest-data.js
+++ b/app/javascript/services/forest-data.js
@@ -24,7 +24,7 @@ const SQL_QUERIES = {
   locationsLoss:
     "SELECT {select} AS region, year_data.year as year, SUM(year_data.area_loss) as area_loss, FROM data WHERE polyname = '{indicator}' AND iso = '{iso}' {region} AND thresh= {threshold} GROUP BY {group}, nested(year_data.year) ORDER BY {order}",
   fao:
-    "SELECT fao.iso, fao.name, forest_planted, forest_primary, forest_regenerated, fao.forest_primary, fao.extent, a.land as area_ha FROM gfw2_countries as fao INNER JOIN umd_nat_staging as a ON fao.iso = a.iso WHERE fao.forest_primary is not null AND fao.iso = '{country}' AND a.year = 2001 AND a.thresh = 30",
+    "SELECT fao.iso, fao.name, forest_planted, forest_primary, forest_regenerated, fao.forest_primary, fao.extent, a.land as area_ha FROM gfw2_countries as fao INNER JOIN umd_nat_staging as a ON fao.iso = a.iso WHERE fao.iso = '{country}' AND a.year = 2001 AND a.thresh = 30",
   faoExtent:
     'SELECT country AS iso, name, year, reforest AS rate, forest*1000 AS extent FROM table_1_forest_area_and_characteristics as fao WHERE fao.year = {period} AND reforest > 0 ORDER BY rate DESC',
   faoDeforest:


### PR DESCRIPTION
## Overview
Previously we were excluding countries which had no Primary Forest data in the fao table. That meant that the FAO extent widget used to look like this:

<img width="369" alt="screen shot 2018-03-01 at 11 47 34" src="https://user-images.githubusercontent.com/30242314/36840787-90490100-1d46-11e8-948f-c3eedaa0fffb.png">

The Irish were sad.

Now we accept data from all countries, whether they had Primary Forests or now. We don't discriminate. Instead, we handle null data on the front end so that the widget now looks like this:

<img width="412" alt="screen shot 2018-03-01 at 11 42 22" src="https://user-images.githubusercontent.com/30242314/36840862-cc87e76c-1d46-11e8-9f63-96dc598235ed.png">

_You're welcome_, Ireland.

## Test

Please test! I will compile a list of countries without Primary forests in the fao data and stick it here shortly...

EDIT: here's the list

{'COL', 'CMR', 'EGY', 'JEY', 'GGY', 'FRA', 'MAF', 'UNK', 'KEN', 'PSE', 'MTQ', 'ABW', 'GNQ', 'SSD', 'ISR', 'AFG', 'YEM', 'TLS', 'TWN', 'DOM', 'GIB', 'BFA', 'ETH', 'CUB', 'MAC', 'MAR', 'SWZ', 'TZA', 'BEN', 'BES', 'AIA', 'BMU', 'DEU', 'LSO', 'BLM', 'HTI', 'CYM', 'UMI', 'KAZ', 'NAM', 'VUT', 'GNB', 'IMN', 'TCD', 'LBY', 'ATG', 'BEL', 'VCT', 'LBN', 'ESH', 'IRQ', 'MUS', 'AGO', 'UGA', 'CPV', 'BHS', 'DZA', 'MRT', 'LUX', 'SXM', 'CUW', 'MLT', 'BWA', 'MDA', 'PRI', 'MLI', 'AND', 'SPM', 'TUN', 'NLD', 'MDV', 'PAN', 'HUN', 'GRC', 'TGO', 'ESP', 'ERI', 'IRL', 'SOM', 'MSR', 'JOR', 'PAK', 'ARE', 'OMN', 'MKD', 'SMR', 'PLW', 'MOZ', 'ZMB', 'HKG'}