### PR TITLE
Fixes getLocationsLoss query

### DIFF
--- a/app/javascript/services/forest-data.js
+++ b/app/javascript/services/forest-data.js
@@ -72,7 +72,7 @@ export const getLocationsLoss = ({ country, region, indicator, threshold }) => {
     .replace('{group}', region ? 'adm2' : 'adm1')
     .replace('{order}', region ? 'adm2' : 'adm1')
     .replace('{iso}', country)
-    .replace('{region}', region ? `AND adm1 = ${region} AS region` : '')
+    .replace('{region}', region ? `AND adm1 = ${region}` : '')
     .replace('{threshold}', threshold)
     .replace('{indicator}', indicator);
   return axios.get(url);


### PR DESCRIPTION
## Overview

There was an issue in that the *'Where is Forest Loss Located?'* was reporting larger loss in adm2 regions than was found in the entire adm1 supra-region!

This was due to a small bug in the way the aggregated loss query was formed, which had now been fixed!

## Testing

As always, please test!
- Check the values [here](http://www.globalforestwatch.org/country/IDN/24?widget=lossLocated#lossLocated)
- Check that they match for the total reported in each adm2 region [here](http://www.globalforestwatch.org/country/IDN/24/301?widget=treeLoss#treeLoss)
- Are they consistent (e.g.**947kha** =/= **120kha** in this case... but should be fixed in local)
