### PR TITLE
fix/modal-meta-dependency

### DIFF
--- a/app/javascript/components/dropdown/dropdown.js
+++ b/app/javascript/components/dropdown/dropdown.js
@@ -19,8 +19,8 @@ const mapStateToProps = (
   const activeLabel = (activeValue && activeValue.label) || noSelectedValue;
 
   return {
-    modalOpen: modalMeta.open,
-    modalClosing: modalMeta.closing,
+    modalOpen: modalMeta ? modalMeta.open : false,
+    modalClosing: modalMeta ? modalMeta.closing : false,
     isDeviceTouch: isTouch(),
     activeValue,
     activeLabel


### PR DESCRIPTION
## Overview

If you use the `<Dropdown>` component without the `<ModalMeta>` component, the page breaks.