### PR TITLE
Fix/cross browser grid

### DIFF
--- a/app/javascript/components/dropdown/dropdown-component.jsx
+++ b/app/javascript/components/dropdown/dropdown-component.jsx
@@ -52,7 +52,7 @@ class Dropdown extends PureComponent {
         onOuterClick={checkModalClosing}
         {...this.props}
       >
-        {({ getInputProps, getItemProps, getRootProps, clearSelection }) => (
+        {({ getInputProps, getItemProps, getRootProps }) => (
           <Selector
             isOpen={isOpen}
             arrowPosition={arrowPosition}
@@ -62,7 +62,7 @@ class Dropdown extends PureComponent {
             activeLabel={activeLabel}
             searchable={searchable}
             inputProps={() => buildInputProps(getInputProps)}
-            handleClearSelection={() => handleClearSelection(clearSelection)}
+            handleClearSelection={() => handleClearSelection()}
             {...getRootProps({ refKey: 'innerRef' })}
           >
             <Menu

--- a/app/javascript/components/dropdown/dropdown.js
+++ b/app/javascript/components/dropdown/dropdown.js
@@ -106,8 +106,9 @@ class DropdownContainer extends PureComponent {
     this.setState({ isOpen: !isOpen, inputValue: '' });
   };
 
-  handleClearSelection = clearSelection => {
-    clearSelection();
+  handleClearSelection = () => {
+    const { onChange } = this.props;
+    onChange();
     this.setState({ isOpen: false, showGroup: '' });
   };
 
@@ -173,7 +174,8 @@ DropdownContainer.propTypes = {
   searchable: PropTypes.bool,
   options: PropTypes.array,
   groupKey: PropTypes.string,
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
+  onChange: PropTypes.func
 };
 
 export default connect(mapStateToProps, null)(DropdownContainer);

--- a/app/javascript/pages/country/root/root-styles.scss
+++ b/app/javascript/pages/country/root/root-styles.scss
@@ -15,7 +15,8 @@ $right-panel-width: calc((#{$max-width} * 0.3) + ((100vw - #{$max-width}) / 2));
   .content-panel {
     display: flex;
     flex-direction: column;
-    align-items: flex-end;
+    align-items: flex-start;
+    height: 100%;
   }
 
   .map-panel {
@@ -88,6 +89,7 @@ $right-panel-width: calc((#{$max-width} * 0.3) + ((100vw - #{$max-width}) / 2));
   .widgets {
     position: relative;
     display: grid;
+    height: 100%;
     grid-template-columns: 1fr;
     grid-gap: 30px;
     grid-auto-flow: dense;


### PR DESCRIPTION
Hotfix for small bug in Safari. When viewing certain widgets they would spill over the total height of the container.

BONUS: selector were not clearing every click on the new selector. Now they do.