### PR TITLE
Feature/new analysis endpoint

### DIFF
--- a/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
+++ b/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * The AnalysisResultsPresenter class for the AnalysisResultsView.
  *
@@ -31,7 +32,7 @@ define(
        */
       _subscriptions: [
         {
-          'Place/go': function (place) {
+          'Place/go': function(place) {
             const params = place.params;
             this.status.set(
               'baselayers_full',
@@ -41,14 +42,14 @@ define(
           }
         },
         {
-          'LayerNav/change': function (layerSpec) {
+          'LayerNav/change': function(layerSpec) {
             this.status.set('baselayers_full', layerSpec.getBaselayers(), {
               silent: true
             });
           }
         },
         {
-          'Analysis/results': function (status) {
+          'Analysis/results': function(status) {
             this.status.set(status, { silent: true });
             this.status.set(
               {
@@ -64,7 +65,7 @@ define(
           }
         },
         {
-          'Analysis/results-error': function (status) {
+          'Analysis/results-error': function(status) {
             this.status.set(status, { silent: true });
             this.view.renderError();
           }
@@ -143,14 +144,12 @@ define(
          * Exceptions
          */
         if (p.slug === 'umd-loss-gain') {
-          var results = type == 'country' ? results.total : results;
+          var results = type == 'country' ? results.totals : results;
           p.areaHa = this.roundNumber(results.areaHa || 0);
           p.alerts.totalAlerts = this.roundNumber(results.loss || 0);
           p.alerts.gainAlerts = this.roundNumber(results.gain || 0);
-          p.alerts.treeExtent = this.roundNumber(results.treeExtent || 0);
-          p.alerts.treeExtent2010 = this.roundNumber(
-            results.treeExtent2010 || 0
-          );
+          p.alerts.treeExtent = this.roundNumber(results.extent2000 || 0);
+          p.alerts.treeExtent2010 = this.roundNumber(results.extent2010 || 0);
 
           // Dates
           p.dates.lossDateRange = '{0}-{1}'.format(

--- a/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
+++ b/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
@@ -76,9 +76,14 @@ define(
         const iso = this.status.get('iso');
 
         // Get regions if analysis has country
-        !!iso.country && iso.country != 'ALL'
-          ? this.getRegions()
-          : this.view.render();
+        if (!!iso.country && iso.country != 'ALL') {
+          this.getRegions();
+          if (!!iso.region) {
+            this.getSubRegions();
+          }
+        } else {
+          this.view.render();
+        }
       },
 
       getRegions() {
@@ -87,6 +92,20 @@ define(
         CountryService.getRegionsList({ iso: iso.country }).then(results => {
           this.status.set({
             regions: results
+          });
+          this.view.render();
+        });
+      },
+
+      getSubRegions() {
+        const iso = this.status.get('iso');
+
+        CountryService.getSubRegionsList({
+          iso: iso.country,
+          region: iso.region
+        }).then(results => {
+          this.status.set({
+            subRegions: results
           });
           this.view.render();
         });

--- a/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
+++ b/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
@@ -51,17 +51,22 @@ define(
         {
           'Analysis/results': function(status) {
             this.status.set(status, { silent: true });
-            this.status.set(
-              {
-                resource: _.clone(this.setAnalysisResource())
-              },
-              {
-                silent: true
-              }
-            );
+            if (!status.results) {
+              this.publishNotification('notification-empty-analysis');
+              this.view.renderError();
+            } else {
+              this.status.set(
+                {
+                  resource: _.clone(this.setAnalysisResource())
+                },
+                {
+                  silent: true
+                }
+              );
 
-            // Trigger change always
-            this.changeResource();
+              // Trigger change always
+              this.changeResource();
+            }
           }
         },
         {

--- a/app/assets/javascripts/map/presenters/tabs/AnalysisNewPresenter.js
+++ b/app/assets/javascripts/map/presenters/tabs/AnalysisNewPresenter.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * The AnalysisNewPresenter class for the AnalysisToolView.
  *
@@ -59,7 +60,8 @@ define(
           // Country
           iso: {
             country: null,
-            region: null
+            region: null,
+            subRegion: null
           },
           isoDisabled: false,
 
@@ -304,7 +306,7 @@ define(
       _subscriptions: [
         // GLOBAL EVENTS
         {
-          'Place/go': function (place) {
+          'Place/go': function(place) {
             const params = place.params;
             const layerSpec = place.layerSpec;
 
@@ -312,7 +314,8 @@ define(
               // Countries
               iso: {
                 country: params.iso.country,
-                region: params.iso.region
+                region: params.iso.region,
+                subRegion: params.iso.subRegion
               },
               // Check if param exists, if it doesn't check if country exists and it isn't equal to 'ALL'
               isoDisabled:
@@ -351,7 +354,7 @@ define(
           }
         },
         {
-          'LayerNav/change': function (layerSpec) {
+          'LayerNav/change': function(layerSpec) {
             const currentBaselayers = this.status.get('baselayers');
             const newBaselayers = _.keys(layerSpec.getBaselayers());
 
@@ -365,29 +368,29 @@ define(
           }
         },
         {
-          'LayerNav/changeLayerOptions': function (layerOptions) {
+          'LayerNav/changeLayerOptions': function(layerOptions) {
             this.status.set('layerOptions', _.clone(layerOptions));
           }
         },
         {
-          'Threshold/update': function (threshold) {
+          'Threshold/update': function(threshold) {
             this.status.set('threshold', threshold);
           }
         },
 
         // DRAWING EVENTS
         {
-          'Analysis/start-drawing': function () {
+          'Analysis/start-drawing': function() {
             this.status.set('isDrawing', true);
           }
         },
         {
-          'Analysis/stop-drawing': function () {
+          'Analysis/stop-drawing': function() {
             this.status.set('isDrawing', false);
           }
         },
         {
-          'Analysis/geojson': function (geojson) {
+          'Analysis/geojson': function(geojson) {
             if (geojson) {
               this.status.set('spinner', true);
               GeostoreService.save(geojson).then(geostoreId => {
@@ -404,7 +407,7 @@ define(
 
         // COUNTRY EVENTS
         {
-          'Analysis/iso': function (iso, isoDisabled) {
+          'Analysis/iso': function(iso, isoDisabled) {
             this.status.set({
               iso,
               isoDisabled
@@ -412,7 +415,7 @@ define(
           }
         },
         {
-          'Subscribe/iso': function (iso) {
+          'Subscribe/iso': function(iso) {
             let subscritionObj = {};
             subscritionObj = {
               iso,
@@ -429,7 +432,7 @@ define(
 
         // SHAPE
         {
-          'Analysis/shape': function (data) {
+          'Analysis/shape': function(data) {
             this.status.set({
               useid: data.useid,
               use: data.use,
@@ -438,7 +441,7 @@ define(
           }
         },
         {
-          'Subscribe/shape': function (data) {
+          'Subscribe/shape': function(data) {
             let subscritionObj = {};
 
             if (!!data.use && this.usenames.indexOf(data.use) === -1) {
@@ -453,7 +456,8 @@ define(
                 subscritionObj = {
                   iso: {
                     country: null,
-                    region: null
+                    region: null,
+                    subRegion: null
                   },
                   geostore: useGeostoreId,
                   useid: null,
@@ -469,7 +473,8 @@ define(
               subscritionObj = {
                 iso: {
                   country: null,
-                  region: null
+                  region: null,
+                  subRegion: null
                 },
                 geostore: null,
                 useid: data.useid,
@@ -484,14 +489,14 @@ define(
           }
         },
         {
-          'Analysis/shape-enableds': function () {
+          'Analysis/shape-enableds': function() {
             this.publishEnableds();
           }
         },
 
         // TIMELINE
         {
-          'Timeline/date-change': function (layerSlug, date) {
+          'Timeline/date-change': function(layerSlug, date) {
             const dateFormat = 'YYYY-MM-DD';
             var date = date.map(date => moment(date).format(dateFormat));
 
@@ -502,7 +507,7 @@ define(
           }
         },
         {
-          'Torque/date-range-change': function (date) {
+          'Torque/date-range-change': function(date) {
             const dateFormat = 'YYYY-MM-DD';
             var date = date.map(date => moment(date).format(dateFormat));
 
@@ -513,61 +518,61 @@ define(
           }
         },
         {
-          'Timeline/start-playing': function () {
+          'Timeline/start-playing': function() {
             this.status.set('enabledUpdating', false);
           }
         },
         {
-          'Timeline/stop-playing': function () {
+          'Timeline/stop-playing': function() {
             this.status.set('enabledUpdating', true);
           }
         },
 
         // GLOBAL ANALYSIS EVENTS
         {
-          'Analysis/toggle': function (toggle) {
+          'Analysis/toggle': function(toggle) {
             this.status.set('mobileEnabled', toggle);
           }
         },
         {
-          'Subscribe/toggle': function (toggle) {
+          'Subscribe/toggle': function(toggle) {
             this.status.set('subscribe', !!toggle);
           }
         },
         {
-          'Analysis/subtab': function (subtab) {
+          'Analysis/subtab': function(subtab) {
             this.status.set('subtab', subtab);
           }
         },
         {
-          'Analysis/active': function (active) {
+          'Analysis/active': function(active) {
             this.status.set('active', active);
           }
         },
         {
-          'Analysis/type': function (type) {
+          'Analysis/type': function(type) {
             this.status.set('type', type);
           }
         },
         {
-          'Analysis/refresh': function () {
+          'Analysis/refresh': function() {
             this.publishAnalysis();
           }
         },
         {
-          'Analysis/delete': function (options) {
+          'Analysis/delete': function(options) {
             this.deleteAnalysis(options);
           }
         },
 
         // DIALOGS
         {
-          'Dialogs/close': function () {
+          'Dialogs/close': function() {
             this.status.set('mobileEnabled', false);
           }
         },
         {
-          'Layers/toggle': function () {
+          'Layers/toggle': function() {
             this.status.set('mobileEnabled', false);
           }
         }
@@ -879,7 +884,8 @@ define(
                 'iso',
                 {
                   country: null,
-                  region: null
+                  region: null,
+                  subRegion: null
                 },
                 options
               );

--- a/app/assets/javascripts/map/services/AnalysisNewService.js
+++ b/app/assets/javascripts/map/services/AnalysisNewService.js
@@ -125,7 +125,6 @@ define(
       },
 
       getApiHost: function(dataset) {
-        debugger;
         return dataset === 'umd-loss-gain' ? APIURLV2 : APIURL;
       },
 

--- a/app/assets/javascripts/map/services/AnalysisNewService.js
+++ b/app/assets/javascripts/map/services/AnalysisNewService.js
@@ -113,6 +113,7 @@ define(
           {
             country: status.iso.country,
             region: status.iso.region,
+            subRegion: status.iso.subRegion,
             thresh: status.threshold,
             period: period,
 

--- a/app/assets/javascripts/map/services/AnalysisNewService.js
+++ b/app/assets/javascripts/map/services/AnalysisNewService.js
@@ -1,112 +1,145 @@
-define([
-  'Class',
-  'uri',
-  'bluebird',
-  'helpers/geojsonUtilsHelper',
-  'map/services/GeostoreService',
-  'map/services/DataService'
-], function(Class, UriTemplate, Promise, geojsonUtilsHelper, GeostoreService, ds) {
+/* eslint-disable */
+define(
+  [
+    'Class',
+    'uri',
+    'bluebird',
+    'helpers/geojsonUtilsHelper',
+    'map/services/GeostoreService',
+    'map/services/DataService'
+  ],
+  function(
+    Class,
+    UriTemplate,
+    Promise,
+    geojsonUtilsHelper,
+    GeostoreService,
+    ds
+  ) {
+    'use strict';
 
-  'use strict';
+    var GET_REQUEST_ID = 'AnalysisService:get';
 
-  var GET_REQUEST_ID = 'AnalysisService:get';
+    var APIURL = window.gfw.config.GFW_API_HOST_NEW_API;
+    var APIURLV2 = window.gfw.config.GFW_API_HOST_API_V2;
 
-  var APIURL = window.gfw.config.GFW_API_HOST_NEW_API;
+    var APIURLS = {
+      draw: '/{dataset}{?geostore,period,thresh,gladConfirmOnly}',
+      country:
+        '/{dataset}/admin{/country}{/region}{/subRegion}{?period,thresh,gladConfirmOnly}',
+      wdpaid: '/{dataset}/wdpa{/wdpaid}{?period,thresh,gladConfirmOnly}',
+      use: '/{dataset}/use{/use}{/useid}{?period,thresh,gladConfirmOnly}',
+      'use-geostore': '/{dataset}{?geostore,period,thresh,gladConfirmOnly}'
+    };
 
-  var APIURLS = {
-    'draw'         : '/{dataset}{?geostore,period,thresh,gladConfirmOnly}',
-    'country'      : '/{dataset}/admin{/country}{/region}{?period,thresh,gladConfirmOnly}',
-    'wdpaid'       : '/{dataset}/wdpa{/wdpaid}{?period,thresh,gladConfirmOnly}',
-    'use'          : '/{dataset}/use{/use}{/useid}{?period,thresh,gladConfirmOnly}',
-    'use-geostore' : '/{dataset}{?geostore,period,thresh,gladConfirmOnly}',
-  };
+    var AnalysisService = Class.extend({
+      get: function(status) {
+        return new Promise(
+          function(resolve, reject) {
+            this.analysis = this.buildAnalysisFromStatus(status);
+            this.apiHost = this.getApiHost(this.analysis.dataset);
+            this.getUrl().then(
+              function(data) {
+                ds.define(GET_REQUEST_ID, {
+                  cache: false,
+                  url: this.apiHost + data.url,
+                  type: 'GET',
+                  dataType: 'json',
+                  decoder: function(data, status, xhr, success, error) {
+                    if (status === 'success') {
+                      success(data, xhr);
+                    } else if (status === 'fail' || status === 'error') {
+                      error(xhr.responseText);
+                    } else if (status !== 'abort') {
+                      error(xhr.responseText);
+                    }
+                  }
+                });
 
-  var AnalysisService = Class.extend({
+                var requestConfig = {
+                  resourceId: GET_REQUEST_ID,
+                  success: function(response, status) {
+                    resolve(response, status);
+                  }.bind(this),
+                  error: function(errors) {
+                    reject(errors);
+                  }.bind(this)
+                };
 
-    get: function(status) {
-      return new Promise(function(resolve, reject) {
-        this.analysis = this.buildAnalysisFromStatus(status);
-        this.getUrl().then(function(data) {
+                this.abortRequest();
+                this.currentRequest = ds.request(requestConfig);
+              }.bind(this)
+            );
+          }.bind(this)
+        );
+      },
 
-          ds.define(GET_REQUEST_ID, {
-            cache: false,
-            url: APIURL + data.url,
-            type: 'GET',
-            dataType: 'json',
-            decoder: function ( data, status, xhr, success, error ) {
-              if ( status === "success" ) {
-                success( data, xhr );
-              } else if ( status === "fail" || status === "error" ) {
-                error(xhr.responseText);
-              } else if ( status !== "abort") {
-                error(xhr.responseText);
-              }
-            }
-          });
+      getUrl: function() {
+        return new Promise(
+          function(resolve, reject) {
+            resolve({
+              url: UriTemplate(APIURLS[this.analysis.type]).fillFromObject(
+                this.analysis
+              )
+            });
+          }.bind(this)
+        );
+      },
 
-          var requestConfig = {
-            resourceId: GET_REQUEST_ID,
-            success: function(response, status) {
-              resolve(response, status);
-            }.bind(this),
-            error: function(errors) {
-              reject(errors);
-            }.bind(this)
-          };
-
-          this.abortRequest();
-          this.currentRequest = ds.request(requestConfig);
-        }.bind(this));
-
-      }.bind(this));
-    },
-
-    getUrl: function() {
-      return new Promise(function(resolve, reject) {
-        resolve({
-          url: UriTemplate(APIURLS[this.analysis.type]).fillFromObject(this.analysis)
+      buildAnalysisFromStatus: function(status) {
+        // To allow layerOptions
+        // I really think that this should be an object instead of an array, or an array of objects
+        var layerOptions = {};
+        _.each(status.layerOptions, function(val) {
+          layerOptions[val] = true;
         });
-      }.bind(this));
-    },
 
-    buildAnalysisFromStatus: function(status) {
-      // To allow layerOptions
-      // I really think that this should be an object instead of an array, or an array of objects
-      var layerOptions = {};
-      _.each(status.layerOptions, function(val) {
-        layerOptions[val] = true;
-      });
+        // TEMP
+        var period = status.begin + ',' + status.end;
+        if (status.dataset === 'umd-loss-gain') {
+          period =
+            status.begin +
+            ',' +
+            moment
+              .utc(status.end)
+              .subtract(1, 'days')
+              .format('YYYY-MM-DD');
+        }
 
-      // TEMP
-      var period = status.begin + ',' + status.end;
-      if (status.dataset === "umd-loss-gain") {
-        period = status.begin + ',' + moment.utc(status.end).subtract(1, 'days').format('YYYY-MM-DD');
+        return _.extend(
+          {},
+          status,
+          layerOptions,
+          {
+            country: status.iso.country,
+            region: status.iso.region,
+            thresh: status.threshold,
+            period: period,
+
+            // If a userGeostore exists we need to set geostore and type manually
+            geostore: status.useGeostore ? status.useGeostore : status.geostore,
+            type: status.useGeostore ? 'use-geostore' : status.type
+          },
+          layerOptions
+        );
+      },
+
+      getApiHost: function(dataset) {
+        debugger;
+        return dataset === 'umd-loss-gain' ? APIURLV2 : APIURL;
+      },
+
+      /**
+       * Abort the current request if it exists.
+       */
+      abortRequest: function() {
+        if (this.currentRequest) {
+          this.currentRequest.abort();
+          this.currentRequest = null;
+        }
       }
+    });
 
-      return _.extend({}, status, layerOptions, {
-        country: status.iso.country,
-        region: status.iso.region,
-        thresh: status.threshold,
-        period: period,
-
-        // If a userGeostore exists we need to set geostore and type manually
-        geostore: (status.useGeostore) ? status.useGeostore : status.geostore,
-        type: (status.useGeostore) ? 'use-geostore' : status.type
-      }, layerOptions);
-    },
-
-    /**
-     * Abort the current request if it exists.
-     */
-    abortRequest: function() {
-      if (this.currentRequest) {
-        this.currentRequest.abort();
-        this.currentRequest = null;
-      }
-    }
-
-  });
-
-  return new AnalysisService();
-
-});
+    return new AnalysisService();
+  }
+);

--- a/app/assets/javascripts/map/services/PlaceService.js
+++ b/app/assets/javascripts/map/services/PlaceService.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * The PlaceService class manages places in the application.
  *
@@ -44,203 +45,215 @@
  *
  * @return {PlaceService} The PlaceService class
  */
-define([
-  'underscore',
-  'mps',
-  'uri',
-  'map/presenters/PresenterClass',
-  'map/services/LayerSpecService'
-], function (_, mps, UriTemplate, PresenterClass, layerSpecService) {
+define(
+  [
+    'underscore',
+    'mps',
+    'uri',
+    'map/presenters/PresenterClass',
+    'map/services/LayerSpecService'
+  ],
+  function(_, mps, UriTemplate, PresenterClass, layerSpecService) {
+    'use strict';
 
-  'use strict';
+    var urlDefaultsParams = {
+      baselayers: 'loss,forestgain,forest2000',
+      zoom: 3,
+      lat: 15,
+      lng: 27,
+      maptype: 'grayscale',
+      iso: 'ALL',
+      lang: null
+    };
 
-  var urlDefaultsParams = {
-    baselayers: 'loss,forestgain,forest2000',
-    zoom: 3,
-    lat: 15,
-    lng: 27,
-    maptype: 'grayscale',
-    iso: 'ALL',
-    lang: null
-  };
+    var PlaceService = PresenterClass.extend({
+      _uriTemplate:
+        '{name}{/zoom}{/lat}{/lng}{/iso}{/maptype}{/baselayers}{/sublayers}{?tab,fit_to_geom,geojson,geostore,wdpaid,begin,end,threshold,dont_analyze,hresolution,tour,subscribe,use,useid,layer_options,lang}',
 
-  var PlaceService = PresenterClass.extend({
+      /**
+       * Create new PlaceService with supplied Backbone.Router.
+       *
+       * @param  {Backbond.Router} router Instance of Backbone.Router
+       */
+      init: function(router) {
+        this.router = router;
+        this._presenters = [];
+        this._name = null;
+        this._presenters.push(layerSpecService); // this makes the test fail
+        this._super();
+      },
 
-    _uriTemplate: '{name}{/zoom}{/lat}{/lng}{/iso}{/maptype}{/baselayers}{/sublayers}{?tab,fit_to_geom,geojson,geostore,wdpaid,begin,end,threshold,dont_analyze,hresolution,tour,subscribe,use,useid,layer_options,lang}',
+      /**
+       * Subscribe to application events.
+       */
+      _subscriptions: [
+        {
+          'Place/register': function(presenter) {
+            this._presenters = _.union(this._presenters, [presenter]);
+          }
+        },
+        {
+          'Place/update': function() {
+            this._updatePlace();
+          }
+        }
+      ],
 
-    /**
-     * Create new PlaceService with supplied Backbone.Router.
-     *
-     * @param  {Backbond.Router} router Instance of Backbone.Router
-     */
-    init: function(router) {
-      this.router = router;
-      this._presenters = [];
-      this._name = null;
-      this._presenters.push(layerSpecService); // this makes the test fail
-      this._super();
-    },
+      /**
+       * Init by the router to set the name
+       * and publish the first place.
+       *
+       * @param  {String} name   Place name
+       * @param  {Object} params Url params
+       */
+      initPlace: function(name, params) {
+        this._name = name;
+        this._newPlace(params);
+      },
 
-    /**
-     * Subscribe to application events.
-     */
-    _subscriptions: [{
-      'Place/register': function(presenter) {
-        this._presenters = _.union(this._presenters, [presenter]);
+      /**
+       * Silently updates the url from the presenter params.
+       */
+      _updatePlace: function() {
+        var route, params;
+        params = this._destandardizeParams(
+          this._getPresenterParams(this._presenters)
+        );
+
+        route = this._getRoute(params);
+        this.router.navigateTo(route, { silent: true });
+      },
+
+      /**
+       * Handles a new place.
+       *
+       * @param  {Object}  params The place parameters
+       */
+      _newPlace: function(params) {
+        var where,
+          place = {};
+
+        place.params = this._standardizeParams(params);
+
+        where = _.union(place.params.baselayers, place.params.sublayers);
+
+        layerSpecService.toggle(
+          where,
+          _.bind(function(layerSpec) {
+            place.layerSpec = layerSpec;
+            mps.publish('Place/go', [place]);
+          }, this)
+        );
+      },
+
+      /**
+       * Return route URL for supplied route name and route params.
+       *
+       * @param  {Object} params The route params
+       * @return {string} The route URL
+       */
+      _getRoute: function(params) {
+        var url = new UriTemplate(this._uriTemplate).fillFromObject(params);
+        return decodeURIComponent(url);
+      },
+
+      /**
+       * Return standardized representation of supplied params object.
+       *
+       * @param  {Object} params The params to standardize
+       * @return {Object} The standardized params.
+       */
+      _standardizeParams: function(params) {
+        var p = _.extendNonNull({}, urlDefaultsParams, params);
+        p.name = this._name;
+
+        p.baselayers = _.map(p.baselayers.split(','), function(slug) {
+          return { slug: slug };
+        });
+
+        p.sublayers = p.sublayers
+          ? _.map(p.sublayers.split(','), function(id) {
+              return { id: _.toNumber(id) };
+            })
+          : [];
+
+        p.zoom = _.toNumber(p.zoom);
+        p.lat = _.toNumber(p.lat);
+        p.lng = _.toNumber(p.lng);
+        p.iso = _.object(['country', 'region', 'subRegion'], p.iso.split('-'));
+        p.begin = p.begin ? p.begin.format('YYYY-MM-DD') : null;
+        p.end = p.end ? p.end.format('YYYY-MM-DD') : null;
+        p.geostore = p.geostore ? p.geostore : null;
+        p.wdpaid = p.wdpaid ? _.toNumber(p.wdpaid) : null;
+        p.threshold = p.threshold ? _.toNumber(p.threshold) : null;
+        p.dont_analyze = p.dont_analyze ? p.dont_analyze : null;
+        p.subscribe_alerts = p.subscribe_alerts === 'subscribe' ? true : null;
+        p.referral = p.referral;
+        p.hresolution = p.hresolution;
+        p.tour = p.tour;
+
+        if (p.layer_options) {
+          p.layer_options = p.layer_options.split(',');
+        }
+
+        return p;
+      },
+
+      /**
+       * Return formated URL representation of supplied params object based on
+       * a route name.
+       *
+       * @param  {Object} params Place to standardize
+       * @return {Object} Params ready for URL
+       */
+      _destandardizeParams: function(params) {
+        var p = _.extendNonNull({}, urlDefaultsParams, params);
+        var baselayers = _.pluck(p.baselayers, 'slug');
+        p.name = this._name;
+        p.baselayers = baselayers.length > 0 ? baselayers : 'none';
+        p.sublayers = p.sublayers ? p.sublayers.join(',') : null;
+        p.zoom = String(p.zoom);
+        p.lat = p.lat.toFixed(2);
+        p.lng = p.lng.toFixed(2);
+        p.iso = _.compact(_.values(p.iso)).join('-') || 'ALL';
+        p.begin = p.begin ? p.begin.format('YYYY-MM-DD') : null;
+        p.end = p.end ? p.end.format('YYYY-MM-DD') : null;
+        p.geostore = p.geostore ? p.geostore : null;
+        p.wdpaid = p.wdpaid ? String(p.wdpaid) : null;
+        p.threshold = p.threshold ? String(p.threshold) : null;
+        p.dont_analyze = p.dont_analyze ? p.dont_analyze : null;
+        p.hresolution = p.hresolution;
+        p.tour = p.tour;
+
+        if (p.layer_options) {
+          p.layer_options = p.layer_options.join(',');
+        }
+
+        return p;
+      },
+
+      /**
+       * Return param object representing state from all registered presenters
+       * that implement getPlaceParams().
+       *
+       * @param  {Array} presenters The registered presenters
+       * @return {Object} Params representing state from all presenters
+       */
+      _getPresenterParams: function(presenters) {
+        var p = {};
+
+        _.each(
+          presenters,
+          function(presenter) {
+            _.extend(p, presenter.getPlaceParams());
+          },
+          this
+        );
+
+        return p;
       }
-    }, {
-      'Place/update': function() {
-        this._updatePlace();
-      }
-    }],
+    });
 
-    /**
-     * Init by the router to set the name
-     * and publish the first place.
-     *
-     * @param  {String} name   Place name
-     * @param  {Object} params Url params
-     */
-    initPlace: function(name, params) {
-      this._name = name;
-      this._newPlace(params);
-    },
-
-    /**
-     * Silently updates the url from the presenter params.
-     */
-    _updatePlace: function() {
-      var route, params;
-      params = this._destandardizeParams(this._getPresenterParams(this._presenters));
-
-      route = this._getRoute(params);
-      this.router.navigateTo(route, {silent: true});
-    },
-
-    /**
-     * Handles a new place.
-     *
-     * @param  {Object}  params The place parameters
-     */
-    _newPlace: function(params) {
-      var where, place = {};
-
-      place.params = this._standardizeParams(params);
-
-      where = _.union(place.params.baselayers,
-        place.params.sublayers);
-
-      layerSpecService.toggle(
-        where,
-        _.bind(function(layerSpec) {
-          place.layerSpec = layerSpec;
-          mps.publish('Place/go', [place]);
-        }, this)
-      );
-    },
-
-    /**
-     * Return route URL for supplied route name and route params.
-     *
-     * @param  {Object} params The route params
-     * @return {string} The route URL
-     */
-    _getRoute: function(params) {
-      var url = new UriTemplate(this._uriTemplate).fillFromObject(params);
-      return decodeURIComponent(url);
-    },
-
-    /**
-     * Return standardized representation of supplied params object.
-     *
-     * @param  {Object} params The params to standardize
-     * @return {Object} The standardized params.
-     */
-    _standardizeParams: function(params) {
-      var p = _.extendNonNull({}, urlDefaultsParams, params);
-      p.name = this._name;
-
-      p.baselayers = _.map(p.baselayers.split(','), function(slug) {
-        return {slug: slug};
-      });
-
-      p.sublayers = p.sublayers ? _.map(p.sublayers.split(','), function(id) {
-        return {id: _.toNumber(id)};
-      }) : [];
-
-      p.zoom = _.toNumber(p.zoom);
-      p.lat = _.toNumber(p.lat);
-      p.lng = _.toNumber(p.lng);
-      p.iso = _.object(['country', 'region'], p.iso.split('-'));
-      p.begin = p.begin ? p.begin.format('YYYY-MM-DD') : null;
-      p.end = p.end ? p.end.format('YYYY-MM-DD') : null;
-      p.geostore = p.geostore ? p.geostore : null;
-      p.wdpaid = p.wdpaid ? _.toNumber(p.wdpaid) : null;
-      p.threshold = p.threshold ? _.toNumber(p.threshold) : null;
-      p.dont_analyze = p.dont_analyze ? p.dont_analyze : null;
-      p.subscribe_alerts = (p.subscribe_alerts === 'subscribe') ? true : null;
-      p.referral = p.referral;
-      p.hresolution = p.hresolution;
-      p.tour = p.tour;
-
-      if (p.layer_options) {
-        p.layer_options = p.layer_options.split(",");
-      }
-
-      return p;
-    },
-
-    /**
-     * Return formated URL representation of supplied params object based on
-     * a route name.
-     *
-     * @param  {Object} params Place to standardize
-     * @return {Object} Params ready for URL
-     */
-    _destandardizeParams: function(params) {
-      var p = _.extendNonNull({}, urlDefaultsParams, params);
-      var baselayers = _.pluck(p.baselayers, 'slug');
-      p.name = this._name;
-      p.baselayers = (baselayers.length > 0) ? baselayers : 'none';
-      p.sublayers = p.sublayers ? p.sublayers.join(',') : null;
-      p.zoom = String(p.zoom);
-      p.lat = p.lat.toFixed(2);
-      p.lng = p.lng.toFixed(2);
-      p.iso = _.compact(_.values(p.iso)).join('-') || 'ALL';
-      p.begin = p.begin ? p.begin.format('YYYY-MM-DD') : null;
-      p.end = p.end ? p.end.format('YYYY-MM-DD') : null;
-      p.geostore = p.geostore ? p.geostore : null;
-      p.wdpaid = p.wdpaid ? String(p.wdpaid) : null;
-      p.threshold = p.threshold ? String(p.threshold) : null;
-      p.dont_analyze = p.dont_analyze ? p.dont_analyze : null;
-      p.hresolution = p.hresolution;
-      p.tour = p.tour;
-
-      if (p.layer_options) {
-        p.layer_options = p.layer_options.join(",");
-      }
-
-      return p;
-    },
-
-    /**
-     * Return param object representing state from all registered presenters
-     * that implement getPlaceParams().
-     *
-     * @param  {Array} presenters The registered presenters
-     * @return {Object} Params representing state from all presenters
-     */
-    _getPresenterParams: function(presenters) {
-      var p = {};
-
-      _.each(presenters, function(presenter) {
-        _.extend(p, presenter.getPlaceParams());
-      }, this);
-
-      return p;
-    }
-
-  });
-
-  return PlaceService;
-});
+    return PlaceService;
+  }
+);

--- a/app/assets/javascripts/map/templates/analysis/analysis-country.handlebars
+++ b/app/assets/javascripts/map/templates/analysis/analysis-country.handlebars
@@ -5,7 +5,10 @@
       <option value="{{this.iso}}">{{this.name}}</option>
     {{/each}}
 	</select>
-	<select data-placeholder="Select jurisdiction (optional)" disabled="true" class="chosen-select default notranslate" id="analysis-region-select">
+	<select data-placeholder="Select region (optional)" disabled="true" class="chosen-select default notranslate" id="analysis-region-select">
+		<option></option>
+	</select>
+	<select data-placeholder="Select region (optional)" disabled="true" class="chosen-select default notranslate" id="analysis-subregion-select">
 		<option></option>
 	</select>
 </div>

--- a/app/assets/javascripts/map/templates/analysis/analysis-results.handlebars
+++ b/app/assets/javascripts/map/templates/analysis/analysis-results.handlebars
@@ -7,7 +7,12 @@
     {{/each}}
   </select>
   {{#if showRegions}}
-    <select data-placeholder="Select jurisdiction (optional)" disabled="true" class="chosen-select default notranslate" id="analysis-region-select">
+    <select data-placeholder="Select region (optional)" disabled="true" class="chosen-select default notranslate" id="analysis-region-select">
+      <option></option>
+    </select>
+  {{/if}}
+  {{#if showSubRegions}}
+    <select data-placeholder="Select region (optional)" disabled="true" class="chosen-select default notranslate" id="analysis-subregion-select">
       <option></option>
     </select>
   {{/if}}

--- a/app/assets/javascripts/map/views/analysis/AnalysisCountryView.js
+++ b/app/assets/javascripts/map/views/analysis/AnalysisCountryView.js
@@ -1,252 +1,306 @@
+/* eslint-disable */
 /**
  * The AnalysisCountryView selector view.
  *
  * @return AnalysisCountryView instance (extends Backbone.View).
  */
-define([
-  'underscore',
-  'handlebars',
-  'amplify',
-  'chosen',
-  'turf',
-  'mps',
-  'core/View',
-  'helpers/geojsonUtilsHelper',
-  'map/presenters/analysis/AnalysisCountryPresenter',
-  'text!map/templates/analysis/analysis-country.handlebars',
-], function(_, Handlebars, amplify, chosen, turf, mps, View, geojsonUtilsHelper, Presenter, tpl) {
+define(
+  [
+    'underscore',
+    'handlebars',
+    'amplify',
+    'chosen',
+    'turf',
+    'mps',
+    'core/View',
+    'helpers/geojsonUtilsHelper',
+    'map/presenters/analysis/AnalysisCountryPresenter',
+    'text!map/templates/analysis/analysis-country.handlebars'
+  ],
+  function(
+    _,
+    Handlebars,
+    amplify,
+    chosen,
+    turf,
+    mps,
+    View,
+    geojsonUtilsHelper,
+    Presenter,
+    tpl
+  ) {
+    'use strict';
 
-  'use strict';
+    var AnalysisCountryView = View.extend({
+      el: '#analysis-country-tab',
 
+      template: Handlebars.compile(tpl),
 
-  var AnalysisCountryView = View.extend({
+      events: {
+        // selects
+        'change #analysis-country-select': 'selectIso',
+        'change #analysis-region-select': 'selectRegion',
+        'change #analysis-subregion-select': 'selectSubRegion',
+        // buttons
+        'click #analysis-country-button': 'analyzeCountry'
+      },
 
-    el: '#analysis-country-tab',
+      initialize: function(map, countries) {
+        View.prototype.initialize.apply(this);
+        this.map = map;
+        this.countries = countries;
+        this.presenter = new Presenter(this, this.map, this.countries);
 
-    template: Handlebars.compile(tpl),
+        this.render();
+      },
 
-    events: {
-      // selects
-      'change #analysis-country-select' : 'selectIso',
-      'change #analysis-region-select' : 'selectRegion',
-      // buttons
-      'click #analysis-country-button' : 'analyzeCountry'
-    },
+      render: function() {
+        this.$el.removeClass('-results').html(
+          this.template({
+            countries: this.countries
+          })
+        );
 
-    initialize: function(map, countries) {
-      View.prototype.initialize.apply(this);
-      this.map = map;
-      this.countries = countries;
-      this.presenter = new Presenter(this, this.map, this.countries);
+        this.cache();
 
-      this.render();
-    },
+        this.renderChosen();
+      },
 
-    render: function(){
-      this.$el.removeClass('-results').html(this.template({
-        countries: this.countries
-      }));
+      cache: function() {
+        this.$selects = this.$el.find('.chosen-select');
 
-      this.cache();
+        // Select
+        this.$analysisCountrySelect = this.$el.find('#analysis-country-select');
+        this.$analysisRegionSelect = this.$el.find('#analysis-region-select');
+        this.$analysisSubRegionSelect = this.$el.find(
+          '#analysis-subregion-select'
+        );
 
-      this.renderChosen();
-    },
+        // Buttons
+        this.$buttonContainer = this.$el.find('#country-button-container');
+        this.$analysisBtn = this.$el.find('#analysis-country-button');
+        this.$subscribeBtn = this.$el.find('#subscribe-country-button');
+      },
 
-    cache: function() {
-      this.$selects = this.$el.find('.chosen-select');
+      renderChosen: function() {
+        this.$selects.chosen({
+          width: '100%',
+          allow_single_deselect: true,
+          inherit_select_classes: true,
+          no_results_text: 'Oops, nothing found!'
+        });
+      },
 
-      // Select
-      this.$analysisCountrySelect = this.$el.find('#analysis-country-select');
-      this.$analysisRegionSelect = this.$el.find('#analysis-region-select');
+      /**
+       * UI EVENTS
+       *
+       * selectIso & selectRegion
+       * @param  {object} e
+       * @return {void}
+       */
+      selectIso: function(e) {
+        e && e.preventDefault();
+        // Reset region whenever a user selects a new country
+        this.presenter.status.set('iso', {
+          country: $(e.currentTarget).val(),
+          region: null
+        });
+      },
 
-      // Buttons
-      this.$buttonContainer = this.$el.find('#country-button-container');
-      this.$analysisBtn = this.$el.find('#analysis-country-button');
-      this.$subscribeBtn = this.$el.find('#subscribe-country-button');
-    },
+      selectRegion: function(e) {
+        e && e.preventDefault();
+        this.presenter.status.set('iso', {
+          country: this.presenter.status.get('iso').country,
+          region: $(e.currentTarget).val()
+        });
+      },
 
-    renderChosen: function() {
-      this.$selects.chosen({
-        width: '100%',
-        allow_single_deselect: true,
-        inherit_select_classes: true,
-        no_results_text: "Oops, nothing found!"
-      });
-    },
+      selectSubRegion: function(e) {
+        e && e.preventDefault();
+        this.presenter.status.set('iso', {
+          country: this.presenter.status.get('iso').country,
+          region: this.presenter.status.get('iso').region,
+          subRegion: $(e.currentTarget).val()
+        });
+      },
 
-    /**
-     * UI EVENTS
-     *
-     * selectIso & selectRegion
-     * @param  {object} e
-     * @return {void}
-     */
-    selectIso: function(e) {
-      e && e.preventDefault();
-      // Reset region whenever a user selects a new country
-      this.presenter.status.set('iso', {
-        country: $(e.currentTarget).val(),
-        region: null
-      });
-    },
+      /**
+       * analyzeCountry
+       * @param  {object} e
+       * @return {void}
+       */
+      analyzeCountry: function(e) {
+        e && e.preventDefault();
+        this.presenter.status.set('isoDisabled', false);
+      },
 
-    selectRegion: function(e) {
-      e && e.preventDefault();
-      this.presenter.status.set('iso', {
-        country: this.presenter.status.get('iso').country,
-        region: $(e.currentTarget).val()
-      });
-    },
+      /**
+       * PRESENTER ACTIONS
+       *
+       * loadRegions
+       * @return {void}
+       */
+      toggleEnabledButtons: function() {
+        var iso = this.presenter.status.get('iso');
 
-    /**
-     * analyzeCountry
-     * @param  {object} e
-     * @return {void}
-     */
-    analyzeCountry: function(e) {
-      e && e.preventDefault();
-      this.presenter.status.set('isoDisabled', false);
-    },
+        if (!!iso && !!iso.country && iso.country != 'ALL') {
+          this.$analysisBtn.toggleClass(
+            'disabled',
+            !this.presenter.status.get('enabled')
+          );
+          this.$subscribeBtn.toggleClass(
+            'disabled',
+            !this.presenter.status.get('enabledSubscription')
+          );
+        } else {
+          this.$analysisBtn.toggleClass('disabled', true);
+          this.$subscribeBtn.toggleClass('disabled', true);
+        }
+      },
 
+      setSelects: function() {
+        var iso = this.presenter.status.get('iso'),
+          country = iso && iso.country != 'ALL' ? iso.country : null,
+          region = iso.region,
+          subRegion = iso.subRegion;
 
+        // Country
+        this.$analysisCountrySelect.val(country).trigger('chosen:updated');
 
+        // Region
+        if (!!this.presenter.status.get('regions')) {
+          // Append the regions
+          this.$analysisRegionSelect.html('');
+          _.each(
+            this.presenter.status.get('regions'),
+            function(region) {
+              this.$analysisRegionSelect.append(
+                $('<option />')
+                  .val(region.id_1)
+                  .text(region.name_1)
+              );
+            }.bind(this)
+          );
 
+          // Set the selected value
+          this.$analysisRegionSelect
+            .val(region)
+            .attr('disabled', false)
+            .trigger('chosen:updated');
 
+          if (!!this.presenter.status.get('subRegions')) {
+            this.$analysisSubRegionSelect.html('<option></option>');
+            _.each(
+              this.presenter.status.get('subRegions'),
+              function(subRegion) {
+                this.$analysisSubRegionSelect.append(
+                  $('<option />')
+                    .val(subRegion.id)
+                    .text(subRegion.name)
+                );
+              }.bind(this)
+            );
 
+            this.$analysisSubRegionSelect
+              .val(subRegion)
+              .attr('disabled', false)
+              .trigger('chosen:updated');
+          }
+        } else {
+          // Remove the regions
+          this.$analysisRegionSelect.html('');
 
+          // Remove the selected value
+          this.$analysisRegionSelect
+            .val(null)
+            .attr('disabled', true)
+            .trigger('chosen:updated');
+        }
+      },
 
+      /**
+       * HELPERS
+       * getGeojson
+       * @param  {object} overlay
+       * @return {object:geojson}
+       */
+      getGeojson: function(overlay) {
+        var paths = overlay.getPath().getArray();
+        return geojsonUtilsHelper.pathToGeojson(paths);
+      },
 
-    /**
-     * PRESENTER ACTIONS
-     *
-     * loadRegions
-     * @return {void}
-     */
-    toggleEnabledButtons: function() {
-      var iso = this.presenter.status.get('iso');
+      /**
+       * deleteGeojson
+       * @param undefined
+       * @return {void}
+       */
+      deleteGeojson: function() {
+        var overlay = this.presenter.status.get('overlay_country');
+        if (!!overlay) {
+          overlay.setMap(null);
+          this.presenter.status.set('overlay_country', null);
+          this.presenter.status.set('geojson_country', null);
+        }
+      },
 
-      if (!!iso && !!iso.country && iso.country != 'ALL') {
-        this.$analysisBtn.toggleClass('disabled', !this.presenter.status.get('enabled'));
-        this.$subscribeBtn.toggleClass('disabled', !this.presenter.status.get('enabledSubscription'));
-      } else {
-        this.$analysisBtn.toggleClass('disabled', true);
-        this.$subscribeBtn.toggleClass('disabled', true);
+      /**
+       * showGeojson
+       * @param undefined
+       * @return {void}
+       */
+      showGeojson: function() {
+        var overlay = this.presenter.status.get('overlay_country');
+        this.presenter.status.set('overlay_stroke_weight', 2);
+        if (!!overlay) {
+          overlay.setOptions({ strokeWeight: 2 });
+        }
+      },
+
+      /**
+       * hideGeojson
+       * @param undefined
+       * @return {void}
+       */
+      hideGeojson: function() {
+        var overlay = this.presenter.status.get('overlay_country');
+        this.presenter.status.set('overlay_stroke_weight', 0);
+        if (!!overlay) {
+          overlay.setOptions({ strokeWeight: 0 });
+        }
+      },
+
+      /**
+       * drawGeojson
+       * @param  {object:geojson} geojson
+       * @return {void}
+       */
+      drawGeojson: function(geojson) {
+        // Delete previous overlay if it exists
+        this.deleteGeojson();
+
+        var paths = geojsonUtilsHelper.geojsonToPath(geojson);
+        var overlay = new google.maps.Polygon({
+          paths: paths,
+          editable: false,
+          strokeWeight: this.presenter.status.get('overlay_stroke_weight'),
+          fillOpacity: 0,
+          fillColor: '#FFF',
+          strokeColor: '#A2BC28'
+        });
+
+        overlay.setMap(this.map);
+
+        this.presenter.status.set('overlay_country', overlay, { silent: true });
+        this.presenter.status.set('geojson_country', this.getGeojson(overlay), {
+          silent: true
+        });
+
+        if (this.presenter.status.get('fit_to_geom')) {
+          var bounds = geojsonUtilsHelper.getBoundsFromGeojson(geojson);
+          this.map.fitBounds(bounds);
+        }
       }
-    },
-
-    setSelects: function() {
-      var iso = this.presenter.status.get('iso'),
-          country = (iso && iso.country != 'ALL') ? iso.country : null,
-          region = iso.region;
-
-      // Country
-      this.$analysisCountrySelect.val(country).trigger('chosen:updated');
-
-      // Region
-      if (!!this.presenter.status.get('regions')) {
-        // Append the regions
-        this.$analysisRegionSelect.html('');
-        _.each(this.presenter.status.get('regions'), function(region) {
-          this.$analysisRegionSelect.append($("<option />").val(region.id_1).text(region.name_1));
-        }.bind(this));
-
-        // Set the selected value
-        this.$analysisRegionSelect.val(region).attr('disabled', false).trigger('chosen:updated');
-      } else {
-        // Remove the regions
-        this.$analysisRegionSelect.html('');
-
-        // Remove the selected value
-        this.$analysisRegionSelect.val(null).attr('disabled', true).trigger('chosen:updated');
-      }
-
-    },
-
-
-
-    /**
-     * HELPERS
-     * getGeojson
-     * @param  {object} overlay
-     * @return {object:geojson}
-     */
-    getGeojson: function(overlay) {
-      var paths = overlay.getPath().getArray();
-      return geojsonUtilsHelper.pathToGeojson(paths);
-    },
-
-    /**
-     * deleteGeojson
-     * @param undefined
-     * @return {void}
-     */
-    deleteGeojson: function() {
-      var overlay = this.presenter.status.get('overlay_country');
-      if (!!overlay) {
-        overlay.setMap(null);
-        this.presenter.status.set('overlay_country', null);
-        this.presenter.status.set('geojson_country', null);
-      }
-    },
-
-    /**
-     * showGeojson
-     * @param undefined
-     * @return {void}
-     */
-    showGeojson: function() {
-      var overlay = this.presenter.status.get('overlay_country');
-      this.presenter.status.set('overlay_stroke_weight', 2);
-      if (!!overlay) {
-        overlay.setOptions({ strokeWeight: 2});
-      }
-    },
-
-    /**
-     * hideGeojson
-     * @param undefined
-     * @return {void}
-     */
-    hideGeojson: function() {
-      var overlay = this.presenter.status.get('overlay_country');
-      this.presenter.status.set('overlay_stroke_weight', 0);
-      if (!!overlay) {
-        overlay.setOptions({ strokeWeight: 0});
-      }
-    },
-
-    /**
-     * drawGeojson
-     * @param  {object:geojson} geojson
-     * @return {void}
-     */
-    drawGeojson: function(geojson) {
-      // Delete previous overlay if it exists
-      this.deleteGeojson();
-
-      var paths = geojsonUtilsHelper.geojsonToPath(geojson);
-      var overlay = new google.maps.Polygon({
-        paths: paths,
-        editable: false,
-        strokeWeight: this.presenter.status.get('overlay_stroke_weight'),
-        fillOpacity: 0,
-        fillColor: '#FFF',
-        strokeColor: '#A2BC28'
-      });
-
-      overlay.setMap(this.map);
-
-      this.presenter.status.set('overlay_country', overlay, { silent: true });
-      this.presenter.status.set('geojson_country', this.getGeojson(overlay), { silent: true });
-
-      if (this.presenter.status.get('fit_to_geom')) {
-        var bounds = geojsonUtilsHelper.getBoundsFromGeojson(geojson);
-        this.map.fitBounds(bounds);
-      }
-    }
-
-
-  });
-  return AnalysisCountryView;
-
-});
+    });
+    return AnalysisCountryView;
+  }
+);

--- a/app/assets/javascripts/map/views/analysis/AnalysisResultsNewView.js
+++ b/app/assets/javascripts/map/views/analysis/AnalysisResultsNewView.js
@@ -1,176 +1,227 @@
+/* eslint-disable */
 /**
  * The AnalysisResultsNewView view.
  *
  * @return AnalysisResultsNewView view
  */
-define([
-  'underscore',
-  'handlebars',
-  'enquire',
-  'map/presenters/analysis/AnalysisResultsNewPresenter',
-  'text!map/templates/analysis/analysis-results.handlebars',
-  'text!map/templates/analysis/analysis-results-error.handlebars'
-], function(_, Handlebars, enquire, Presenter, tpl, errorTpl) {
+define(
+  [
+    'underscore',
+    'handlebars',
+    'enquire',
+    'map/presenters/analysis/AnalysisResultsNewPresenter',
+    'text!map/templates/analysis/analysis-results.handlebars',
+    'text!map/templates/analysis/analysis-results-error.handlebars'
+  ],
+  function(_, Handlebars, enquire, Presenter, tpl, errorTpl) {
+    'use strict';
 
-  'use strict';
-
-  var AnalysisResultsNewView = Backbone.View.extend({
-
-    templates: {
-      success: Handlebars.compile(tpl),
-      error: Handlebars.compile(errorTpl),
-    },
-
-    types: [
-      // GEOSTORE
-      {
-        el: '#analysis-draw-tab',
-        type: 'draw',
+    var AnalysisResultsNewView = Backbone.View.extend({
+      templates: {
+        success: Handlebars.compile(tpl),
+        error: Handlebars.compile(errorTpl)
       },
 
-      // COUNTRY
-      {
-        el: '#analysis-country-tab',
-        type: 'country',
+      types: [
+        // GEOSTORE
+        {
+          el: '#analysis-draw-tab',
+          type: 'draw'
+        },
+
+        // COUNTRY
+        {
+          el: '#analysis-country-tab',
+          type: 'country'
+        },
+
+        // SHAPE
+        {
+          el: '#analysis-shape-tab',
+          type: 'use'
+        },
+        {
+          el: '#analysis-shape-tab',
+          type: 'wdpaid'
+        }
+      ],
+
+      initialize: function(map, countries) {
+        this.map = map;
+        this.countries = countries;
+        this.presenter = new Presenter(this);
+
+        enquire.register(
+          'screen and (min-width:' + window.gfw.config.GFW_MOBILE + 'px)',
+          {
+            match: _.bind(function() {
+              this.mobile = false;
+            }, this)
+          }
+        );
+        enquire.register(
+          'screen and (max-width:' + window.gfw.config.GFW_MOBILE + 'px)',
+          {
+            match: _.bind(function() {
+              this.mobile = true;
+            }, this)
+          }
+        );
       },
 
-      // SHAPE
-      {
-        el: '#analysis-shape-tab',
-        type: 'use',
+      render: function() {
+        var el = this.setEl();
+        var country = this.presenter.status.get('iso').country;
+        var showRegions = this._showRegions();
+
+        // Set element to render
+        this.setElement(el);
+
+        this.$el.addClass('-results').html(
+          this.templates.success({
+            resource: this.presenter.status.get('resource'),
+            countries: !!country && country != 'ALL' ? this.countries : null,
+            showRegions: showRegions,
+            showSubRegions: showRegions
+          })
+        );
+
+        this.cache();
+        this.renderChosen();
+        this.setSelects();
       },
-      {
-        el: '#analysis-shape-tab',
-        type: 'wdpaid',
+
+      renderError: function() {
+        var type = this.presenter.status.get('type');
+        if (!!type) {
+          this.setElement(this.setEl());
+          this.$el.addClass('-results').html(
+            this.templates.error({
+              errors: this.presenter.status.get('errors')
+            })
+          );
+        }
       },
 
-    ],
+      cache: function() {
+        this.$selects = this.$el.find('.chosen-select');
 
-    initialize: function(map, countries) {
-      this.map = map;
-      this.countries = countries;
-      this.presenter = new Presenter(this);
+        // Select
+        this.$analysisCountrySelect = this.$el.find('#analysis-country-select');
+        this.$analysisRegionSelect = this.$el.find('#analysis-region-select');
+        this.$analysisSubRegionSelect = this.$el.find(
+          '#analysis-subregion-select'
+        );
+      },
 
-      enquire.register("screen and (min-width:"+window.gfw.config.GFW_MOBILE+"px)", {
-        match: _.bind(function(){
-          this.mobile = false;
-        },this)
-      });
-      enquire.register("screen and (max-width:"+window.gfw.config.GFW_MOBILE+"px)", {
-        match: _.bind(function(){
-          this.mobile = true;
-        },this)
-      });
-    },
+      /**
+       * UI EVENTS
+       * - onClickDelete
+       */
 
-    render: function() {
-      var el = this.setEl();
-      var country = this.presenter.status.get('iso').country;
+      /**
+       * HELPERS
+       * - setEl
+       */
+      setEl: function() {
+        var type = this.presenter.status.get('type');
+        return _.findWhere(this.types, { type: type }).el;
+      },
 
-      // Set element to render
-      this.setElement(el);
+      setSelects: function() {
+        var iso = this.presenter.status.get('iso'),
+          country = iso && iso.country != 'ALL' ? iso.country : null,
+          region = iso.region,
+          subRegion = iso.subRegion;
 
-      this.$el.addClass('-results').html(this.templates.success({
-        resource: this.presenter.status.get('resource'),
-        countries: (!!country && country != 'ALL') ? this.countries : null,
-        showRegions: this._showRegions()
-      }));
+        // Country
+        this.$analysisCountrySelect.val(country).trigger('chosen:updated');
 
-      this.cache();
-      this.renderChosen();
-      this.setSelects();
-    },
+        // Region
+        if (!!this.presenter.status.get('regions')) {
+          // Append the regions
+          this.$analysisRegionSelect.html('<option></option>');
+          _.each(
+            this.presenter.status.get('regions'),
+            function(region) {
+              this.$analysisRegionSelect.append(
+                $('<option />')
+                  .val(region.id_1)
+                  .text(region.name_1)
+              );
+            }.bind(this)
+          );
 
-    renderError: function() {
-      var type = this.presenter.status.get('type');
-      if (!!type) {
-        this.setElement(this.setEl())
-        this.$el.addClass('-results').html(this.templates.error({
-          errors: this.presenter.status.get('errors')
-        }));
+          // Set the selected value
+          this.$analysisRegionSelect
+            .val(region)
+            .attr('disabled', false)
+            .trigger('chosen:updated');
+
+          if (!!this.presenter.status.get('subRegions')) {
+            this.$analysisSubRegionSelect.html('<option></option>');
+            _.each(
+              this.presenter.status.get('subRegions'),
+              function(subRegion) {
+                this.$analysisSubRegionSelect.append(
+                  $('<option />')
+                    .val(subRegion.id)
+                    .text(subRegion.name)
+                );
+              }.bind(this)
+            );
+
+            this.$analysisSubRegionSelect
+              .val(subRegion)
+              .attr('disabled', false)
+              .trigger('chosen:updated');
+          }
+        } else {
+          // Remove the regions
+          this.$analysisRegionSelect.html('<option></option>');
+          this.$analysisSubRegionSelect.html('<option></option>');
+
+          // Remove the selected value
+          this.$analysisRegionSelect
+            .val(null)
+            .attr('disabled', true)
+            .trigger('chosen:updated');
+          this.$analysisSubRegionSelect
+            .val(null)
+            .attr('disabled', true)
+            .trigger('chosen:updated');
+        }
+      },
+
+      renderChosen: function() {
+        this.$selects.chosen({
+          width: '100%',
+          allow_single_deselect: true,
+          inherit_select_classes: true,
+          no_results_text: 'Oops, nothing found!'
+        });
+      },
+
+      // Temp to disable GLAD and terra-i
+      _showRegions: function() {
+        var layers = this.presenter.status.attributes.baselayers_full;
+        var layersSlugs = [];
+        var showRegions = true;
+
+        _.each(layers, function(val, key) {
+          layersSlugs.push(key);
+        });
+
+        if (
+          layersSlugs.indexOf('umd_as_it_happens') !== -1 ||
+          layersSlugs.indexOf('terrailoss') !== -1
+        ) {
+          showRegions = false;
+        }
+        return showRegions;
       }
-    },
+    });
 
-    cache: function() {
-      this.$selects = this.$el.find('.chosen-select');
-
-      // Select
-      this.$analysisCountrySelect = this.$el.find('#analysis-country-select');
-      this.$analysisRegionSelect = this.$el.find('#analysis-region-select');
-    },
-
-    /**
-     * UI EVENTS
-     * - onClickDelete
-     */
-
-
-    /**
-     * HELPERS
-     * - setEl
-     */
-    setEl: function() {
-      var type = this.presenter.status.get('type');
-      return _.findWhere(this.types, { type: type }).el
-    },
-
-    setSelects: function() {
-      var iso = this.presenter.status.get('iso'),
-          country = (iso && iso.country != 'ALL') ? iso.country : null,
-          region = iso.region;
-
-      // Country
-      this.$analysisCountrySelect.val(country).trigger('chosen:updated');
-
-      // Region
-      if (!!this.presenter.status.get('regions')) {
-        // Append the regions
-        this.$analysisRegionSelect.html('<option></option>');
-        _.each(this.presenter.status.get('regions'), function(region) {
-          this.$analysisRegionSelect.append($("<option />").val(region.id_1).text(region.name_1));
-        }.bind(this));
-
-        // Set the selected value
-        this.$analysisRegionSelect.val(region).attr('disabled', false).trigger('chosen:updated');
-      } else {
-        // Remove the regions
-        this.$analysisRegionSelect.html('<option></option>');
-
-        // Remove the selected value
-        this.$analysisRegionSelect.val(null).attr('disabled', true).trigger('chosen:updated');
-      }
-
-    },
-
-    renderChosen: function() {
-      this.$selects.chosen({
-        width: '100%',
-        allow_single_deselect: true,
-        inherit_select_classes: true,
-        no_results_text: "Oops, nothing found!"
-      });
-    },
-
-    // Temp to disable GLAD and terra-i
-    _showRegions: function() {
-      var layers = this.presenter.status.attributes.baselayers_full;
-      var layersSlugs = [];
-      var showRegions = true;
-
-      _.each(layers, function(val, key) {
-        layersSlugs.push(key);
-      });
-
-      if (layersSlugs.indexOf('umd_as_it_happens') !== -1 ||
-        layersSlugs.indexOf('terrailoss') !== -1) {
-        showRegions = false;
-      }
-      return showRegions;
-    }
-
-
-  });
-
-  return AnalysisResultsNewView;
-
-});
+    return AnalysisResultsNewView;
+  }
+);

--- a/app/assets/javascripts/services/CountryService.js
+++ b/app/assets/javascripts/services/CountryService.js
@@ -32,7 +32,7 @@ define(['Class', 'uri', 'bluebird', 'map/services/DataService'], function(
     getCountryConfig:
       "/query/{countriesConfigDataset}?sql=SELECT iso, indepth FROM {countriesConfigTable} WHERE iso='{iso}'",
     getCountriesList:
-      '/query/{countriesDataset}?sql=SELECT name_engli as name, iso FROM {countriesTable}',
+      '/query/{countriesDataset}?sql=SELECT name_engli as name, iso FROM {countriesTable} ORDER BY name',
     showCountry:
       "/query/{countriesDataset}?sql=SELECT name_engli as name, iso, topojson FROM {countriesTable} WHERE iso='{iso}'",
     getRegionsList:

--- a/app/assets/javascripts/services/CountryService.js
+++ b/app/assets/javascripts/services/CountryService.js
@@ -1,10 +1,10 @@
-define([
-  'Class',
-  'uri',
-  'bluebird',
-  'map/services/DataService'
-], function(Class, UriTemplate, Promise, ds) {
-
+/* eslint-disable */
+define(['Class', 'uri', 'bluebird', 'map/services/DataService'], function(
+  Class,
+  UriTemplate,
+  Promise,
+  ds
+) {
   'use strict';
 
   var CONFIG = {
@@ -19,20 +19,28 @@ define([
   };
 
   var GET_REQUEST_COUNTRY_CONFIG_ID = 'CountryService:getCountries',
-      GET_REQUEST_COUNTRIES_LIST_ID = 'CountryService:getCountries',
-      SHOW_REQUEST_COUNTRY_ID = 'CountryService:showCountry',
-      GET_REQUEST_REGIONS_LIST_ID = 'CountryService:getRegionsList',
-      SHOW_REQUEST_REGION_ID = 'CountryService:showRegion';
+    GET_REQUEST_COUNTRIES_LIST_ID = 'CountryService:getCountries',
+    SHOW_REQUEST_COUNTRY_ID = 'CountryService:showCountry',
+    GET_REQUEST_REGIONS_LIST_ID = 'CountryService:getRegionsList',
+    SHOW_REQUEST_REGION_ID = 'CountryService:showRegion',
+    GET_REQUEST_SUBREGIONS_LIST_ID = 'CountryService:getRegionsList';
 
   var APIURL = window.gfw.config.GFW_API_HOST_PROD;
+  var CARTO_API_URL = window.gfw.config.CARTO_API_URL;
 
   var APIURLS = {
-    'getCountryConfig'   : '/query/{countriesConfigDataset}?sql=SELECT iso, indepth FROM {countriesConfigTable} WHERE iso=\'{iso}\'',
-    'getCountriesList'   : '/query/{countriesDataset}?sql=SELECT name_engli as name, iso FROM {countriesTable}',
-    'showCountry'        : '/query/{countriesDataset}?sql=SELECT name_engli as name, iso, topojson FROM {countriesTable} WHERE iso=\'{iso}\'',
-    'getRegionsList'     : '/query/{regionsDataset}?sql=SELECT cartodb_id, iso, bbox as bounds, id_1, name_1 FROM {regionsTable} WHERE iso=\'{iso}\' ORDER BY name_1',
-    'showRegion'         : '/query/{regionsDataset}?sql=SELECT id_1, name_1, geojson FROM {regionsTable} WHERE iso=\'{iso}\' AND id_1={region} ORDER BY name_1',
-    'getSubRegionsList'  : '/query/{subRegionsDataset}?sql=SELECT id_1, name_1 FROM {subRegionsTable} WHERE iso=\'{iso}\' ORDER BY name_1'
+    getCountryConfig:
+      "/query/{countriesConfigDataset}?sql=SELECT iso, indepth FROM {countriesConfigTable} WHERE iso='{iso}'",
+    getCountriesList:
+      '/query/{countriesDataset}?sql=SELECT name_engli as name, iso FROM {countriesTable}',
+    showCountry:
+      "/query/{countriesDataset}?sql=SELECT name_engli as name, iso, topojson FROM {countriesTable} WHERE iso='{iso}'",
+    getRegionsList:
+      "/query/{regionsDataset}?sql=SELECT cartodb_id, iso, bbox as bounds, id_1, name_1 FROM {regionsTable} WHERE iso='{iso}' ORDER BY name_1",
+    showRegion:
+      "/query/{regionsDataset}?sql=SELECT id_1, name_1, geojson FROM {regionsTable} WHERE iso='{iso}' AND id_1={region} ORDER BY name_1",
+    getSubRegionsList:
+      "/sql?q=SELECT id_2 as id, name_2 as name FROM gadm28_adm2 WHERE iso = '{iso}' AND id_1 = '{region}' ORDER BY name"
   };
 
   var CountriesService = Class.extend({
@@ -42,142 +50,217 @@ define([
 
     getCountryConfig: function(params) {
       var datasetId = GET_REQUEST_COUNTRY_CONFIG_ID + '_' + params.iso;
-      return new Promise(function(resolve, reject) {
-        var status = _.extend({}, CONFIG, params);
-        var url = new UriTemplate(APIURLS.getCountryConfig).fillFromObject(status);
+      return new Promise(
+        function(resolve, reject) {
+          var status = _.extend({}, CONFIG, params);
+          var url = new UriTemplate(
+            APIURL + APIURLS.getCountryConfig
+          ).fillFromObject(status);
 
-        this.defineRequest(datasetId,
-          url, { type: 'persist', duration: 1, unit: 'days' });
+          this.defineRequest(datasetId, url, {
+            type: 'persist',
+            duration: 1,
+            unit: 'days'
+          });
 
-        var requestConfig = {
-          resourceId: datasetId,
-          success: function(res, status) {
-            resolve(res.data, status);
-          },
-          error: function(errors) {
-            reject(errors);
-          }
-        };
+          var requestConfig = {
+            resourceId: datasetId,
+            success: function(res, status) {
+              resolve(res.data, status);
+            },
+            error: function(errors) {
+              reject(errors);
+            }
+          };
 
-        ds.request(requestConfig);
-      }.bind(this));
+          ds.request(requestConfig);
+        }.bind(this)
+      );
     },
 
     getCountries: function() {
-      return new Promise(function(resolve, reject) {
-        var url = new UriTemplate(APIURLS.getCountriesList).fillFromObject(CONFIG);
+      return new Promise(
+        function(resolve, reject) {
+          var url = new UriTemplate(
+            APIURL + APIURLS.getCountriesList
+          ).fillFromObject(CONFIG);
 
-        this.defineRequest(GET_REQUEST_COUNTRIES_LIST_ID,
-          url, { type: 'persist', duration: 1, unit: 'days' });
+          this.defineRequest(GET_REQUEST_COUNTRIES_LIST_ID, url, {
+            type: 'persist',
+            duration: 1,
+            unit: 'days'
+          });
 
-        var requestConfig = {
-          resourceId: GET_REQUEST_COUNTRIES_LIST_ID,
-          success: function(res, status) {
-            resolve(res.data, status);
-          },
-          error: function(errors) {
-            reject(errors);
-          }
-        };
+          var requestConfig = {
+            resourceId: GET_REQUEST_COUNTRIES_LIST_ID,
+            success: function(res, status) {
+              resolve(res.data, status);
+            },
+            error: function(errors) {
+              reject(errors);
+            }
+          };
 
-        this.abortRequest(GET_REQUEST_COUNTRIES_LIST_ID);
-        this.currentRequest[GET_REQUEST_COUNTRIES_LIST_ID] = ds.request(requestConfig);
-      }.bind(this));
+          this.abortRequest(GET_REQUEST_COUNTRIES_LIST_ID);
+          this.currentRequest[GET_REQUEST_COUNTRIES_LIST_ID] = ds.request(
+            requestConfig
+          );
+        }.bind(this)
+      );
     },
 
     showCountry: function(params) {
       var datasetId = SHOW_REQUEST_COUNTRY_ID + '_' + params.iso;
-      return new Promise(function(resolve, reject) {
-        this.getCountryConfig(params)
-          .then(function(countryConfig) {
-            var status = _.extend({}, CONFIG, params);
-            var url = new UriTemplate(APIURLS.showCountry).fillFromObject(status);
+      return new Promise(
+        function(resolve, reject) {
+          this.getCountryConfig(params)
+            .then(
+              function(countryConfig) {
+                var status = _.extend({}, CONFIG, params);
+                var url = new UriTemplate(
+                  APIURL + APIURLS.showCountry
+                ).fillFromObject(status);
 
-            this.defineRequest(datasetId,
-              url, { type: 'persist', duration: 1, unit: 'days' });
+                this.defineRequest(datasetId, url, {
+                  type: 'persist',
+                  duration: 1,
+                  unit: 'days'
+                });
 
-            var requestConfig = {
-              resourceId: datasetId,
-              success: function(res, status) {
-                var dataCountryConfig = countryConfig.length >= 0 ? countryConfig[0] : [];
-                var dataCountry = res.data.length >= 0 ? res.data[0] : [];
-                var data = _.extend({}, dataCountry, dataCountryConfig);
-                resolve(data, status);
-              },
-              error: function(errors) {
-                reject(errors);
-              }
-            };
+                var requestConfig = {
+                  resourceId: datasetId,
+                  success: function(res, status) {
+                    var dataCountryConfig =
+                      countryConfig.length >= 0 ? countryConfig[0] : [];
+                    var dataCountry = res.data.length >= 0 ? res.data[0] : [];
+                    var data = _.extend({}, dataCountry, dataCountryConfig);
+                    resolve(data, status);
+                  },
+                  error: function(errors) {
+                    reject(errors);
+                  }
+                };
 
-            ds.request(requestConfig);
-          }.bind(this))
-          .error(function(error) {
-            console.warn(error);
-          }.bind(this))
-      }.bind(this));
+                ds.request(requestConfig);
+              }.bind(this)
+            )
+            .error(
+              function(error) {
+                console.warn(error);
+              }.bind(this)
+            );
+        }.bind(this)
+      );
     },
 
     getRegionsList: function(params) {
-      return new Promise(function(resolve, reject) {
-        var status = _.extend({}, CONFIG, params);
-        var url = new UriTemplate(APIURLS.getRegionsList).fillFromObject(status);
+      return new Promise(
+        function(resolve, reject) {
+          var status = _.extend({}, CONFIG, params);
+          var url = new UriTemplate(
+            APIURL + APIURLS.getRegionsList
+          ).fillFromObject(status);
 
-        this.defineRequest(GET_REQUEST_REGIONS_LIST_ID,
-          url, { type: 'persist', duration: 1, unit: 'days' });
+          this.defineRequest(GET_REQUEST_REGIONS_LIST_ID, url, {
+            type: 'persist',
+            duration: 1,
+            unit: 'days'
+          });
 
-        var requestConfig = {
-          resourceId: GET_REQUEST_REGIONS_LIST_ID,
-          success: function(res, status) {
-            resolve(res.data, status);
-          },
-          error: function(errors) {
-            reject(errors);
-          }
-        };
+          var requestConfig = {
+            resourceId: GET_REQUEST_REGIONS_LIST_ID,
+            success: function(res, status) {
+              resolve(res.data, status);
+            },
+            error: function(errors) {
+              reject(errors);
+            }
+          };
 
-        this.abortRequest(GET_REQUEST_REGIONS_LIST_ID);
-        this.currentRequest[GET_REQUEST_REGIONS_LIST_ID] = ds.request(requestConfig);
-      }.bind(this));
+          this.abortRequest(GET_REQUEST_REGIONS_LIST_ID);
+          this.currentRequest[GET_REQUEST_REGIONS_LIST_ID] = ds.request(
+            requestConfig
+          );
+        }.bind(this)
+      );
     },
 
     showRegion: function(params) {
-      var datasetId = SHOW_REQUEST_REGION_ID + '_' + params.iso + '_' + params.region;
-      return new Promise(function(resolve, reject) {
-        var status = _.extend({}, CONFIG, params);
-        var url = new UriTemplate(APIURLS.showRegion).fillFromObject(status);
+      var datasetId =
+        SHOW_REQUEST_REGION_ID + '_' + params.iso + '_' + params.region;
+      return new Promise(
+        function(resolve, reject) {
+          var status = _.extend({}, CONFIG, params);
+          var url = new UriTemplate(APIURL + APIURLS.showRegion).fillFromObject(
+            status
+          );
 
-        this.defineRequest(datasetId,
-          url, { type: 'persist', duration: 1, unit: 'days' });
+          this.defineRequest(datasetId, url, {
+            type: 'persist',
+            duration: 1,
+            unit: 'days'
+          });
 
-        var requestConfig = {
-          resourceId: datasetId,
-          success: function(res, status) {
-            var data = res.data.length >= 0 ? res.data[0] : [];
-            resolve(data, status);
-          },
-          error: function(errors) {
-            reject(errors);
-          }
-        };
+          var requestConfig = {
+            resourceId: datasetId,
+            success: function(res, status) {
+              var data = res.data.length >= 0 ? res.data[0] : [];
+              resolve(data, status);
+            },
+            error: function(errors) {
+              reject(errors);
+            }
+          };
 
-        ds.request(requestConfig);
-      }.bind(this));
+          ds.request(requestConfig);
+        }.bind(this)
+      );
     },
 
-    defineRequest: function (id, url, cache) {
+    getSubRegionsList: function(params) {
+      return new Promise(
+        function(resolve, reject) {
+          var status = _.extend({}, CONFIG, params);
+          var url = new UriTemplate(
+            CARTO_API_URL + APIURLS.getSubRegionsList
+          ).fillFromObject(status);
+
+          this.defineRequest(GET_REQUEST_SUBREGIONS_LIST_ID, url, {
+            type: 'persist',
+            duration: 1,
+            unit: 'days'
+          });
+
+          var requestConfig = {
+            resourceId: GET_REQUEST_SUBREGIONS_LIST_ID,
+            success: function(res, status) {
+              resolve(res.rows, status);
+            },
+            error: function(errors) {
+              reject(errors);
+            }
+          };
+
+          this.abortRequest(GET_REQUEST_SUBREGIONS_LIST_ID);
+          this.currentRequest[GET_REQUEST_SUBREGIONS_LIST_ID] = ds.request(
+            requestConfig
+          );
+        }.bind(this)
+      );
+    },
+
+    defineRequest: function(id, url, cache) {
       ds.define(id, {
         cache: cache,
-        url: APIURL + url,
+        url: url,
         type: 'GET',
         dataType: 'json',
-        contentType: 'application/json; charset=utf-8',
-        decoder: function ( data, status, xhr, success, error ) {
-          if ( status === "success" ) {
-            success( data, xhr );
-          } else if ( status === "fail" || status === "error" ) {
+        decoder: function(data, status, xhr, success, error) {
+          if (status === 'success') {
+            success(data, xhr);
+          } else if (status === 'fail' || status === 'error') {
             error(xhr.statusText);
-          } else if ( status === "abort") {
-
+          } else if (status === 'abort') {
           } else {
             error(xhr.statusText);
           }
@@ -194,9 +277,7 @@ define([
         this.currentRequest[request] = null;
       }
     }
-
   });
 
   return new CountriesService();
-
 });

--- a/app/views/layouts/embed.html.erb
+++ b/app/views/layouts/embed.html.erb
@@ -62,6 +62,7 @@
         config: {
           GFW_API_HOST: "<%= ENV['GFW_API_HOST'] %>",
           GFW_API_HOST_NEW_API: "<%= ENV['GFW_API_HOST_NEW_API'] %>",
+          GFW_API_HOST_API_V2: "<%= ENV['GFW_API_HOST_API_V2'] %>",
           GFW_API_AUTH: "<%= ENV['GFW_API_AUTH'] %>",
           GFW_API_HOST_PROD: "<%= ENV['GFW_API_HOST_PROD'] %>",
           GFW_MOBILE: 1000,

--- a/app/views/layouts/embed.html.erb
+++ b/app/views/layouts/embed.html.erb
@@ -63,6 +63,7 @@
           GFW_API_HOST: "<%= ENV['GFW_API_HOST'] %>",
           GFW_API_HOST_NEW_API: "<%= ENV['GFW_API_HOST_NEW_API'] %>",
           GFW_API_HOST_API_V2: "<%= ENV['GFW_API_HOST_API_V2'] %>",
+          CARTO_API_URL: "<%= ENV['CARTO_API_URL'] %>",
           GFW_API_AUTH: "<%= ENV['GFW_API_AUTH'] %>",
           GFW_API_HOST_PROD: "<%= ENV['GFW_API_HOST_PROD'] %>",
           GFW_MOBILE: 1000,

--- a/app/views/shared/_js_config.html.erb
+++ b/app/views/shared/_js_config.html.erb
@@ -6,6 +6,7 @@
         GFW_API_HOST: "<%= ENV['GFW_API_HOST'] %>",
         GFW_API_HOST_NEW_API: "<%= ENV['GFW_API_HOST_NEW_API'] %>",
         GFW_API_HOST_API_V2: "<%= ENV['GFW_API_HOST_API_V2'] %>",
+        CARTO_API_URL: "<%= ENV['CARTO_API_URL'] %>",
         SENTINEL_KEY: "<%= ENV['SENTINEL_KEY'] %>",
         LANDSTAD_KEY: "<%= ENV['LANDSTAD_KEY'] %>",
         GFW_API_AUTH: "<%= ENV['GFW_API_AUTH'] %>",

--- a/app/views/shared/_js_config.html.erb
+++ b/app/views/shared/_js_config.html.erb
@@ -5,6 +5,7 @@
         ENV_VERSION: "<%= ENV['RAILS_ENV'] %>",
         GFW_API_HOST: "<%= ENV['GFW_API_HOST'] %>",
         GFW_API_HOST_NEW_API: "<%= ENV['GFW_API_HOST_NEW_API'] %>",
+        GFW_API_HOST_API_V2: "<%= ENV['GFW_API_HOST_API_V2'] %>",
         SENTINEL_KEY: "<%= ENV['SENTINEL_KEY'] %>",
         LANDSTAD_KEY: "<%= ENV['LANDSTAD_KEY'] %>",
         GFW_API_AUTH: "<%= ENV['GFW_API_AUTH'] %>",

--- a/app/views/shared/_notifications.html.erb
+++ b/app/views/shared/_notifications.html.erb
@@ -44,6 +44,9 @@
   <div id="notification-over-limit" data-type="error">
     <p>File exceedes feature limit <button class="btn little white source" data-source="drop-shapefile">More info</button></p>
   </div>
+  <div id="notification-empty-analysis" data-type="warning">
+    <p>No data available for this analysis</p>
+  </div>
 
 
   <!-- STORIES -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "globalforestwatch",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Global Forest Watch",
   "main": "Gruntfile.js",
   "engines": {


### PR DESCRIPTION
## Overview

This PR changes the analysis url for the `umd-loss-gain` dataset to use the need endpoint that @01painadam made here: https://github.com/gfw-api/gfw-umd-forest-api/pull/8
I've also added a new select to analyze admin2 regions.

## Demo

![admin2](https://user-images.githubusercontent.com/1432880/37777613-493c10a6-2de8-11e8-8b12-492f85d69ff8.gif)


