### PR TITLE
Fixes percentage calculation bug in Global Loss Rank

### DIFF
--- a/app/javascript/pages/country/widget/widgets/widget-loss-ranked/widget-loss-ranked-selectors.js
+++ b/app/javascript/pages/country/widget/widgets/widget-loss-ranked/widget-loss-ranked-selectors.js
@@ -28,11 +28,11 @@ export const getSummedByYearsData = createSelector(
     const isos = Object.keys(groupedByIso);
     const mappedData = isos.map(i => {
       const isoLoss = sumBy(groupedByIso[i], 'loss') || 0;
-      const isoExtent = extent.find(e => e.iso === i).total_area;
+      const isoExtent = extent.find(e => e.iso === i).value;
       return {
         id: i,
         loss: isoLoss,
-        extent,
+        extent: isoExtent,
         percentage: isoExtent ? 100 * isoLoss / isoExtent : 0
       };
     });


### PR DESCRIPTION
## Overview

Currently on production there is a calculation error between the [loss by year](http://www.globalforestwatch.org/country/BRA?widget=treeLoss#treeLoss) and the [global loss ranking](http://www.globalforestwatch.org/country/BRA?widget=lossRanked#lossRanked) widgets - meaning that the area_loss% values do not match in the dynamic sentences

This commit fixes the issue.
