### PR TITLE
fixing a couple of bugs on FAO people widgets

### DIFF
--- a/app/javascript/components/widget/widget-config.json
+++ b/app/javascript/components/widget/widget-config.json
@@ -563,7 +563,7 @@
       "categories": ["people"],
       "admins": ["country"],
       "selectors": ["years"],
-      "years": [2000, 2005, 2010],
+      "years": [1990, 2000, 2005, 2010],
       "type": "fao",
       "metaKey": "widget_forestry_employment",
       "sortOrder": {
@@ -571,7 +571,7 @@
       }
     },
     "settings": {
-      "year": 2000
+      "year": 2010
     },
     "enabled": true
   },
@@ -587,7 +587,17 @@
       "metaKey": "widget_economic_impact",
       "sortOrder": {
         "people": 1
-      }
+      },
+      "customLocationWhitelist": ["AGO","ALB","ARG","ARM","BEL","BEN","BFA","BGD",
+        "BGR","BLM","BLR","BRA","BRN","BTN","BWA","CHL","CHN","CRI","CUB","CYP",
+        "DNK","DOM","DZA","EGY","FIN","FJI","FLK","FRA","FRO","GAB","GBR","GEO",
+        "GIB","GLP","GMB","GNQ","GRL","GTM","GUF","GUY","HRV","HUN","IDN","IND",
+        "IRN","ISL","JAM","JPN","KEN","KGZ","KHM","KIR","KOR","LAO","LBN","LCA",
+        "LKA","LTU","LVA","MAR","MCO","MEX","MLI","MMR","MNE","MNG","MRT","MTQ",
+        "MUS","MWI","MYS","MYT","NER","NPL","NRU","NZL","PAN","PER","PHL","PNG",
+        "POL","PRY","PYF","QAT","REU","RUS","RWA","SDN","SEN","SGP","SJM","SLE",
+        "SMR","SRB","SUR","SVK","SVN","SWE","SYC","SYR","TGO","TKL","TON","TTO",
+        "TUN","TUR","TZA","URY","USA","UZB","VAT","VEN","VUT","WLF","ZWE"]
     },
     "settings": {
       "unit": "net_usd"

--- a/app/javascript/services/forest-data.js
+++ b/app/javascript/services/forest-data.js
@@ -36,7 +36,7 @@ const SQL_QUERIES = {
   faoDeforestRank:
     'WITH mytable AS (SELECT fao.country as iso, fao.name, fao.deforest * 1000 AS deforest, fao.humdef FROM table_1_forest_area_and_characteristics as fao WHERE fao.year = {year} AND deforest is not null), rank AS (SELECT deforest, iso, name from mytable ORDER BY mytable.deforest DESC) SELECT row_number() over () as rank, iso, name, deforest from rank',
   faoEcoLive:
-    'SELECT fao.country, fao.forempl, fao.femempl, fao.usdrev, fao.usdexp, fao.gdpusd2012, fao.totpop1000, fao.year FROM table_7_economics_livelihood as fao WHERE fao.year = 2000 or fao.year = 2005 or fao.year = 2010 or fao.year = 9999'
+    'SELECT fao.country, fao.forempl, fao.femempl, fao.usdrev, fao.usdexp, fao.gdpusd2012, fao.totpop1000, fao.year FROM table_7_economics_livelihood as fao WHERE fao.year = 1990 or fao.year = 2000 or fao.year = 2005 or fao.year = 2010 or fao.year = 9999'
 };
 
 const getExtentYear = year =>


### PR DESCRIPTION
## Overview

* 1990's were missing from the employment widget. Added it back in.
* Changed default year from 2000 to 2010 for economic widget.
* Created a whitelist to prevent the economic widget from appearing on pages where no data exists.

## Tests
* whitelist 
E.g. Check http://localhost:5000/country/BHR?category=people
Bahrain page should have no economic widget.

* 1990's - Angola should have 1990's data, where it didn't before
http://localhost:5000/country/AGO?category=people&forestryEmployment=eyJ5ZWFyIjoxOTkwfQ%3D%3D

