### PR TITLE
Removes indicators with broken units

### DIFF
--- a/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/initial-state.js
@@ -2,16 +2,7 @@ export default {
   title: 'Tree cover gain',
   config: {
     size: 'small',
-    indicators: [
-      'gadm28',
-      'wdpa',
-      'plantations',
-      'landmark',
-      'mining',
-      'kba',
-      'aze',
-      'tcl'
-    ],
+    indicators: ['gadm28', 'wdpa', 'plantations', 'landmark', 'mining'],
     units: ['ha', '%'],
     categories: ['summary', 'forest-change'],
     admins: ['country', 'region', 'subRegion'],


### PR DESCRIPTION
## Overview

Removes indicators with broken units (AZE, KBA, TCL) from the only widget currently using them.

NOTE: this only affects gain and loss widgets