### PR TITLE
fix/ismobile-not-defined

### DIFF
--- a/app/views/map/index.html.erb
+++ b/app/views/map/index.html.erb
@@ -44,3 +44,4 @@
 <div class="mini-modal download-modal"></div>
 
 <script src="//www.google-analytics.com/cx/api.js"></script>
+<%= render "shared/js_footer" %>


### PR DESCRIPTION
## Overview

This fixes a JS error that we have since the last views refactor. I realize that we need the `isMobile` var defined on the `shared/js_footer`, but we have more stuffs inside it, so @edbrett, as you did the refactor, do you think this is a good idea? or we'll have duplicated things?

## Demo

![captura de pantalla 2018-05-18 a las 10 10 18](https://user-images.githubusercontent.com/1432880/40223690-2f7e33ce-5a84-11e8-8299-0f6221100a34.png)
