### PR TITLE
Bugfix/nan loss location widget

### DIFF
--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/initial-state.js
@@ -49,7 +49,8 @@ export default {
       initialPercent:
         'In {location}, the top {percentileLength} regions were responsible for {topLoss} of all tree cover loss between {startYear} and {endYear}. {region} had the most relative tree cover loss at {value} compared to an average of {average}.',
       withIndicatorPercent:
-        'For {indicator} in {location}, the top {percentileLength} regions were responsible for {topLoss} of all tree cover loss between {startYear} and {endYear}. {region} had the most relative tree cover loss at {value} compared to an average of {average}.'
+        'For {indicator} in {location}, the top {percentileLength} regions were responsible for {topLoss} of all tree cover loss between {startYear} and {endYear}. {region} had the most relative tree cover loss at {value} compared to an average of {average}.',
+      noLoss: 'There was no tree cover loss identified in {location}.'
     }
   },
   settings: {

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/selectors.js
@@ -86,7 +86,8 @@ export const getSentence = createSelector(
       initial,
       withIndicator,
       initialPercent,
-      withIndicatorPercent
+      withIndicatorPercent,
+      noLoss
     } = sentences;
     const { startYear, endYear } = settings;
     const totalLoss = sumBy(data, 'loss');
@@ -103,10 +104,13 @@ export const getSentence = createSelector(
       percentileLoss += data[percentileLength].loss;
       percentileLength += 1;
     }
-    const topLoss = percentileLoss / totalLoss * 100;
+    const topLoss = percentileLoss / totalLoss * 100 || 0;
     let sentence = !indicator ? initialPercent : withIndicatorPercent;
     if (settings.unit !== '%') {
       sentence = !indicator ? initial : withIndicator;
+    }
+    if (percentileLength === 0) {
+      sentence = noLoss;
     }
 
     const params = {

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/initial-state.js
@@ -44,7 +44,8 @@ export const initialState = {
       initial:
         'From {startYear} to {endYear}, {location} lost {loss} of tree cover {indicator}, equivalent to a {percent} decrease since {extentYear} and {globalPercent} of global tree cover loss.',
       withIndicator:
-        'From {startYear} to {endYear}, {location} lost {loss} of tree cover in {indicator}, equivalent to a {percent} decrease since {extentYear} and {globalPercent} of global tree cover loss.'
+        'From {startYear} to {endYear}, {location} lost {loss} of tree cover in {indicator}, equivalent to a {percent} decrease since {extentYear} and {globalPercent} of global tree cover loss.',
+      noLoss: 'There was no tree cover loss identified in {location}.'
     }
   },
   settings: {

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
@@ -116,7 +116,7 @@ export const getSentence = createSelector(
   (data, settings, indicator, currentLocation, sentences) => {
     if (!data || !data.length || !currentLocation) return null;
     const { startYear, endYear } = settings;
-    const { initial, withIndicator } = sentences;
+    const { initial, withIndicator, noLoss } = sentences;
     const locationData =
       currentLocation && data.find(l => l.id === currentLocation.value);
     const loss = locationData && locationData.loss;
@@ -127,7 +127,10 @@ export const getSentence = createSelector(
     const indicatorName = !indicator
       ? 'region-wide'
       : `${indicator.label.toLowerCase()}`;
-    const sentence = !indicator ? initial : withIndicator;
+    let sentence = !indicator ? initial : withIndicator;
+    if (loss === 0) {
+      sentence = noLoss;
+    }
     const params = {
       indicator: indicatorName,
       location: currentLocation && currentLocation.label,

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss/initial-state.js
@@ -39,7 +39,7 @@ export const initialState = {
     },
     sentences: {
       initial:
-        'From blah thing {startYear} and {endYear}, {location} lost {loss} of tree cover, equivalent to a {percent} decrease since {extentYear} and {emissions} of CO\u2082 emissions.',
+        'From {startYear} and {endYear}, {location} lost {loss} of tree cover, equivalent to a {percent} decrease since {extentYear} and {emissions} of CO\u2082 emissions.',
       withIndicator:
         'From {startYear} and {endYear}, {location} lost {loss} of tree cover in {indicator}, equivalent to a {percent} decrease since {extentYear} and {emissions} of CO\u2082 emissions.',
       noLoss:

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss/initial-state.js
@@ -39,7 +39,7 @@ export const initialState = {
     },
     sentences: {
       initial:
-        'From {startYear} and {endYear}, {location} lost {loss} of tree cover, equivalent to a {percent} decrease since {extentYear} and {emissions} of CO\u2082 emissions.',
+        'From blah thing {startYear} and {endYear}, {location} lost {loss} of tree cover, equivalent to a {percent} decrease since {extentYear} and {emissions} of CO\u2082 emissions.',
       withIndicator:
         'From {startYear} and {endYear}, {location} lost {loss} of tree cover in {indicator}, equivalent to a {percent} decrease since {extentYear} and {emissions} of CO\u2082 emissions.',
       noLoss:

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/initial-state.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/initial-state.js
@@ -44,7 +44,8 @@ export default {
       largePercentileWithIndicator:
         'For {indicator} in {location}, the top {count} regions represent {percentage} of all tree cover. {region} has the largest tree cover at {extent} compared to an average of {averageExtent}.',
       hasPercentage:
-        '{region} had the largest relative tree cover of {relPercentage}, compared to a regional average of {averagePerc}.'
+        '{region} had the largest relative tree cover of {relPercentage}, compared to a regional average of {averagePerc}.',
+      noCover: 'No tree cover was identified in {location}.'
     },
     data: [
       {

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
@@ -53,7 +53,7 @@ export const getSentence = createSelector(
   ],
   (data, settings, options, location, indicator, currentLabel, sentences) => {
     if (!data || !options || !currentLabel) return null;
-    const { initial, hasPercentage, hasIndicator } = sentences;
+    const { initial, hasPercentage, hasIndicator, noCover } = sentences;
     const topRegion = data.length && data[0];
     const totalExtent = sumBy(data, 'extent');
     const avgExtent = sumBy(data, 'extent') / data.length;
@@ -85,6 +85,9 @@ export const getSentence = createSelector(
     let sentence = settings.unit === '%' ? hasPercentage : initial;
     if (indicator) {
       sentence = hasIndicator;
+    }
+    if (params.percentage === '0%') {
+      sentence = noCover;
     }
 
     return {


### PR DESCRIPTION
## Overview

This PR address [the BC thread here](https://basecamp.com/3063126/projects/10727890/todos/350629881).

Specifically it:
* Catches cases where a NaN value was getting through on one of the widgets (e.g. Location of tree cover loss https://www.globalforestwatch.org/country/DJI?category=forest-change )
* Adds some extra sentences to several of the widgets to deal with no tree cover and no tree cover loss cases.
<img width="766" alt="screen shot 2018-05-24 at 11 58 45" src="https://user-images.githubusercontent.com/6503031/40479330-91365f4e-5f4b-11e8-870c-de7ab2a6f81c.png">
<img width="385" alt="screen shot 2018-05-24 at 11 55 23" src="https://user-images.githubusercontent.com/6503031/40479332-91666720-5f4b-11e8-90c9-4dcfe4efac10.png">

