### PR TITLE
Fix: force resize horizontal bar chart

### DIFF
--- a/app/javascript/components/charts/horizontal-bar-chart/horizontal-bar-chart-component.js
+++ b/app/javascript/components/charts/horizontal-bar-chart/horizontal-bar-chart-component.js
@@ -26,7 +26,7 @@ class HorizontalBarChart extends PureComponent {
 
     return (
       <div className={`c-horizontal-bar-chart ${className}`}>
-        <ResponsiveContainer>
+        <ResponsiveContainer width="99%">
           <BarChart
             data={pageData}
             margin={{ top: 15, right: 0, left: -24, bottom: 0 }}


### PR DESCRIPTION
We have a bug that when changing screen size the horizontal bar chart isnt interested. This is due to a bug in recharts responsive component. A check for 99% width has been added for force the resize.