### PR TITLE
fix pie chart tooltip when no label given

### DIFF
--- a/app/javascript/components/charts/components/chart-tooltip/chart-tooltip-component.js
+++ b/app/javascript/components/charts/components/chart-tooltip/chart-tooltip-component.js
@@ -20,7 +20,7 @@ class WidgetChartTooltip extends PureComponent {
                       key={d.key}
                       className={`data-line ${d.position || ''}`}
                     >
-                      {d.label && (
+                      {(d.label || d.labelKey) && (
                         <div className="data-label">
                           {d.color && (
                             <div
@@ -28,7 +28,7 @@ class WidgetChartTooltip extends PureComponent {
                               style={{ backgroundColor: d.color }}
                             />
                           )}
-                          {<span>{d.label || values[d.label]}</span>}
+                          {<span>{d.label || values[d.labelKey]}</span>}
                         </div>
                       )}
                       {d.unit && d.unitFormat

--- a/app/javascript/components/charts/components/chart-tooltip/chart-tooltip-styles.scss
+++ b/app/javascript/components/charts/components/chart-tooltip/chart-tooltip-styles.scss
@@ -6,6 +6,7 @@
   background-color: $slate;
   color: $white;
   border-radius: rem(2px);
+  font-size: rem(16px);
 
   .data-line {
     display: flex;

--- a/app/javascript/components/charts/pie-chart/pie-chart-component.js
+++ b/app/javascript/components/charts/pie-chart/pie-chart-component.js
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { format } from 'd3-format';
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
 import ChartToolTip from '../components/chart-tooltip';
 
@@ -16,7 +15,8 @@ class CustomPieChart extends PureComponent {
       outerRadius,
       startAngle,
       endAngle,
-      className
+      className,
+      tooltip
     } = this.props;
 
     return (
@@ -39,20 +39,7 @@ class CustomPieChart extends PureComponent {
                 />
               ))}
             </Pie>
-            <Tooltip
-              content={
-                <ChartToolTip
-                  settings={[
-                    {
-                      key: 'percentage',
-                      label: 'label',
-                      unit: '%',
-                      unitFormat: value => format('.1f')(value)
-                    }
-                  ]}
-                />
-              }
-            />
+            <Tooltip content={<ChartToolTip settings={tooltip} />} />
           </PieChart>
         </ResponsiveContainer>
       </div>
@@ -68,7 +55,8 @@ CustomPieChart.propTypes = {
   outerRadius: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   startAngle: PropTypes.number,
   endAngle: PropTypes.number,
-  className: PropTypes.string
+  className: PropTypes.string,
+  tooltip: PropTypes.array
 };
 
 CustomPieChart.defaultProps = {

--- a/app/javascript/components/widgets/components/widget-pie-chart-legend/component.jsx
+++ b/app/javascript/components/widgets/components/widget-pie-chart-legend/component.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { format } from 'd3-format';
 
 import PieChart from 'components/charts/pie-chart';
 import PieChartLegend from 'components/charts/components/pie-chart-legend';
@@ -22,7 +23,19 @@ class WidgetTreeCover extends PureComponent {
             key: 'value'
           }}
         />
-        <PieChart className="cover-pie-chart" data={data} maxSize={140} />
+        <PieChart
+          className="cover-pie-chart"
+          data={data}
+          maxSize={140}
+          tooltip={[
+            {
+              key: 'percentage',
+              unit: '%',
+              labelKey: 'label',
+              unitFormat: value => format('.1f')(value)
+            }
+          ]}
+        />
       </div>
     );
   }

--- a/app/javascript/components/widgets/widgets/land-cover/primary-forest/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/primary-forest/selectors.js
@@ -48,14 +48,8 @@ export const getSentence = createSelector(
   (parsedData, settings, currentLabel, indicator, sentences) => {
     if (!parsedData || !currentLabel) return null;
     const { initial, withIndicator } = sentences;
-    const totalExtent = parsedData
-      .filter(d => d.label !== 'Non-Forest')
-      .map(d => d.value)
-      .reduce((sum, d) => sum + d);
-    const primaryPercentage =
-      parsedData.find(d => d.label === 'Primary Forest').value /
-      totalExtent *
-      100;
+    const primaryPercentage = parsedData.find(d => d.label === 'Primary Forest')
+      .percentage;
 
     let indicatorLabel = indicator && indicator.label;
     switch (indicator && indicator.value) {


### PR DESCRIPTION
Pie charts on widgets were showing 'label' in some cases due to an order error in logic for selecting the key from the data.