### PR TITLE
make widget titles translateable and editable

### DIFF
--- a/app/javascript/components/widgets/components/widget-header/widget-header.js
+++ b/app/javascript/components/widgets/components/widget-header/widget-header.js
@@ -24,7 +24,10 @@ const mapStateToProps = (
     widget === 'treeCover' && whitelist && whitelist.indexOf('plantations')
       ? 'widget_natural_vs_planted'
       : config.metaKey;
-
+  const parsedTitle =
+    title && currentLabel !== 'global'
+      ? title.withLocation.replace('{location}', currentLabel)
+      : title.global;
   return {
     location,
     size,
@@ -32,26 +35,23 @@ const mapStateToProps = (
     widgetMetaKey,
     modalOpen: modalMeta.open,
     modalClosing: modalMeta.closing,
-    citation: `Global Forest Watch. “${title} in ${
-      currentLabel
+    citation: `Global Forest Watch. “${
+      parsedTitle
     }”. Accessed on ${moment().format(
       'MMMM Do YYYY'
     )} from www.globalforestwatch.org.`,
     shareData: {
       title: 'Share this widget',
-      subtitle: `${title} in ${currentLabel || ''}`,
+      subtitle: parsedTitle,
       shareUrl,
       embedUrl,
       embedSettings:
         config.size === 'small'
           ? { width: 315, height: 460 }
           : { width: 670, height: 490 },
-      socialText: `${title} in ${currentLabel || ''}`
+      socialText: parsedTitle
     },
-    title:
-      currentLabel !== 'global'
-        ? `${title} in ${currentLabel}`
-        : `${location.payload.type || 'global'} ${title}`
+    title: parsedTitle
   };
 };
 

--- a/app/javascript/components/widgets/widgets/climate/emissions-deforestation/initial-state.js
+++ b/app/javascript/components/widgets/widgets/climate/emissions-deforestation/initial-state.js
@@ -1,5 +1,7 @@
 export default {
-  title: 'Emissions from biomass loss',
+  title: {
+    withLocation: 'Emissions from biomass loss in {location}'
+  },
   config: {
     size: 'small',
     indicators: [

--- a/app/javascript/components/widgets/widgets/climate/emissions/initial-state.js
+++ b/app/javascript/components/widgets/widgets/climate/emissions/initial-state.js
@@ -1,5 +1,7 @@
 export default {
-  title: 'Historical emissions',
+  title: {
+    withLocation: 'Historical emissions in {location}'
+  },
   config: {
     size: 'small',
     categories: ['climate'],

--- a/app/javascript/components/widgets/widgets/conservation/glad-biodiversity/initial-state.js
+++ b/app/javascript/components/widgets/widgets/conservation/glad-biodiversity/initial-state.js
@@ -1,5 +1,7 @@
 export default {
-  title: 'Deforestation Alerts in Biodiversity Areas',
+  title: {
+    withLocation: 'Deforestation Alerts in Biodiversity Areas in {location}'
+  },
   config: {
     landCategories: ['kba', 'aze', 'wdpa'],
     categories: ['conservation'],

--- a/app/javascript/components/widgets/widgets/forest-change/fao-deforest/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/fao-deforest/initial-state.js
@@ -1,5 +1,8 @@
 export const initialState = {
-  title: 'FAO deforestation',
+  title: {
+    global: 'Global FAO deforestation',
+    withLocation: 'FAO deforestation in {location}'
+  },
   config: {
     size: 'small',
     categories: ['forest-change'],

--- a/app/javascript/components/widgets/widgets/forest-change/fao-reforest/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/fao-reforest/initial-state.js
@@ -1,5 +1,8 @@
 export const initialState = {
-  title: 'FAO reforestation',
+  title: {
+    global: 'Global FAO reforestation',
+    withLocation: 'FAO reforestation in {location}'
+  },
   config: {
     size: 'small',
     categories: ['forest-change'],

--- a/app/javascript/components/widgets/widgets/forest-change/fires/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/fires/initial-state.js
@@ -1,5 +1,7 @@
 export default {
-  title: 'Fires',
+  title: {
+    withLocation: 'Fires in {location}'
+  },
   config: {
     size: 'small',
     categories: ['forest-change', 'summary'],

--- a/app/javascript/components/widgets/widgets/forest-change/glad-alerts/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/glad-alerts/initial-state.js
@@ -1,5 +1,7 @@
 export default {
-  title: 'Deforestation Alerts',
+  title: {
+    withLocation: 'Deforestation Alerts in {location}'
+  },
   config: {
     size: 'large',
     categories: ['summary', 'forest-change'],

--- a/app/javascript/components/widgets/widgets/forest-change/glad-ranked/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/glad-ranked/initial-state.js
@@ -1,5 +1,7 @@
 export default {
-  title: 'Location of deforestation Alerts',
+  title: {
+    withLocation: 'Location of deforestation Alerts in {location}'
+  },
   config: {
     size: 'small',
     forestTypes: ['ifl_2013', 'plantations', 'primary_forest'],

--- a/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/initial-state.js
@@ -1,5 +1,8 @@
 export default {
-  title: 'Tree cover gain',
+  title: {
+    global: 'Global Tree cover gain',
+    withLocation: 'Tree cover gain in {location}'
+  },
   config: {
     size: 'small',
     landCategories: ['wdpa', 'landmark', 'mining'],

--- a/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/initial-state.js
@@ -1,5 +1,7 @@
 export default {
-  title: 'Location of tree cover gain in',
+  title: {
+    withLocation: 'Location of tree cover gain in {location}'
+  },
   config: {
     size: 'small',
     forestTypes: ['ifl_2013', 'plantations', 'primary_forest'],

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/initial-state.js
@@ -1,5 +1,7 @@
 export default {
-  title: 'Tree cover loss',
+  title: {
+    global: 'Global Tree cover loss'
+  },
   config: {
     admins: ['global'],
     forestTypes: ['ifl_2013'],

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/initial-state.js
@@ -1,5 +1,7 @@
 export default {
-  title: 'Location of tree cover loss',
+  title: {
+    withLocation: 'Location of tree cover loss in {location}'
+  },
   config: {
     size: 'small',
     forestTypes: ['ifl_2013', 'plantations', 'primary_forest'],

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-plantations/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-plantations/initial-state.js
@@ -1,5 +1,7 @@
 export const initialState = {
-  title: 'Forest loss in natural forest',
+  title: {
+    withLocation: 'Forest loss in natural forest in {location}'
+  },
   config: {
     size: 'large',
     showIndicators: ['plantations'],

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/initial-state.js
@@ -1,5 +1,7 @@
 export const initialState = {
-  title: 'Tree cover loss',
+  title: {
+    withLocation: 'Tree cover loss in {location}'
+  },
   config: {
     size: 'small',
     forestTypes: ['ifl_2013', 'plantations', 'primary_forest'],

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss/initial-state.js
@@ -1,5 +1,7 @@
 export const initialState = {
-  title: 'Tree cover loss',
+  title: {
+    withLocation: 'Tree cover loss in {location}'
+  },
   config: {
     size: 'large',
     forestTypes: ['ifl_2013', 'primary_forest'],

--- a/app/javascript/components/widgets/widgets/land-cover/fao-cover/initial-state.js
+++ b/app/javascript/components/widgets/widgets/land-cover/fao-cover/initial-state.js
@@ -1,5 +1,8 @@
 export const initialState = {
-  title: 'FAO forest cover',
+  title: {
+    global: 'Global FAO forest cover',
+    withLocation: 'FAO forest cover in {location}'
+  },
   config: {
     size: 'small',
     categories: ['land-cover'],

--- a/app/javascript/components/widgets/widgets/land-cover/intact-tree-cover/initial-state.js
+++ b/app/javascript/components/widgets/widgets/land-cover/intact-tree-cover/initial-state.js
@@ -1,5 +1,8 @@
 export default {
-  title: 'Intact forest',
+  title: {
+    global: 'Global Intact forest',
+    withLocation: 'Intact forest in {location}'
+  },
   config: {
     size: 'small',
     landCategories: ['wdpa', 'mining', 'landmark'],

--- a/app/javascript/components/widgets/widgets/land-cover/primary-forest/initial-state.js
+++ b/app/javascript/components/widgets/widgets/land-cover/primary-forest/initial-state.js
@@ -1,5 +1,7 @@
 export default {
-  title: 'Primary forest',
+  title: {
+    withLocation: 'Primary forest in {location}'
+  },
   config: {
     size: 'small',
     landCategories: ['mining', 'wdpa', 'landmark'],

--- a/app/javascript/components/widgets/widgets/land-cover/ranked-plantations/initial-state.js
+++ b/app/javascript/components/widgets/widgets/land-cover/ranked-plantations/initial-state.js
@@ -1,5 +1,7 @@
 export default {
-  title: 'Location of plantations',
+  title: {
+    withLocation: 'Location of plantations in {location}'
+  },
   config: {
     size: 'small',
     categories: ['land-cover'],

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/initial-state.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/initial-state.js
@@ -1,5 +1,8 @@
 export default {
-  title: 'Location of tree cover',
+  title: {
+    global: 'Global Location of tree cover',
+    withLocation: 'Location of tree cover in {location}'
+  },
   config: {
     size: 'small',
     forestTypes: ['ifl_2013', 'plantations', 'primary_forest'],

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-plantations/initial-state.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-plantations/initial-state.js
@@ -1,5 +1,7 @@
 export default {
-  title: 'Plantations in',
+  title: {
+    withLocation: 'Plantations in {location}'
+  },
   config: {
     size: 'small',
     categories: ['land-cover'],

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/initial-state.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/initial-state.js
@@ -1,5 +1,7 @@
 export default {
-  title: 'Tree cover extent',
+  title: {
+    withLocation: 'Tree cover extent in {location}'
+  },
   config: {
     size: 'small',
     landCategories: ['wdpa', 'kba', 'aze', 'tcl'],

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover/initial-state.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover/initial-state.js
@@ -1,5 +1,8 @@
 export default {
-  title: 'Tree cover',
+  title: {
+    global: 'Global tree cover',
+    withLocation: 'Tree cover in {location}'
+  },
   config: {
     size: 'small',
     landCategories: ['mining', 'landmark', 'wdpa'],

--- a/app/javascript/components/widgets/widgets/people/economic-impact/initial-state.js
+++ b/app/javascript/components/widgets/widgets/people/economic-impact/initial-state.js
@@ -1,5 +1,7 @@
 export default {
-  title: 'Economic Impact of forests',
+  title: {
+    withLocation: 'Economic Impact of forests in {location}'
+  },
   config: {
     size: 'large',
     categories: ['people'],

--- a/app/javascript/components/widgets/widgets/people/forestry-employment/initial-state.js
+++ b/app/javascript/components/widgets/widgets/people/forestry-employment/initial-state.js
@@ -1,5 +1,7 @@
 export default {
-  title: 'Forestry Employment',
+  title: {
+    withLocation: 'Forestry Employment in {location}'
+  },
   config: {
     size: 'small',
     categories: ['people'],


### PR DESCRIPTION
For both translations and custom widget titles we needed to change them to use the same method as the dynamic sentences.