### PR TITLE
Feature - Low extent values

### DIFF
--- a/app/javascript/components/widgets/widgets/forest-change/fao-deforest/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/fao-deforest/selectors.js
@@ -60,6 +60,7 @@ export const getSentence = createSelector(
     const topFao = data.fao.filter(d => d.year === settings.period);
     const { deforest, humdef } = topFao[0];
     const totalDeforest = sumBy(data.rank, 'deforest');
+    const rate = currentLabel === 'global' ? totalDeforest : deforest;
 
     let sentence = humdef ? humanDeforest : initial;
     if (currentLabel === 'global') {
@@ -70,10 +71,13 @@ export const getSentence = createSelector(
       location: currentLabel,
       year: period && period.label,
       rate:
-        currentLabel === 'global'
-          ? `${format('.3s')(totalDeforest)}ha/yr`
-          : `${format('.3s')(deforest)}ha/yr`,
-      human: `${format('.3s')(humdef)}ha/yr`
+        rate < 1
+          ? `${format('.3r')(rate)}ha/yr`
+          : `${format('.3s')(rate)}ha/yr`,
+      human:
+        humdef < 1
+          ? `${format('.3r')(humdef)}ha/yr`
+          : `${format('.3s')(humdef)}ha/yr`
     };
 
     return {

--- a/app/javascript/components/widgets/widgets/forest-change/fao-reforest/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/fao-reforest/selectors.js
@@ -65,6 +65,8 @@ export const getSentence = createSelector(
     Object.keys(sortedData).forEach(k => {
       globalRate += sortedData[k].rate;
     });
+    const rate =
+      currentLabel === 'global' ? globalRate : countryData && countryData.value;
 
     let sentence = globalInitial;
     if (currentLabel !== 'global') {
@@ -75,9 +77,7 @@ export const getSentence = createSelector(
       location: currentLabel,
       year: period && period.label,
       rate:
-        currentLabel === 'global'
-          ? `${format('.3s')(globalRate)}ha/yr`
-          : `${format('.3s')(countryData && countryData.value)}ha/yr`
+        rate < 1 ? `${format('.3r')(rate)}ha/yr` : `${format('.3s')(rate)}ha/yr`
     };
 
     return {

--- a/app/javascript/components/widgets/widgets/forest-change/glad-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/glad-ranked/selectors.js
@@ -108,10 +108,14 @@ export const getSentence = createSelector(
       percentileLength += 1;
     }
     const topCount = percentileCount / totalCount * 100;
+    const countArea = sumBy(data, 'area');
     const params = {
       timeframe: options.weeks.find(w => w.value === settings.weeks).label,
       count: format(',')(sumBy(data, 'count')),
-      area: `${format('.3s')(sumBy(data, 'area'))}ha`,
+      area:
+        countArea < 1
+          ? `${format('.3r')(countArea)}ha`
+          : `${format('.3s')(countArea)}ha`,
       topPercent: `${format('.2r')(topCount)}%`,
       topRegions: percentileLength,
       location: currentLabel,

--- a/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
@@ -118,7 +118,7 @@ export const getSentence = createSelector(
 
     const params = {
       location: currentLabel === 'global' ? 'globally' : currentLabel,
-      gain: `${format('.3s')(gain)}ha`,
+      gain: gain < 1 ? `${format('.3r')(gain)}ha` : `${format('.3s')(gain)}ha`,
       indicator: (indicator && indicator.label.toLowerCase()) || 'region-wide',
       percent: areaPercent >= 0.1 ? `${format('.2r')(areaPercent)}%` : '<0.1%',
       globalPercent:

--- a/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/selectors.js
@@ -92,6 +92,16 @@ export const getSentence = createSelector(
       percentileGain += data[percentileLength].gain;
       percentileLength += 1;
     }
+    const value =
+      topRegion.percentage > 0 && settings.unit === '%'
+        ? `${format('.2r')(topRegion.percentage)}%`
+        : `${format('.3s')(topRegion.gain)}ha`;
+
+    const average =
+      topRegion.percentage > 0 && settings.unit === '%'
+        ? `${format('.2r')(avgGainPercentage)}%`
+        : `${format('.3s')(avgGain)}ha`;
+
     const topGain = percentileGain / totalGain * 100;
     let sentence = !indicator ? initialPercent : withIndicatorPercent;
     if (settings.unit !== '%') {
@@ -105,13 +115,13 @@ export const getSentence = createSelector(
       percentileLength,
       region: percentileLength > 1 ? topRegion.label : 'This region',
       value:
-        topRegion.percentage > 1 && settings.unit === '%'
-          ? `${format('.2r')(topRegion.percentage)}%`
-          : `${format('.3s')(topRegion.gain)}ha`,
+        topRegion.gain < 1 && settings.unit === 'ha'
+          ? `${format('.3r')(topRegion.gain)}ha`
+          : value,
       average:
-        topRegion.percentage > 1 && settings.unit === '%'
-          ? `${format('.2r')(avgGainPercentage)}%`
-          : `${format('.3s')(avgGain)}ha`
+        avgGain < 1 && settings.unit === 'ha'
+          ? `${format('.3r')(avgGain)}ha`
+          : average
     };
 
     return {

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/selectors.js
@@ -165,7 +165,10 @@ export const getSentence = createSelector(
       location: currentLabel === 'global' ? 'globally' : currentLabel,
       startYear,
       endYear,
-      loss: `${format('.3s')(totalLoss)}ha`,
+      loss:
+        totalLoss < 1
+          ? `${format('.3s')(totalLoss)}ha`
+          : `${format('.3s')(totalLoss)}ha`,
       percent: `${format('.2r')(percentageLoss)}%`,
       emissions: `${format('.3s')(totalEmissions)}t`,
       extentYear

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/selectors.js
@@ -107,6 +107,16 @@ export const getSentence = createSelector(
     }
     const topLoss = percentileLoss / totalLoss * 100 || 0;
     let sentence = !indicator ? initialPercent : withIndicatorPercent;
+    const value =
+      topRegion.percentage > 0 && settings.unit === '%'
+        ? `${format('.2r')(topRegion.percentage)}%`
+        : `${format('.3s')(topRegion.loss)}ha`;
+
+    const average =
+      topRegion.percentage > 0 && settings.unit === '%'
+        ? `${format('.2r')(avgLossPercentage)}%`
+        : `${format('.3s')(avgLoss)}ha`;
+
     if (settings.unit !== '%') {
       sentence = !indicator ? initial : withIndicator;
     }
@@ -123,13 +133,13 @@ export const getSentence = createSelector(
       percentileLength,
       region: percentileLength > 1 ? topRegion.label : 'This region',
       value:
-        topRegion.percentage > 1 && settings.unit === '%'
-          ? `${format('.2r')(topRegion.percentage)}%`
-          : `${format('.3s')(topRegion.loss)}ha`,
+        topRegion.loss < 1 && settings.unit === 'ha'
+          ? `${format('.3r')(topRegion.loss)}ha`
+          : value,
       average:
-        topRegion.percentage > 1 && settings.unit === '%'
-          ? `${format('.2r')(avgLossPercentage)}%`
-          : `${format('.3s')(avgLoss)}ha`
+        avgLoss < 1 && settings.unit === 'ha'
+          ? `${format('.3r')(avgLoss)}ha`
+          : average
     };
 
     return {

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
@@ -137,7 +137,7 @@ export const getSentence = createSelector(
       indicator_alt: indicatorName,
       startYear,
       endYear,
-      loss: loss ? `${format('.3s')(loss)}ha` : '0ha',
+      loss: loss < 1 ? `${format('.3r')(loss)}ha` : `${format('.3s')(loss)}ha`,
       percent: areaPercent >= 0.1 ? `${format('.2r')(areaPercent)}%` : '<0.1%',
       globalPercent:
         globalPercent >= 0.1 ? `${format('.2r')(globalPercent)}%` : '<0.1%',

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss/selectors.js
@@ -97,7 +97,9 @@ export const getSentence = createSelector(
       location: currentLabel,
       startYear,
       endYear,
-      loss: `${format('.3s')(totalLoss)}ha`,
+      loss: totalLoss
+        ? `${format('.3r')(totalLoss)}ha`
+        : `${format('.3s')(totalLoss)}ha`,
       percent: `${format('.2r')(percentageLoss)}%`,
       emissions: `${format('.3s')(totalEmissions)}t`,
       extentYear

--- a/app/javascript/components/widgets/widgets/land-cover/fao-cover/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/fao-cover/selectors.js
@@ -72,7 +72,10 @@ export const getSentence = createSelector(
 
     const params = {
       location: currentLabel !== 'global' ? currentLabel : 'globally',
-      extent: `${format('.3s')(extent)}ha`,
+      extent:
+        extent < 1
+          ? `${format('.3r')(extent)}ha`
+          : `${format('.3s')(extent)}ha`,
       primaryPercent:
         primaryPercent >= 0.1 ? `${format('.2r')(primaryPercent)}%` : '<0.1%'
     };

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
@@ -95,6 +95,15 @@ export const getSentence = createSelector(
     }
     const topExtent = percentileExtent / (totalExtent || 0) * 100;
 
+    const topRegionExtent =
+      topRegion.extent < 1
+        ? `${format('.3r')(topRegion.extent)}ha`
+        : `${format('.3s')(topRegion.extent)}ha`;
+    const aveRegionExtent =
+      avgExtent < 1
+        ? `${format('.3r')(avgExtent)}ha`
+        : `${format('.3s')(avgExtent)}ha`;
+
     const params = {
       location: currentLabel === 'global' ? 'Globally' : currentLabel,
       region: topRegion.label,
@@ -104,11 +113,11 @@ export const getSentence = createSelector(
       value:
         settings.unit === '%'
           ? `${format('.2r')(topRegion.percentage)}%`
-          : `${format('.3s')(topRegion.extent)}ha`,
+          : topRegionExtent,
       average:
         settings.unit === '%'
           ? `${format('.2r')(avgExtentPercentage)}%`
-          : `${format('.3s')(avgExtent)}ha`,
+          : aveRegionExtent,
       count: percentileLength
     };
 

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-plantations/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-plantations/selectors.js
@@ -45,13 +45,21 @@ export const getSentence = createSelector(
     const top =
       settings.type === 'bound2' ? data.slice(0, 2) : data.slice(0, 1);
     const areaPerc = 100 * sumBy(top, 'value') / rawData.totalArea;
+    const topExtent = sumBy(top, 'value');
+    const otherExtent = sumBy(data.slice(2), 'value');
     const params = {
       location: currentLabel,
       firstSpecies: top[0].label.toLowerCase(),
       secondSpecies: top.length > 1 && top[1].label.toLowerCase(),
       type: settings.type === 'bound2' ? 'species' : 'type',
-      extent: `${format('.3s')(sumBy(top, 'value'))}ha`,
-      other: `${format('.3s')(sumBy(data.slice(2), 'value'))}ha`,
+      extent:
+        topExtent < 1
+          ? `${format('.3r')(topExtent)}ha`
+          : `${format('.3s')(topExtent)}ha`,
+      other:
+        otherExtent < 1
+          ? `${format('.3r')(otherExtent)}ha`
+          : `${format('.3s')(otherExtent)}ha`,
       count: data.length - top.length,
       topType: `${top[0].label}${endsWith(top[0].label, 's') ? '' : 's'}`,
       percent: areaPerc >= 0.1 ? `${format('.2r')(areaPerc)}%` : '<0.1%'

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/selectors.js
@@ -100,7 +100,10 @@ export const getSentence = createSelector(
     const params = {
       extentYear: settings.extentYear,
       location: currentLocation.label,
-      extent: `${extent ? format('.3s')(extent) : '0'}ha`,
+      extent:
+        extent < 1
+          ? `${format('.3r')(extent)}ha`
+          : `${format('.3s')(extent)}ha`,
       indicator: indicator && indicator.value.toLowerCase(),
       landPercentage:
         landPercent >= 0.1 ? `${format('.2r')(landPercent)}%` : '<0.1%',

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover/selectors.js
@@ -66,7 +66,10 @@ export const getSentence = createSelector(
       indicator: indicator && indicator.label.toLowerCase(),
       percentage:
         percentCover >= 0.1 ? `${format('.2r')(percentCover)}%` : '<0.1%',
-      value: `${format('.3s')(data.cover)}ha`
+      value:
+        data.cover < 1
+          ? `${format('.3r')(data.cover)}ha`
+          : `${format('.3s')(data.cover)}ha`
     };
     let sentence = indicator ? withIndicator : initial;
     if (currentLabel === 'global') {

--- a/app/javascript/pages/dashboards/header/header-selectors.js
+++ b/app/javascript/pages/dashboards/header/header-selectors.js
@@ -48,7 +48,8 @@ export const getSentence = createSelector(
     }
     if (isEmpty(data) || isEmpty(locationNames)) return {};
     const { initial, withLoss, withPlantationLoss } = sentences;
-    const extent = format('.3s')(data.extent);
+    const extent =
+      data.extent < 1 ? format('.3r')(data.extent) : format('.3s')(data.extent);
     const percentageCover = format('.1f')(data.extent / data.totalArea * 100);
     const lossWithOutPlantations = format('.2s')(
       data.totalLoss.area - (data.plantationsLoss.area || 0)


### PR DESCRIPTION
## Overview

All widget dynamic sentences should now report loss/gain/extent areas that are less than 1ha as a 3sf value instead of using symbol notation:

> e.g. 0.135 ha *instead of* 135 mha

## Testing

Please test all widgets - its difficult to find numbers in some cases! Most importantly, check that changing units (ha/%) still works as it should.

