### PR TITLE
Removes uncorrect Other Tree Cover values

### DIFF
--- a/app/javascript/components/widgets/widgets/land-cover/fao-cover/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/fao-cover/selectors.js
@@ -45,7 +45,7 @@ export const parseData = createSelector(
       },
       {
         label: 'Other Tree Cover',
-        value: otherCover,
+        value: otherCover > 0 ? otherCover : 0,
         percentage: otherCover / area_ha * 100,
         color: colorRange[6]
       },

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/initial-state.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/initial-state.js
@@ -26,7 +26,7 @@ export default {
   settings: {
     threshold: 30,
     unit: '%',
-    extentYear: 2000,
+    extentYear: 2010,
     layers: ['forest2010']
   },
   enabled: true


### PR DESCRIPTION
## Overview

There seems to be an error in the FAO dataset (possibly rounding on their part) where the sum of all the forest types can be greater than the measured extent, resulting in this:

![screen shot 2018-05-31 at 11 39 26](https://user-images.githubusercontent.com/30242314/40775041-693ae722-64c7-11e8-85c7-f0f140b73962.png)

To avoid this, we now check that the sum of forest types **does not** exceed the extent. If it does, ignore it and set Other Tree Cover to 0ha.

If sum of forest types is less than total extent, Other tree cover is the remainder.

## Note

Also bundled in a new default setting for Tree Cover Ranking that was missed.