### PR TITLE
Fix/widget query navigation

### DIFF
--- a/app/javascript/components/widgets/components/widget-numbered-list/component.jsx
+++ b/app/javascript/components/widgets/components/widget-numbered-list/component.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import NumberedList from 'components/numbered-list';
 
-class WidgetTreeLocated extends PureComponent {
+class WidgetNumberedList extends PureComponent {
   render() {
     const {
       parsedData,
@@ -32,7 +32,7 @@ class WidgetTreeLocated extends PureComponent {
   }
 }
 
-WidgetTreeLocated.propTypes = {
+WidgetNumberedList.propTypes = {
   parsedData: PropTypes.array,
   settings: PropTypes.object.isRequired,
   setWidgetSettingsUrl: PropTypes.func.isRequired,
@@ -40,4 +40,4 @@ WidgetTreeLocated.propTypes = {
   widget: PropTypes.string
 };
 
-export default WidgetTreeLocated;
+export default WidgetNumberedList;

--- a/app/javascript/components/widgets/utils.js
+++ b/app/javascript/components/widgets/utils.js
@@ -1,0 +1,4 @@
+export const getAdminPath = ({ country, region, query, id }) =>
+  `/dashboards/country/${country ? `${country}/` : ''}${
+    region ? `${region}/` : ''
+  }${id}${query && query.category ? `?category=${query.category}` : ''}`;

--- a/app/javascript/components/widgets/widgets/forest-change/fao-deforest/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/fao-deforest/selectors.js
@@ -3,8 +3,11 @@ import findIndex from 'lodash/findIndex';
 import sumBy from 'lodash/sumBy';
 import { format } from 'd3-format';
 
+import { getAdminPath } from '../../../utils';
+
 const getData = state => state.data || null;
 const getLocation = state => state.payload || null;
+const getQuery = state => state.query || null;
 const getCurrentLocation = state => state.currentLabel || null;
 const getColors = state => state.colors || null;
 const getSettings = state => state.settings || null;
@@ -12,8 +15,8 @@ const getPeriod = state => state.period || null;
 const getSentences = state => state.config && state.config.sentences;
 
 export const parseData = createSelector(
-  [getData, getLocation, getColors],
-  (data, location, colors) => {
+  [getData, getLocation, getColors, getQuery],
+  (data, location, colors, query) => {
     if (!data || !data.rank) return null;
 
     const { rank } = data;
@@ -33,7 +36,7 @@ export const parseData = createSelector(
       ...d,
       label: d.name,
       color: colors.main,
-      path: `/dashboards/country/${d.iso}`,
+      path: getAdminPath({ query, id: d.iso }),
       value: d.deforest
     }));
   }

--- a/app/javascript/components/widgets/widgets/forest-change/fao-reforest/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/fao-reforest/selectors.js
@@ -4,8 +4,11 @@ import findIndex from 'lodash/findIndex';
 import { sortByKey } from 'utils/data';
 import { format } from 'd3-format';
 
+import { getAdminPath } from '../../../utils';
+
 const getData = state => state.data || null;
 const getLocation = state => state.payload || null;
+const getQuery = state => state.query || null;
 const getColors = state => state.colors || null;
 const getCurrentLocation = state => state.currentLabel || null;
 const getSettings = state => state.settings || null;
@@ -21,8 +24,8 @@ export const getSortedData = createSelector([getData], data => {
 });
 
 export const parseData = createSelector(
-  [getSortedData, getLocation, getColors],
-  (data, location, colors) => {
+  [getSortedData, getLocation, getColors, getQuery],
+  (data, location, colors, query) => {
     if (!data || !data.length) return null;
     const locationIndex = findIndex(data, d => d.iso === location.country);
     let trimStart = locationIndex - 2;
@@ -40,7 +43,7 @@ export const parseData = createSelector(
       ...d,
       label: d.name,
       color: colors.main,
-      path: `/dashboards/country/${d.iso}`,
+      path: getAdminPath({ query, id: d.iso }),
       value: d.rate
     }));
   }

--- a/app/javascript/components/widgets/widgets/forest-change/glad-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/glad-ranked/selectors.js
@@ -6,6 +6,8 @@ import groupBy from 'lodash/groupBy';
 import sumBy from 'lodash/sumBy';
 import moment from 'moment';
 
+import { getAdminPath } from '../../../utils';
+
 // get list data
 const getData = state => (state.data && state.data.alerts) || null;
 const getLatestDates = state => (state.data && state.data.latest) || null;
@@ -14,6 +16,7 @@ const getSettings = state => state.settings || null;
 const getOptions = state => state.options || null;
 const getIndicator = state => state.indicator || null;
 const getLocation = state => state.payload || null;
+const getQuery = state => state.query || null;
 const getLocationsMeta = state =>
   (!state.payload.region ? state.regions : state.subRegions) || null;
 const getCurrentLocation = state => state.currentLabel || null;
@@ -27,10 +30,11 @@ export const parseData = createSelector(
     getExtent,
     getSettings,
     getLocation,
+    getQuery,
     getLocationsMeta,
     getColors
   ],
-  (data, latest, extent, settings, location, meta, colors) => {
+  (data, latest, extent, settings, location, query, meta, colors) => {
     if (!data || isEmpty(data) || !meta || isEmpty(meta)) return null;
     const latestWeek = moment(latest)
       .subtract(1, 'weeks')
@@ -73,9 +77,7 @@ export const parseData = createSelector(
         area: countsArea,
         value: settings.unit === 'ha' ? countsArea : countsAreaPerc,
         label: (region && region.label) || '',
-        path: `/dashboards/country/${location.country}/${
-          location.region ? `${location.region}/` : ''
-        }${k}`
+        path: getAdminPath({ ...location, query, id: k })
       };
     });
     return sortBy(mappedData, 'value').reverse();

--- a/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
@@ -5,10 +5,13 @@ import findIndex from 'lodash/findIndex';
 import { sortByKey } from 'utils/data';
 import { format } from 'd3-format';
 
+import { getAdminPath } from '../../../utils';
+
 // get list data
 const getData = state => state.data || null;
 const getSettings = state => state.settings || null;
 const getLocation = state => state.payload || null;
+const getQuery = state => state.query || null;
 const getLocationsMeta = state =>
   state[state.adminKey] || state.countries || null;
 const getColors = state => state.colors || null;
@@ -39,11 +42,12 @@ export const parseData = createSelector(
     getSortedData,
     getSettings,
     getLocation,
+    getQuery,
     getCurrentLocation,
     getLocationsMeta,
     getColors
   ],
-  (data, settings, location, currentLocation, meta, colors) => {
+  (data, settings, location, query, currentLocation, meta, colors) => {
     if (!data || !data.length) return null;
     const locationIndex = findIndex(data, d => d.id === currentLocation.value);
     let trimStart = locationIndex - 2;
@@ -59,20 +63,17 @@ export const parseData = createSelector(
     const dataTrimmed = data.slice(trimStart, trimEnd);
     return dataTrimmed.map(d => {
       const locationData = meta && meta.find(l => d.id === l.value);
-      let path = '/dashboards/country/';
-      if (location.subRegion) {
-        path += `${location.country}/${location.region}/${d.id}`;
-      } else if (location.region) {
-        path += `${location.country}/${d.id}`;
-      } else {
-        path += d.id;
-      }
 
       return {
         ...d,
         label: (locationData && locationData.label) || '',
         color: colors.main,
-        path,
+        path: getAdminPath({
+          ...location,
+          country: location.region && location.country,
+          query,
+          id: d.id
+        }),
         value: settings.unit === 'ha' ? d.gain : d.percentage
       };
     });

--- a/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/selectors.js
@@ -5,6 +5,8 @@ import sumBy from 'lodash/sumBy';
 import { sortByKey } from 'utils/data';
 import { format } from 'd3-format';
 
+import { getAdminPath } from '../../../utils';
+
 // get list data
 const getGain = state => (state.data && state.data.gain) || null;
 const getExtent = state => (state.data && state.data.extent) || null;
@@ -12,6 +14,7 @@ const getSettings = state => state.settings || null;
 const getOptions = state => state.options || null;
 const getIndicator = state => state.indicator || null;
 const getLocation = state => state.payload || null;
+const getQuery = state => state.query || null;
 const getLocationsMeta = state =>
   (state.payload.region ? state.subRegions : state.regions) || null;
 const getCurrentLocation = state => state.currentLabel || null;
@@ -19,8 +22,16 @@ const getColors = state => state.colors || null;
 const getSentences = state => state.config.sentences || null;
 
 export const getSortedData = createSelector(
-  [getGain, getExtent, getSettings, getLocation, getLocationsMeta, getColors],
-  (data, extent, settings, location, meta, colors) => {
+  [
+    getGain,
+    getExtent,
+    getSettings,
+    getLocation,
+    getQuery,
+    getLocationsMeta,
+    getColors
+  ],
+  (data, extent, settings, location, query, meta, colors) => {
     if (isEmpty(data) || isEmpty(meta)) return null;
     const dataMapped = [];
     data.forEach(d => {
@@ -33,9 +44,7 @@ export const getSortedData = createSelector(
           gain: d.gain,
           percentage,
           value: settings.unit === 'ha' ? d.gain : percentage,
-          path: `/dashboards/country/${location.country}/${
-            location.region ? `${location.region}/` : ''
-          }${d.id}`,
+          path: getAdminPath({ ...location, query, id: d.id }),
           color: colors.main
         });
       }
@@ -78,7 +87,7 @@ export const getSentence = createSelector(
       withIndicatorPercent
     } = sentences;
     const totalGain = sumBy(data, 'gain');
-    const topRegion = sortedData.length && sortedData[0];
+    const topRegion = (sortedData && sortedData.length && sortedData[0]) || {};
     const avgGainPercentage = sumBy(data, 'percentage') / data.length;
     const avgGain = sumBy(data, 'gain') / data.length;
     let percentileGain = 0;

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/selectors.js
@@ -5,6 +5,8 @@ import sumBy from 'lodash/sumBy';
 import { sortByKey } from 'utils/data';
 import { format } from 'd3-format';
 
+import { getAdminPath } from '../../../utils';
+
 // get list data
 const getLoss = state => (state.data && state.data.lossByRegion) || null;
 const getExtent = state => (state.data && state.data.extent) || null;
@@ -12,6 +14,7 @@ const getSettings = state => state.settings || null;
 const getOptions = state => state.options || null;
 const getIndicator = state => state.indicator || null;
 const getLocation = state => state.payload || null;
+const getQuery = state => state.query || null;
 const getLocationsMeta = state =>
   (state.payload.region ? state.subRegions : state.regions) || null;
 const getCurrentLocation = state => state.currentLabel || null;
@@ -19,8 +22,8 @@ const getColors = state => state.colors || null;
 const getSentences = state => state.config && state.config.sentences;
 
 export const mapData = createSelector(
-  [getLoss, getExtent, getSettings, getLocation, getLocationsMeta],
-  (data, extent, settings, location, meta) => {
+  [getLoss, getExtent, getSettings, getLocation, getLocationsMeta, getQuery],
+  (data, extent, settings, location, meta, query) => {
     if (isEmpty(data) || isEmpty(meta)) return null;
     const { startYear, endYear } = settings;
     const mappedData = data.map(d => {
@@ -37,9 +40,7 @@ export const mapData = createSelector(
         loss,
         percentage,
         value: settings.unit === 'ha' ? loss : percentage,
-        path: `/dashboards/country/${location.country}/${
-          location.region ? `${location.region}/` : ''
-        }${d.id}`
+        path: getAdminPath({ ...location, query, id: d.id })
       };
     });
 
@@ -91,7 +92,7 @@ export const getSentence = createSelector(
     } = sentences;
     const { startYear, endYear } = settings;
     const totalLoss = sumBy(data, 'loss');
-    const topRegion = sortedData.length && sortedData[0];
+    const topRegion = (sortedData && sortedData.length && sortedData[0]) || {};
     const avgLossPercentage = sumBy(data, 'percentage') / data.length;
     const avgLoss = sumBy(data, 'loss') / data.length;
     let percentileLoss = 0;

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
@@ -7,6 +7,8 @@ import sumBy from 'lodash/sumBy';
 import { sortByKey } from 'utils/data';
 import { format } from 'd3-format';
 
+import { getAdminPath } from '../../../utils';
+
 // get list data
 const getData = state => state.data || null;
 const getSettings = state => state.settings || null;
@@ -14,6 +16,7 @@ const getLocation = state => state.payload || null;
 const getLocationsMeta = state => state.countries || null;
 const getColors = state => state.colors || null;
 const getIndicator = state => state.indicator || null;
+const getQuery = state => state.query || null;
 const getCurrentLocation = state => state.currentLocation || null;
 const getSentences = state => state.config && state.config.sentences;
 
@@ -70,9 +73,10 @@ export const parseData = createSelector(
     getLocation,
     getCurrentLocation,
     getLocationsMeta,
-    getColors
+    getColors,
+    getQuery
   ],
-  (data, settings, location, currentLocation, meta, colors) => {
+  (data, settings, location, currentLocation, meta, colors, query) => {
     if (!data || !data.length) return null;
     const locationIndex = findIndex(
       data,
@@ -91,20 +95,17 @@ export const parseData = createSelector(
     const dataTrimmed = data.slice(trimStart, trimEnd);
     return dataTrimmed.map(d => {
       const locationData = meta && meta.find(l => d.id === l.value);
-      let path = '/dashboards/country/';
-      if (location.subRegion) {
-        path += `${location.country}/${location.region}/${d.id}`;
-      } else if (location.region) {
-        path += `${location.country}/${d.id}`;
-      } else {
-        path += d.id;
-      }
 
       return {
         ...d,
         label: (locationData && locationData.label) || '',
         color: colors.main,
-        path,
+        path: getAdminPath({
+          ...location,
+          country: location.region && location.country,
+          query,
+          id: d.id
+        }),
         value: settings.unit === 'ha' ? d.loss : d.percentage
       };
     });

--- a/app/javascript/components/widgets/widgets/land-cover/ranked-plantations/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/ranked-plantations/selectors.js
@@ -105,7 +105,7 @@ export const getSentence = createSelector(
   (data, settings, location, currentLabel, sentences) => {
     if (!data || !data.length) return null;
     const { initial } = sentences;
-    const topRegion = data[0];
+    const topRegion = data[0] || {};
     const topPlantation = maxBy(
       remove(
         Object.keys(topRegion).map(k => ({

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
@@ -4,6 +4,7 @@ import uniqBy from 'lodash/uniqBy';
 import sumBy from 'lodash/sumBy';
 import { sortByKey } from 'utils/data';
 import { format } from 'd3-format';
+import { getAdminPath } from '../../../utils';
 
 // get list data
 const getData = state => state.data || null;
@@ -11,17 +12,17 @@ const getSettings = state => state.settings || null;
 const getOptions = state => state.options || null;
 const getIndicator = state => state.indicator || null;
 const getLocation = state => state.payload || null;
+const getQuery = state => state.query || null;
 const getLocationsMeta = state => state[state.childKey] || null;
 const getCurrentLocation = state => state.currentLabel || null;
 const getColors = state => state.colors || null;
 const getSentences = state => state.config && state.config.sentences;
 
 export const parseList = createSelector(
-  [getData, getSettings, getLocation, getLocationsMeta, getColors],
-  (data, settings, location, meta, colors) => {
+  [getData, getSettings, getLocation, getLocationsMeta, getColors, getQuery],
+  (data, settings, location, meta, colors, query) => {
     if (isEmpty(data) || isEmpty(meta)) return null;
     const dataMapped = [];
-    const { type, country, region } = location;
     data.forEach(d => {
       const regionMeta = meta.find(l => d.id === l.value);
       if (regionMeta) {
@@ -30,9 +31,7 @@ export const parseList = createSelector(
           extent: d.extent,
           percentage: d.percentage,
           value: settings.unit === 'ha' ? d.extent : d.percentage,
-          path: `/dashboards/${type || 'global'}/${country}/${
-            region ? `${region}/` : ''
-          }${d.id}`,
+          path: getAdminPath({ ...location, query, id: d.id }),
           color: colors.main
         });
       }
@@ -79,7 +78,7 @@ export const getSentence = createSelector(
       percGlobalWithIndicator,
       noCover
     } = sentences;
-    const topRegion = data.length && data[0];
+    const topRegion = (data.length && data[0]) || {};
     const totalExtent = sumBy(data, 'extent');
     const avgExtent = sumBy(data, 'extent') / data.length;
     const avgExtentPercentage = sumBy(data, 'percentage') / data.length;

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/selectors.js
@@ -4,11 +4,13 @@ import findIndex from 'lodash/findIndex';
 import { sortByKey } from 'utils/data';
 import { format } from 'd3-format';
 import sumBy from 'lodash/sumBy';
+import { getAdminPath } from '../../../utils';
 
 // get list data
 const getData = state => state.data || null;
 const getSettings = state => state.settings || null;
 const getLocation = state => state.payload || null;
+const getQuery = state => state.query || null;
 const getLocationsMeta = state => state.countries || null;
 const getColors = state => state.colors || null;
 const getIndicator = state => state.indicator || null;
@@ -37,9 +39,10 @@ export const parseData = createSelector(
     getLocation,
     getCurrentLocation,
     getLocationsMeta,
-    getColors
+    getColors,
+    getQuery
   ],
-  (data, settings, location, currentLocation, meta, colors) => {
+  (data, settings, location, currentLocation, meta, colors, query) => {
     if (!data || !data.length || !currentLocation || !meta) return null;
     const locationIndex = findIndex(
       data,
@@ -59,20 +62,12 @@ export const parseData = createSelector(
     const dataTrimmed = data.slice(trimStart, trimEnd);
     return dataTrimmed.map(d => {
       const locationData = meta && meta.find(l => d.id === l.value);
-      let path = '/dashboards/country/';
-      if (location.subRegion) {
-        path += `${location.country}/${location.region}/${d.id}`;
-      } else if (location.region) {
-        path += `${location.country}/${d.id}`;
-      } else {
-        path += d.id;
-      }
 
       return {
         ...d,
         label: (locationData && locationData.label) || '',
         color: colors.main,
-        path,
+        path: getAdminPath({ ...location, query, id: d.id }),
         value: settings.unit === 'ha' ? d.extent : d.percentage
       };
     });

--- a/app/javascript/pages/dashboards/header/header-component.js
+++ b/app/javascript/pages/dashboards/header/header-component.js
@@ -25,7 +25,8 @@ class Header extends PureComponent {
       shareData,
       payload,
       forestAtlasLink,
-      sentence
+      sentence,
+      query
     } = this.props;
 
     return (
@@ -42,7 +43,7 @@ class Header extends PureComponent {
               ...location
             }}
             tooltip={{
-              text: `Download the country data${
+              text: `Download the data${
                 locationNames.country
                   ? ` for ${locationNames.country.label}`
                   : ''
@@ -74,7 +75,7 @@ class Header extends PureComponent {
                 noSelectedValue="Select a country"
                 value={locationNames.country}
                 options={locationOptions.countries}
-                onChange={handleCountryChange}
+                onChange={country => handleCountryChange(country, query)}
                 searchable
                 disabled={loading}
                 tooltip={{
@@ -95,7 +96,7 @@ class Header extends PureComponent {
                     value={locationNames.region}
                     options={locationOptions.regions}
                     onChange={region =>
-                      handleRegionChange(locationNames.country, region)
+                      handleRegionChange(locationNames.country, region, query)
                     }
                     searchable
                     disabled={loading}
@@ -123,7 +124,8 @@ class Header extends PureComponent {
                       handleSubRegionChange(
                         locationNames.country,
                         locationNames.region,
-                        subRegion
+                        subRegion,
+                        query
                       )
                     }
                     searchable
@@ -173,7 +175,8 @@ Header.propTypes = {
   shareData: PropTypes.object.isRequired,
   payload: PropTypes.object.isRequired,
   forestAtlasLink: PropTypes.object,
-  sentence: PropTypes.object
+  sentence: PropTypes.object,
+  query: PropTypes.object
 };
 
 export default Header;

--- a/app/javascript/pages/dashboards/header/header.js
+++ b/app/javascript/pages/dashboards/header/header.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 
 import { COUNTRY } from 'pages/dashboards/router';
-import { decodeUrlForState, encodeStateForUrl } from 'utils/stateToUrl';
 import { deburrUpper } from 'utils/data';
 
 import shareActions from 'components/modals/share/share-actions';
@@ -54,27 +53,10 @@ const mapStateToProps = ({ countryData, location, header, widgets, cache }) => {
   };
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => {
-  const { query, widgets } = ownProps;
-  const widgetQueries = {};
-  if (query) {
-    Object.keys(query).forEach(key => {
-      if (Object.keys(widgets).indexOf(key) > -1) {
-        widgetQueries[key] = encodeStateForUrl({
-          ...decodeUrlForState(query[key]),
-          indicator: widgets[key].settings.indicator
-        });
-      }
-    });
-  }
-  const newQuery = {
-    ...query,
-    ...widgetQueries
-  };
-
-  return bindActionCreators(
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(
     {
-      handleCountryChange: country => ({
+      handleCountryChange: (country, query) => ({
         type: COUNTRY,
         payload: {
           type: country ? 'country' : 'global',
@@ -82,9 +64,12 @@ const mapDispatchToProps = (dispatch, ownProps) => {
           region: undefined,
           subRegion: undefined
         },
-        query: newQuery
+        ...(!!query &&
+          query.category && {
+            query: { category: query.category }
+          })
       }),
-      handleRegionChange: (country, region) => ({
+      handleRegionChange: (country, region, query) => ({
         type: COUNTRY,
         payload: {
           type: 'country',
@@ -92,9 +77,12 @@ const mapDispatchToProps = (dispatch, ownProps) => {
           ...(!!region && region.value && { region: region.value }),
           subRegion: undefined
         },
-        query: newQuery
+        ...(!!query &&
+          query.category && {
+            query: { category: query.category }
+          })
       }),
-      handleSubRegionChange: (country, region, subRegion) => ({
+      handleSubRegionChange: (country, region, subRegion, query) => ({
         type: COUNTRY,
         payload: {
           type: 'country',
@@ -102,13 +90,15 @@ const mapDispatchToProps = (dispatch, ownProps) => {
           region: region.value,
           ...(!!subRegion && subRegion.value && { subRegion: subRegion.value })
         },
-        query: newQuery
+        ...(!!query &&
+          query.category && {
+            query: { category: query.category }
+          })
       }),
       ...actions
     },
     dispatch
   );
-};
 
 class HeaderContainer extends PureComponent {
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
We had the frustrating situation where the paths in some widgets were not working correctly. This lead to difficult maintenance. A util file has been created with a helper for creating the path in the selectors. 

Additionally, the category selected is persistent when changing location in the dashboard.