### PR TITLE
reset forestType and landCategory when changing route

### DIFF
--- a/app/javascript/pages/dashboards/page/page-component.js
+++ b/app/javascript/pages/dashboards/page/page-component.js
@@ -34,7 +34,8 @@ class Page extends PureComponent {
       activeWidget,
       setMapZoom,
       widgets,
-      title
+      title,
+      query
     } = this.props;
 
     return (
@@ -49,7 +50,7 @@ class Page extends PureComponent {
           </Button>
         )}
         <div className="content-panel">
-          <Header className="header" />
+          <Header className="header" widgets={widgets} query={query} />
           <SubNavMenu
             className="nav"
             theme="theme-subnav-dark"
@@ -104,7 +105,8 @@ Page.propTypes = {
   widgetAnchor: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   activeWidget: PropTypes.string,
   setMapZoom: PropTypes.func,
-  title: PropTypes.string
+  title: PropTypes.string,
+  query: PropTypes.object
 };
 
 export default Page;


### PR DESCRIPTION
BUG FIX: when changing routes on the header of the dashboard, the widget settings for forestType and landCategory were not reseting (not good with whitelists). Now they do.