### PR TITLE
Updates gain widgets

### DIFF
--- a/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/initial-state.js
@@ -9,7 +9,7 @@ export default {
     units: ['ha', '%'],
     categories: ['summary', 'forest-change'],
     admins: ['global', 'country', 'region', 'subRegion'],
-    selectors: ['forestTypes', 'landCategories', 'extentYears', 'units'],
+    selectors: ['forestTypes', 'landCategories', 'units'],
     type: 'gain',
     metaKey: 'widget_tree_cover_gain',
     layers: ['forestgain'],
@@ -19,23 +19,23 @@ export default {
     },
     sentences: {
       globalInitial:
-        'From 2001 to 2012, {gain} of tree cover was gained {location}, equivalent to a {globalPercent} increase since {extentYear}.',
+        'From 2001 to 2012, {gain} of tree cover was gained {location}.',
       globalWithIndicator:
-        'From 2001 to 2012, {gain} of tree cover was gained within {indicator} {location}, equivalent to a {globalPercent} increase since {extentYear}.',
+        'From 2001 to 2012, {gain} of tree cover was gained within {indicator} {location}.',
       initial:
-        'From 2001 to 2012, {location} gained {gain} of tree cover {indicator}, equivalent to a {percent} increase since {extentYear} and {gainPercent} of global tree cover gain.',
+        'From 2001 to 2012, {location} gained {gain} of tree cover {indicator} equal to {gainPercent} of global tree cover gain.',
       withIndicator:
-        'From 2001 to 2012, {location} gained {gain} of tree cover in {indicator}, equivalent to a {percent} increase since {extentYear} and {gainPercent} of global tree cover gain.',
+        'From 2001 to 2012, {location} gained {gain} of tree cover in {indicator} equal to {gainPercent} of global tree cover gain.',
       regionInitial:
-        'From 2001 to 2012, {location} gained {gain} of tree cover {indicator}, equivalent to a {percent} increase since {extentYear} and {gainPercent} of all tree cover gain in {parent}.',
+        'From 2001 to 2012, {location} gained {gain} of tree cover {indicator} equal to {gainPercent} of all tree cover gain in {parent}.',
       regionWithIndicator:
-        'From 2001 to 2012, {location} gained {gain} of tree cover in {indicator}, equivalent to a {percent} increase since {extentYear} and {gainPercent} of all tree cover gain in {parent}.'
+        'From 2001 to 2012, {location} gained {gain} of tree cover in {indicator} equal to {gainPercent} of all tree cover gain in {parent}.'
     }
   },
   settings: {
     threshold: 0,
-    unit: '%',
     extentYear: 2000,
+    unit: 'ha',
     layers: ['forestgain']
   },
   enabled: true

--- a/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
@@ -113,7 +113,6 @@ export const getSentence = createSelector(
     const locationData =
       currentLocation && data.find(l => l.id === currentLocation.value);
     const gain = locationData ? locationData.gain : sumBy(data, 'gain');
-    const globalPercent = gain ? 100 * gain / sumBy(data, 'extent') : 0;
     const gainPercent = gain ? 100 * gain / sumBy(data, 'gain') : 0;
     const areaPercent = (locationData && locationData.percentage) || 0;
 
@@ -122,11 +121,8 @@ export const getSentence = createSelector(
       gain: gain < 1 ? `${format('.3r')(gain)}ha` : `${format('.3s')(gain)}ha`,
       indicator: (indicator && indicator.label.toLowerCase()) || 'region-wide',
       percent: areaPercent >= 0.1 ? `${format('.2r')(areaPercent)}%` : '<0.1%',
-      globalPercent:
-        globalPercent >= 0.1 ? `${format('.2r')(globalPercent)}%` : '<0.1%',
       gainPercent:
         gainPercent >= 0.1 ? `${format('.2r')(gainPercent)}%` : '<0.1%',
-      extentYear: settings.extentYear,
       parent: parent && parent.label
     };
 

--- a/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/initial-state.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/initial-state.js
@@ -30,7 +30,7 @@ export default {
   },
   settings: {
     threshold: 0,
-    unit: '%',
+    unit: 'ha',
     extentYear: 2000,
     pageSize: 5,
     page: 0,


### PR DESCRIPTION
## Overview

Quick update to gain sentences and defaults as per feedback.

- sentences no longer reference gain relative to extent (apples & oranges)
- removes extent year option
