### PR TITLE
Removes mHa from vertical axis in Composed Chart

### DIFF
--- a/app/javascript/components/charts/composed-chart/composed-chart-component.js
+++ b/app/javascript/components/charts/composed-chart/composed-chart-component.js
@@ -99,7 +99,14 @@ class CustomComposedChart extends PureComponent {
                 <CustomTick
                   dataMax={maxYValue}
                   unit={unit || ''}
-                  unitFormat={unitFormat || (value => format('.2s')(value))}
+                  unitFormat={
+                    unitFormat ||
+                    (value => {
+                      const formattedValue =
+                        value < 1 ? format('.2r')(value) : format('.2s')(value);
+                      return formattedValue;
+                    })
+                  }
                   fill="#555555"
                 />
               }


### PR DESCRIPTION
## Overview

If unit is `ha` and *<1* it will swap units to be formatted as '.2r' instead of using symbols.