### PR TITLE
Fixes Emissions Calculations in Natural Forest Loss widget

### DIFF
--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-plantations/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-plantations/selectors.js
@@ -4,6 +4,7 @@ import groupBy from 'lodash/groupBy';
 import { format } from 'd3-format';
 import { formatNumber } from 'utils/format';
 import { getColorPalette } from 'utils/data';
+import { biomassToCO2 } from 'utils/calculations';
 
 // get list data
 const getLoss = state => (state.data && state.data.loss) || null;
@@ -93,7 +94,7 @@ export const getSentence = createSelector(
       startYear,
       endYear,
       lossPhrase,
-      value: `${format('.3s')(outsideEmissions)}t`,
+      value: `${format('.3s')(biomassToCO2(outsideEmissions))}t`,
       percentage: formatNumber({ num: percentage, unit: '%' })
     };
 

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss/selectors.js
@@ -3,7 +3,6 @@ import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import { format } from 'd3-format';
 import moment from 'moment';
-import { biomassToCO2 } from 'utils/calculations';
 
 // get list data
 const getLoss = state => (state.data && state.data.loss) || null;
@@ -84,7 +83,7 @@ export const getSentence = createSelector(
     const { startYear, endYear, extentYear } = settings;
     const totalLoss = (data && data.length && sumBy(data, 'area')) || 0;
     const totalEmissions =
-      (data && data.length && biomassToCO2(sumBy(data, 'emissions'))) || 0;
+      (data && data.length && sumBy(data, 'emissions')) || 0;
     const percentageLoss =
       (totalLoss && extent && totalLoss / extent * 100) || 0;
     let sentence = indicator ? withIndicator : initial;

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss/selectors.js
@@ -3,6 +3,7 @@ import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import { format } from 'd3-format';
 import moment from 'moment';
+import { biomassToCO2 } from 'utils/calculations';
 
 // get list data
 const getLoss = state => (state.data && state.data.loss) || null;
@@ -83,7 +84,7 @@ export const getSentence = createSelector(
     const { startYear, endYear, extentYear } = settings;
     const totalLoss = (data && data.length && sumBy(data, 'area')) || 0;
     const totalEmissions =
-      (data && data.length && sumBy(data, 'emissions')) || 0;
+      (data && data.length && biomassToCO2(sumBy(data, 'emissions'))) || 0;
     const percentageLoss =
       (totalLoss && extent && totalLoss / extent * 100) || 0;
     let sentence = indicator ? withIndicator : initial;

--- a/app/javascript/pages/dashboards/header/header-selectors.js
+++ b/app/javascript/pages/dashboards/header/header-selectors.js
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import { biomassToCO2 } from 'utils/calculations';
 import isEmpty from 'lodash/isEmpty';
 import { format } from 'd3-format';
 
@@ -53,8 +54,10 @@ export const getSentence = createSelector(
     const lossWithOutPlantations = format('.2s')(
       data.totalLoss.area - (data.plantationsLoss.area || 0)
     );
-    const emissionsWithoutPlantations = format('.3s')(
-      data.totalLoss.emissions - (data.plantationsLoss.emissions || 0)
+    const emissionsWithoutPlantations = format('.2s')(
+      biomassToCO2(
+        data.totalLoss.emissions - (data.plantationsLoss.emissions || 0)
+      )
     );
     const location = locationNames && locationNames.label;
 

--- a/app/javascript/pages/dashboards/header/header-selectors.js
+++ b/app/javascript/pages/dashboards/header/header-selectors.js
@@ -1,5 +1,4 @@
 import { createSelector } from 'reselect';
-import { biomassToCO2 } from 'utils/calculations';
 import isEmpty from 'lodash/isEmpty';
 import { format } from 'd3-format';
 
@@ -54,10 +53,8 @@ export const getSentence = createSelector(
     const lossWithOutPlantations = format('.2s')(
       data.totalLoss.area - (data.plantationsLoss.area || 0)
     );
-    const emissionsWithoutPlantations = format('.2s')(
-      biomassToCO2(
-        data.totalLoss.emissions - (data.plantationsLoss.emissions || 0)
-      )
+    const emissionsWithoutPlantations = format('.3s')(
+      data.totalLoss.emissions - (data.plantationsLoss.emissions || 0)
     );
     const location = locationNames && locationNames.label;
 

--- a/app/javascript/pages/dashboards/header/header-selectors.js
+++ b/app/javascript/pages/dashboards/header/header-selectors.js
@@ -54,7 +54,7 @@ export const getSentence = createSelector(
     const lossWithOutPlantations = format('.2s')(
       data.totalLoss.area - (data.plantationsLoss.area || 0)
     );
-    const emissionsWithoutPlantations = format('.2s')(
+    const emissionsWithoutPlantations = format('.3s')(
       biomassToCO2(
         data.totalLoss.emissions - (data.plantationsLoss.emissions || 0)
       )


### PR DESCRIPTION
## Overview

The Natural Forest Loss widget was missing the biomassToCo2 function to convert to the correct units for emissions. This fixes that and makes the value quoted in the header file consistent in format.

