### PR TITLE
CW Historical emissions: add totals to the tooltip

### DIFF
--- a/app/javascript/components/widgets/widgets/climate/emissions/selectors.js
+++ b/app/javascript/components/widgets/widgets/climate/emissions/selectors.js
@@ -50,7 +50,7 @@ export const parseData = createSelector([getSortedData], sortedData => {
       e1Percentage: e1Value / totalEmissions * 100,
       e2Value,
       e2Percentage: e2Value / totalEmissions * 100,
-      total: e1Value + e2Value
+      total: totalEmissions
     });
   });
   return chartData;

--- a/app/javascript/components/widgets/widgets/climate/emissions/selectors.js
+++ b/app/javascript/components/widgets/widgets/climate/emissions/selectors.js
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 import { getColorPalette } from 'utils/data';
 
 const EMISSIONS_KEYS = [
@@ -40,12 +41,16 @@ export const parseData = createSelector([getSortedData], sortedData => {
   const { data, total } = sortedData;
   const chartData = [];
   data[0].emissions.forEach((item, i) => {
+    const e1Value = item.value;
+    const e2Value = data[1].emissions[i].value;
+    const totalEmissions = total.emissions[i].value;
     chartData.push({
       year: item.year,
-      e1Value: item.value,
-      e1Percentage: item.value / total.emissions[i].value * 100,
-      e2Value: data[1].emissions[i].value,
-      e2Percentage: data[1].emissions[i].value / total.emissions[i].value * 100
+      e1Value,
+      e1Percentage: e1Value / totalEmissions * 100,
+      e2Value,
+      e2Percentage: e2Value / totalEmissions * 100,
+      total: e1Value + e2Value
     });
   });
   return chartData;
@@ -81,10 +86,16 @@ export const parseConfig = createSelector(
           }
         }
       },
+      unit: 'tCO₂e',
       tooltip: [
         {
-          key: 'year',
-          position: 'right'
+          key: 'year'
+        },
+        {
+          key: 'total',
+          label: 'Total',
+          unit: 'tCO₂e',
+          unitFormat: num => formatNumber({ num })
         },
         {
           key: 'e1Percentage',

--- a/app/javascript/utils/format.js
+++ b/app/javascript/utils/format.js
@@ -16,5 +16,5 @@ export const formatNumber = ({ num, unit }) => {
   } else if (num > 0 && num < 0.01 && unit !== '%') {
     formattedNum = '<0.01';
   }
-  return `${formattedNum}${unit}`;
+  return `${formattedNum}${unit || ''}`;
 };


### PR DESCRIPTION
## Overview

We wanted to show the total emissions in the tooltip to give context to the emissions percentages shown in the chart

## Demo

![screen shot 2018-06-11 at 10 20 30](https://user-images.githubusercontent.com/20288774/41223212-1af85818-6d61-11e8-8564-ad04792805c4.png)

