### PR TITLE
feature/remove-agriculture

### DIFF
--- a/app/javascript/components/widgets/widgets/climate/emissions/selectors.js
+++ b/app/javascript/components/widgets/widgets/climate/emissions/selectors.js
@@ -4,11 +4,7 @@ import { format } from 'd3-format';
 import { formatNumber } from 'utils/format';
 import { getColorPalette } from 'utils/data';
 
-const EMISSIONS_KEYS = [
-  'Total including LUCF',
-  'Land-Use Change and Forestry',
-  'Agriculture'
-];
+const EMISSIONS_KEYS = ['Total including LUCF', 'Land-Use Change and Forestry'];
 
 // get list data
 const getData = state => state.data || null;
@@ -42,14 +38,11 @@ export const parseData = createSelector([getSortedData], sortedData => {
   const chartData = [];
   data[0].emissions.forEach((item, i) => {
     const e1Value = item.value;
-    const e2Value = data[1].emissions[i].value;
     const totalEmissions = total.emissions[i].value;
     chartData.push({
       year: item.year,
       e1Value,
       e1Percentage: e1Value / totalEmissions * 100,
-      e2Value,
-      e2Percentage: e2Value / totalEmissions * 100,
       total: totalEmissions
     });
   });
@@ -74,15 +67,6 @@ export const parseConfig = createSelector(
             background: false,
             activeDot: false,
             stackId: 1
-          },
-          e2Value: {
-            fill: colorRange[1],
-            stroke: colorRange[1],
-            opacity: 1,
-            strokeWidth: 0,
-            background: false,
-            activeDot: false,
-            stackId: 1
           }
         }
       },
@@ -99,15 +83,8 @@ export const parseConfig = createSelector(
         },
         {
           key: 'e1Percentage',
-          label: 'Agriculture',
-          color: colorRange[0],
-          unit: '%',
-          unitFormat: value => format('.1f')(value)
-        },
-        {
-          key: 'e2Percentage',
           label: 'Land-Use Change and Forestry',
-          color: colorRange[1],
+          color: colorRange[0],
           unit: '%',
           unitFormat: value => format('.1f')(value)
         }
@@ -122,18 +99,9 @@ export const getSentence = createSelector(
     if (!sortedData || !sortedData.data.length) return '';
     const { positive, negative } = sentences;
     const { data, total } = sortedData;
-    const emissionsCount = data.reduce((accumulator, item) => {
-      const accumulatorCount =
-        typeof accumulator !== 'object'
-          ? accumulator
-          : accumulator.emissions
-            .map(a => a.value)
-            .reduce((iSum, value) => iSum + value);
-      const itemCount = item.emissions
-        .map(a => a.value)
-        .reduce((iSum, value) => iSum + value);
-      return accumulatorCount + itemCount;
-    });
+    const emissionsCount = data[0].emissions
+      .map(a => a.value)
+      .reduce((iSum, value) => iSum + value);
     const totalEmissionsCount = total.emissions.reduce(
       (accumulator, item) =>
         (typeof accumulator !== 'object' ? accumulator : accumulator.value) +


### PR DESCRIPTION
## Overview

Remove Agriculture from the Historical Emissions widget

## Demo

![captura de pantalla 2018-06-14 a las 9 59 03](https://user-images.githubusercontent.com/1432880/41399074-a7f5ff04-6fb9-11e8-8a0b-527086e6d78a.png)
