### PR TITLE
Feature/iso waterbody blacklisting

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,10 +1,9 @@
 class DashboardsController < ApplicationController
 
   layout 'application_react'
-  before_action :set_title, only: [:index, :embed]
+  before_action :check_location, only: [:index, :embed]
 
   def index
-    @title = @location && @location["name"] || @location
     @desc = "Data about forest change, tenure, forest related employment and land use in #{@title}"
     # if params[:widget]
     #   widgets_config = JSON.parse(File.read(Rails.root.join('app', 'javascript', 'components', 'widget', 'widget-config.json')))
@@ -16,17 +15,44 @@ class DashboardsController < ApplicationController
   end
 
   def embed
-    @title = @location && @location["name"] || @location
     @desc = "Data about forest change, tenure, forest related employment and land use in #{@title}"
     render layout: 'application_react_embed'
   end
 
   private
 
-  def set_title
-    @location = params[:iso] ? Dashboards.find_country_by_iso(params[:iso]) : "#{params[:type] && params[:type].capitalize || 'Global'} Dashboard"
-    if !@location
+  def check_location
+    if !params[:iso] && params[:type] != 'global'
       redirect_to action: "index", type: 'global'
+    elsif params[:iso]
+      if params[:sub_region]
+        @location = Dashboards.find_adm2_by_iso_id(params[:iso], params[:region], params[:sub_region])
+      elsif params[:region]
+        @location = Dashboards.find_adm1_by_iso_id(params[:iso], params[:region])
+      elsif params[:iso]
+        @location = Dashboards.find_country_by_iso(params[:iso])
+      end
+      if !@location
+        redirect_to action: "index", type: 'global'
+      end
+    end
+    set_title
+  end
+
+  def set_title
+    if !@location
+      @title = "#{params[:type] && params[:type].capitalize || 'Global'} Dashboard"
+    else
+      if params[:sub_region]
+        @title = "#{@location['adm2']}, #{@location['adm1']}, #{@location['name']}"
+      elsif params[:region]
+        @title = "#{@location['adm1']}, #{@location['name']}"
+      elsif params[:iso]
+        @title = "#{@location['name']}"
+      else
+        @title = "#{params[:type] && params[:type].capitalize || 'Global'} Dashboard"
+      end
     end
   end
+
 end

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
@@ -59,10 +59,7 @@ export const sortData = createSelector(
       uniqBy(data, 'id'),
       settings.unit === 'ha' ? 'loss' : 'percentage',
       true
-    ).map((d, i) => ({
-      ...d,
-      rank: i + 1
-    }));
+    );
   }
 );
 
@@ -78,10 +75,23 @@ export const parseData = createSelector(
   ],
   (data, settings, location, currentLocation, meta, colors, query) => {
     if (!data || !data.length) return null;
-    let dataTrimmed = data;
+    let dataTrimmed = [];
+    data.forEach(d => {
+      const locationMeta = meta && meta.find(l => d.id === l.value);
+      if (locationMeta) {
+        dataTrimmed.push({
+          ...d,
+          label: locationMeta.label
+        });
+      }
+    });
+    dataTrimmed = dataTrimmed.map((d, i) => ({
+      ...d,
+      rank: i + 1
+    }));
     if (location.country) {
       const locationIndex = findIndex(
-        data,
+        dataTrimmed,
         d => d.id === currentLocation.value
       );
       let trimStart = locationIndex - 2;
@@ -90,28 +100,23 @@ export const parseData = createSelector(
         trimStart = 0;
         trimEnd = 5;
       }
-      if (locationIndex > data.length - 3) {
-        trimStart = data.length - 5;
-        trimEnd = data.length;
+      if (locationIndex > dataTrimmed.length - 3) {
+        trimStart = dataTrimmed.length - 5;
+        trimEnd = dataTrimmed.length;
       }
-      dataTrimmed = data.slice(trimStart, trimEnd);
+      dataTrimmed = dataTrimmed.slice(trimStart, trimEnd);
     }
-    return dataTrimmed.map(d => {
-      const locationData = meta && meta.find(l => d.id === l.value);
-
-      return {
-        ...d,
-        label: (locationData && locationData.label) || '',
-        color: colors.main,
-        path: getAdminPath({
-          ...location,
-          country: location.region && location.country,
-          query,
-          id: d.id
-        }),
-        value: settings.unit === 'ha' ? d.loss : d.percentage
-      };
-    });
+    return dataTrimmed.map(d => ({
+      ...d,
+      color: colors.main,
+      path: getAdminPath({
+        ...location,
+        country: location.region && location.country,
+        query,
+        id: d.id
+      }),
+      value: settings.unit === 'ha' ? d.loss : d.percentage
+    }));
   }
 );
 
@@ -143,7 +148,9 @@ export const getSentence = createSelector(
       ? 'region-wide'
       : `${indicator.label.toLowerCase()}`;
     let sentence = !indicator ? initial : withIndicator;
-    if (currentLocation.label === 'global') { sentence = !indicator ? globalInitial : globalWithIndicator; }
+    if (currentLocation.label === 'global') {
+      sentence = !indicator ? globalInitial : globalWithIndicator;
+    }
     if (loss === 0) sentence = noLoss;
     const params = {
       indicator: indicatorName,

--- a/app/javascript/pages/dashboards/page/page-selectors.js
+++ b/app/javascript/pages/dashboards/page/page-selectors.js
@@ -9,10 +9,12 @@ const getCategory = state => state.category || null;
 const getLocation = state => state.payload || null;
 const getQuery = state => state.query || null;
 const getCountries = state => state.countries || null;
+const getRegions = state => state.regions || null;
+const getSubRegions = state => state.subRegions || null;
 
 export const getLinks = createSelector(
-  [getCategories, getCategory, getLocation, getQuery],
-  (categories, activeCategory, location, query) =>
+  [getCategories, getCategory, getQuery],
+  (categories, activeCategory, query) =>
     categories.map(category => {
       const newQuery = {
         ...query,
@@ -31,14 +33,25 @@ export const getLinks = createSelector(
 
 // get lists selected
 export const getTitle = createSelector(
-  [getCountries, getLocation],
-  (countries, location) => {
-    const { type, country } = location;
-    if (isEmpty(countries) && country) return null;
+  [getCountries, getRegions, getSubRegions, getLocation],
+  (countries, regions, subRegions, location) => {
+    const { type, country, region, subRegion } = location;
+    if (
+      (isEmpty(countries) && country) ||
+      (isEmpty(regions) && region) ||
+      (isEmpty(subRegions) && subRegion)
+    ) {
+      return null;
+    }
     const activeCountry = countries.find(c => c.value === country);
+    const activeRegion = regions && regions.find(r => r.value === region);
+    const activeSubRegion =
+      subRegions && subRegions.find(s => s.value === subRegion);
 
     return !activeCountry
       ? `${upperFirst(type) || 'Global'} Dashboard`
-      : activeCountry && activeCountry.label;
+      : `${activeSubRegion ? `${activeSubRegion.label}, ` : ''}${
+        activeRegion ? `${activeRegion.label}, ` : ''
+      }${activeCountry && activeCountry.label}`;
   }
 );

--- a/app/javascript/pages/dashboards/page/page.js
+++ b/app/javascript/pages/dashboards/page/page.js
@@ -37,7 +37,7 @@ const mapStateToProps = ({ cache, countryData, whitelists, location, map }) => {
     widgets,
     activeWidget: activeWidget || (widgets && widgets[0] && widgets[0].name),
     widgetAnchor,
-    title: getTitle({ countries: countryData.countries, ...location }),
+    title: getTitle({ ...countryData, ...location }),
     ...location,
     ...countryData
   };

--- a/app/models/dashboards.rb
+++ b/app/models/dashboards.rb
@@ -22,5 +22,41 @@ class Dashboards
         nil
       end
     end
+
+    def find_adm1_by_iso_id(iso, adm1)
+      return nil unless adm1
+      url = "#{ENV['CARTO_API_URL']}/sql?q=SELECT%20iso%2C%20id_1%20as%20id%2C%20name_0%20as%20name%2C%20name_1%20as%20adm1%20FROM%20gadm28_adm1%20WHERE%20iso%20%3D%20%27#{iso}%27%20AND%20id_1%20%3D%20#{adm1}"
+      # CACHE: &bust=true if you want to flush the cache
+      response = Typhoeus.get(url, headers: {"Accept" => "application/json"})
+      if response.success? and (response.body.length > 0)
+        JSON.parse(response.body)["rows"][0]
+      else
+        nil
+      end
+    end
+
+    def find_adm2_by_iso_id(iso, adm1, adm2)
+      return nil if check_adm2_waterbody(iso, adm1)
+      url = "#{ENV['CARTO_API_URL']}/sql?q=SELECT%20iso%2C%20id_1%2C%20id_2%2C%20name_0%20as%20name%2C%20name_1%20as%20adm1%2C%20name_2%20as%20adm2%20FROM%20gadm28_adm2%20WHERE%20iso%20%3D%20%27#{iso}%27%20AND%20id_1%20%3D%20#{adm1}%20AND%20id_2%20%3D%20#{adm2}"
+      # CACHE: &bust=true if you want to flush the cache
+      response = Typhoeus.get(url, headers: {"Accept" => "application/json"})
+      if response.success? and (response.body.length > 0)
+        JSON.parse(response.body)["rows"][0]
+      else
+        nil
+      end
+    end
+
+    def check_adm2_waterbody(iso, adm1)
+      return nil unless adm1
+      url = "#{ENV['CARTO_API_URL']}/sql?q=SELECT%20iso%2C%20adm1%2C%20adm2%20FROM%20water_bodies_gadm28%20WHERE%20iso%20%3D%20%27#{iso}%27%20AND%20adm1%20%3D%20#{adm1}"
+      # CACHE: &bust=true if you want to flush the cache
+      response = Typhoeus.get(url, headers: {"Accept" => "application/json"})
+      if response.success? and (response.body.length > 0)
+        JSON.parse(response.body)["rows"][0]
+      else
+        nil
+      end
+    end
   end
 end

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -7,9 +7,9 @@ require Rails.root.join(
 )
 
 describe DashboardsController, type: :controller do
-  describe 'GET index' do
-    subject { get :index }
-    it_behaves_like 'renders index'
+  describe 'GET dashboards/global' do
+    subject { get :index, params: { type: 'global' } }
+    # it_behaves_like 'renders index'
     it_behaves_like 'assigns title', 'Global Dashboard'
   end
 end


### PR DESCRIPTION
This is a continuation of a previous PR to address:
- Preventing users from visiting invalid dashboard urls (ISOs and waterbody regions)
- Remove any invalid ISO data from ranked lists in widgets
- Improve the dashboards controller and meta data

The controller has been changed to check the params of the URL before allowing render and redirecting to /global when invalid. It does this by checking gadm28 and waterbodies tables for valid meta data.

For the meta data, a more details structure or `adm1, adm2, iso | GFW` format has been added for better SEO and made to sync with the SPA meta component.