### PR TITLE
Feature/meta and share modals for map

### DIFF
--- a/app/javascript/components/map/components/map-controls/map-controls-component.jsx
+++ b/app/javascript/components/map/components/map-controls/map-controls-component.jsx
@@ -13,46 +13,48 @@ import './map-controls-styles.scss';
 class MapControls extends PureComponent {
   render() {
     const {
-      handleZoomIn,
-      handleZoomOut,
+      setMapZoom,
       className,
       stickyOptions,
-      setShareModal
+      setShareModal,
+      share
     } = this.props;
     return (
       <div className={`c-map-controls ${className || ''}`}>
         <Sticky enabled={false} {...stickyOptions}>
           <Button
             theme="theme-button-map-control"
-            onClick={handleZoomIn}
+            onClick={() => setMapZoom({ sum: 1 })}
             tooltip={{ text: 'Zoom in' }}
           >
             <Icon icon={plusIcon} className="plus-icon" />
           </Button>
           <Button
             theme="theme-button-map-control"
-            onClick={handleZoomOut}
+            onClick={() => setMapZoom({ sum: -1 })}
             tooltip={{ text: 'Zoom out' }}
           >
             <Icon icon={minusIcon} className="minus-icon" />
           </Button>
-          <Button
-            className="theme-button-map-control"
-            onClick={() =>
-              setShareModal({
-                title: 'Share this view',
-                shareUrl: window.location.href,
-                embedUrl: window.location.href,
-                embedSettings: {
-                  width: 670,
-                  height: 490
-                }
-              })
-            }
-            tooltip={{ text: 'Share or embed this view' }}
-          >
-            <Icon icon={shareIcon} />
-          </Button>
+          {share && (
+            <Button
+              className="theme-button-map-control"
+              onClick={() =>
+                setShareModal({
+                  title: 'Share this view',
+                  shareUrl: window.location.href,
+                  embedUrl: window.location.href,
+                  embedSettings: {
+                    width: 670,
+                    height: 490
+                  }
+                })
+              }
+              tooltip={{ text: 'Share or embed this view' }}
+            >
+              <Icon icon={shareIcon} />
+            </Button>
+          )}
         </Sticky>
       </div>
     );
@@ -61,10 +63,10 @@ class MapControls extends PureComponent {
 
 MapControls.propTypes = {
   className: Proptypes.string,
-  handleZoomIn: Proptypes.func,
-  handleZoomOut: Proptypes.func,
+  setMapZoom: Proptypes.func,
   stickyOptions: Proptypes.object,
-  setShareModal: Proptypes.func
+  setShareModal: Proptypes.func,
+  share: Proptypes.bool
 };
 
 export default MapControls;

--- a/app/javascript/components/map/components/map-controls/map-controls-component.jsx
+++ b/app/javascript/components/map/components/map-controls/map-controls-component.jsx
@@ -44,8 +44,8 @@ class MapControls extends PureComponent {
                 shareUrl: window.location.href,
                 embedUrl: window.location.href,
                 embedSettings: {
-                  width: 300,
-                  height: 300
+                  width: 670,
+                  height: 490
                 }
               })
             }

--- a/app/javascript/components/map/components/map-controls/map-controls-component.jsx
+++ b/app/javascript/components/map/components/map-controls/map-controls-component.jsx
@@ -7,6 +7,7 @@ import Icon from 'components/ui/icon';
 
 import plusIcon from 'assets/icons/plus.svg';
 import minusIcon from 'assets/icons/minus.svg';
+import shareIcon from 'assets/icons/share.svg';
 import './map-controls-styles.scss';
 
 class MapControls extends PureComponent {
@@ -15,16 +16,42 @@ class MapControls extends PureComponent {
       handleZoomIn,
       handleZoomOut,
       className,
-      stickyOptions
+      stickyOptions,
+      setShareModal
     } = this.props;
     return (
       <div className={`c-map-controls ${className || ''}`}>
         <Sticky enabled={false} {...stickyOptions}>
-          <Button theme="theme-button-map-control" onClick={handleZoomIn}>
+          <Button
+            theme="theme-button-map-control"
+            onClick={handleZoomIn}
+            tooltip={{ text: 'Zoom in' }}
+          >
             <Icon icon={plusIcon} className="plus-icon" />
           </Button>
-          <Button theme="theme-button-map-control" onClick={handleZoomOut}>
+          <Button
+            theme="theme-button-map-control"
+            onClick={handleZoomOut}
+            tooltip={{ text: 'Zoom out' }}
+          >
             <Icon icon={minusIcon} className="minus-icon" />
+          </Button>
+          <Button
+            className="theme-button-map-control"
+            onClick={() =>
+              setShareModal({
+                title: 'Share this view',
+                shareUrl: window.location.href,
+                embedUrl: window.location.href,
+                embedSettings: {
+                  width: 300,
+                  height: 300
+                }
+              })
+            }
+            tooltip={{ text: 'Share or embed this view' }}
+          >
+            <Icon icon={shareIcon} />
           </Button>
         </Sticky>
       </div>
@@ -36,7 +63,8 @@ MapControls.propTypes = {
   className: Proptypes.string,
   handleZoomIn: Proptypes.func,
   handleZoomOut: Proptypes.func,
-  stickyOptions: Proptypes.object
+  stickyOptions: Proptypes.object,
+  setShareModal: Proptypes.func
 };
 
 export default MapControls;

--- a/app/javascript/components/map/components/map-controls/map-controls-styles.scss
+++ b/app/javascript/components/map/components/map-controls/map-controls-styles.scss
@@ -3,8 +3,8 @@
 .c-map-controls {
   width: rem(38px);
 
-  button:first-child {
-    border-bottom: solid 1px rgba($medium-grey, 0.2);
+  button {
+    margin-bottom: rem(5px);
   }
 
   .plus-icon {

--- a/app/javascript/components/map/components/map-controls/map-controls.js
+++ b/app/javascript/components/map/components/map-controls/map-controls.js
@@ -1,3 +1,6 @@
+import { connect } from 'react-redux';
+
+import actions from 'components/modals/share/share-actions';
 import Component from './map-controls-component';
 
-export default Component;
+export default connect(null, actions)(Component);

--- a/app/javascript/components/map/components/map-controls/map-controls.js
+++ b/app/javascript/components/map/components/map-controls/map-controls.js
@@ -1,6 +1,9 @@
 import { connect } from 'react-redux';
 
-import actions from 'components/modals/share/share-actions';
+import shareActions from 'components/modals/share/share-actions';
+import mapActions from 'components/map/map-actions';
 import Component from './map-controls-component';
+
+const actions = { ...mapActions, ...shareActions };
 
 export default connect(null, actions)(Component);

--- a/app/javascript/components/modals/meta/meta-component.jsx
+++ b/app/javascript/components/modals/meta/meta-component.jsx
@@ -6,6 +6,7 @@ import ReactHtmlParser from 'react-html-parser';
 
 import Loader from 'components/ui/loader';
 import NoContent from 'components/ui/no-content';
+import Button from 'components/ui/button';
 import Modal from '../modal';
 
 import './meta-styles.scss';
@@ -13,6 +14,16 @@ import './meta-styles.scss';
 class ModalMeta extends PureComponent {
   getContent() {
     const { metaData, tableData, loading, error } = this.props;
+    const {
+      title,
+      subtitle,
+      overview,
+      citation,
+      map_service,
+      learn_more,
+      download_data,
+      amazon_link
+    } = metaData;
 
     return (
       <div className="c-modal-meta">
@@ -30,10 +41,10 @@ class ModalMeta extends PureComponent {
           !error &&
           !isEmpty(metaData) && (
             <div>
-              <h3 className="title">{metaData.title}</h3>
+              <h3 className="title">{title}</h3>
               <p
                 className="subtitle"
-                dangerouslySetInnerHTML={{ __html: metaData.subtitle }} // eslint-disable-line
+                dangerouslySetInnerHTML={{ __html: subtitle }} // eslint-disable-line
               />
               <div className="meta-table">
                 {tableData &&
@@ -52,20 +63,38 @@ class ModalMeta extends PureComponent {
                       ) : null)
                   )}
               </div>
-              {metaData.overview && (
+              {overview && (
                 <div className="overview">
                   <h4>Overview</h4>
-                  <div className="body">
-                    {this.parseContent(metaData.overview)}
-                  </div>
+                  <div className="body">{this.parseContent(overview)}</div>
                 </div>
               )}
-              {metaData.citation && (
+              {citation && (
                 <div className="citation">
                   <h5>Citation</h5>
-                  <div className="body">
-                    {this.parseContent(metaData.citation)}
-                  </div>
+                  <div className="body">{this.parseContent(citation)}</div>
+                </div>
+              )}
+              {(learn_more || download_data || map_service || amazon_link) && (
+                <div className="ext-actions">
+                  {learn_more && (
+                    <Button theme="theme-button-medium" extLink={learn_more}>
+                      LEARN MORE
+                    </Button>
+                  )}
+                  {download_data && (
+                    <Button theme="theme-button-medium" extLink={download_data}>
+                      DOWNLOAD DATA
+                    </Button>
+                  )}
+                  {(map_service || amazon_link) && (
+                    <Button
+                      theme="theme-button-medium"
+                      extLink={map_service || amazon_link}
+                    >
+                      OPEN IN ARCGIS
+                    </Button>
+                  )}
                 </div>
               )}
             </div>

--- a/app/javascript/components/modals/meta/meta-styles.scss
+++ b/app/javascript/components/modals/meta/meta-styles.scss
@@ -115,6 +115,7 @@ $desktop-padding: rem(50px);
     h5 {
       font-size: rem(12px);
       font-weight: 500;
+      margin-bottom: rem(10px);
     }
 
     .body {
@@ -124,11 +125,38 @@ $desktop-padding: rem(50px);
     }
   }
 
-  a {
-    color: $green-gfw;
+  .ext-actions {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    border-top: solid 1px $border;
+    margin: 0 rem(-30px) rem(-45px);
+    width: auto;
+    padding: rem(20px) rem(30px) rem(10px);
 
-    &:hover {
-      color: darken($green-gfw, 10%);
+    > a {
+      max-width: rem(150px);
+      margin: 0 rem(10px);
+      margin-bottom: rem(10px);
+    }
+
+    @media screen and (min-width: $screen-m) {
+      margin: 0 rem(-50px) rem(-45px);
+      padding: rem(20px) rem(50px) rem(10px);
+      flex-direction: row;
+    }
+  }
+
+  p {
+    margin-bottom: rem(10px);
+
+    a {
+      color: $green-gfw;
+
+      &:hover {
+        color: darken($green-gfw, 10%);
+      }
     }
   }
 }

--- a/app/javascript/components/modals/meta/meta.js
+++ b/app/javascript/components/modals/meta/meta.js
@@ -5,7 +5,16 @@ import actions from './meta-actions';
 import reducers, { initialState } from './meta-reducers';
 import ModalMetaComponent from './meta-component';
 
-const MASTER_META_FIELDS = ['title', 'subtitle', 'citation', 'overview'];
+const MASTER_META_FIELDS = [
+  'title',
+  'subtitle',
+  'citation',
+  'overview',
+  'learn_more',
+  'download_data',
+  'map_service',
+  'amazon_link'
+];
 const MASTER_TABLE_FIELDS = [
   'function',
   'resolution',

--- a/app/javascript/components/ui/button/button-component.jsx
+++ b/app/javascript/components/ui/button/button-component.jsx
@@ -9,6 +9,7 @@ import Tip from 'components/ui/tip';
 import './button-styles.scss';
 import './themes/button-light.scss'; // eslint-disable-line
 import './themes/button-small.scss'; // eslint-disable-line
+import './themes/button-medium.scss'; // eslint-disable-line
 import './themes/button-tiny.scss'; // eslint-disable-line
 import './themes/button-grey.scss'; // eslint-disable-line
 import './themes/button-clear.scss'; // eslint-disable-line

--- a/app/javascript/components/ui/button/themes/button-medium.scss
+++ b/app/javascript/components/ui/button/themes/button-medium.scss
@@ -1,0 +1,21 @@
+@import '~styles/settings';
+
+.theme-button-medium {
+  height: rem(26px);
+  border-radius: rem(13px);
+  padding: 0 rem(13px);
+  font-size: rem(14px);
+  line-height: 0.8em;
+  white-space: nowrap;
+
+  &.square {
+    width: rem(26px);
+    min-width: rem(26px);
+    padding: 0;
+  }
+
+  svg {
+    width: rem(13px);
+    height: rem(13px);
+  }
+}

--- a/app/javascript/pages/dashboards/page/page-component.js
+++ b/app/javascript/pages/dashboards/page/page-component.js
@@ -31,7 +31,6 @@ class Page extends PureComponent {
       isGeostoreLoading,
       widgetAnchor,
       activeWidget,
-      setMapZoom,
       widgets,
       title,
       query
@@ -75,8 +74,6 @@ class Page extends PureComponent {
               enabled: true,
               top: window.innerWidth >= SCREEN_MOBILE ? 15 : 73
             }}
-            handleZoomIn={() => setMapZoom({ sum: 1 })}
-            handleZoomOut={() => setMapZoom({ sum: -1 })}
           />
         )}
         <Share />
@@ -102,7 +99,6 @@ Page.propTypes = {
   widgets: PropTypes.array,
   widgetAnchor: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   activeWidget: PropTypes.string,
-  setMapZoom: PropTypes.func,
   title: PropTypes.string,
   query: PropTypes.object
 };

--- a/app/javascript/pages/map/index.js
+++ b/app/javascript/pages/map/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
-import { handleActionTrack } from 'utils/analytics';
 
 import 'react-tippy/dist/tippy.css';
 import 'styles/styles.scss';
@@ -13,11 +12,7 @@ import router from './router';
 import Page from './page';
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-const middlewares = applyMiddleware(
-  thunk,
-  router.middleware,
-  handleActionTrack
-);
+const middlewares = applyMiddleware(thunk, router.middleware);
 const store = createStore(
   reducers,
   composeEnhancers(router.enhancer, middlewares)

--- a/app/javascript/pages/map/menu/components/forest-change/forest-change-component.jsx
+++ b/app/javascript/pages/map/menu/components/forest-change/forest-change-component.jsx
@@ -11,12 +11,7 @@ class ForestChange extends PureComponent {
         {data &&
           data.map(block => {
             const { name } = block;
-            return (
-              <LayersBlock
-                key={`layers-block-${name}`}
-                {...block}
-              />
-            );
+            return <LayersBlock key={`layers-block-${name}`} {...block} />;
           })}
       </div>
     );

--- a/app/javascript/pages/map/menu/components/forest-change/forest-change-component.jsx
+++ b/app/javascript/pages/map/menu/components/forest-change/forest-change-component.jsx
@@ -10,13 +10,11 @@ class ForestChange extends PureComponent {
       <div className="c-forest-change">
         {data &&
           data.map(block => {
-            const { name, description, layers } = block;
+            const { name } = block;
             return (
               <LayersBlock
                 key={`layers-block-${name}`}
-                name={name}
-                description={description}
-                layers={layers}
+                {...block}
               />
             );
           })}

--- a/app/javascript/pages/map/menu/components/layer-toggle/layer-toggle-component.jsx
+++ b/app/javascript/pages/map/menu/components/layer-toggle/layer-toggle-component.jsx
@@ -11,7 +11,7 @@ import './layer-toggle-styles.scss';
 
 class LayerToggle extends PureComponent {
   render() {
-    const { data: { name, description } } = this.props;
+    const { data: { name, description, meta }, setModalMeta } = this.props;
 
     return (
       <div className="c-layer-toggle">
@@ -21,7 +21,7 @@ class LayerToggle extends PureComponent {
             <div className="c-layer-toggle__name">{name}</div>
             <Button
               className="theme-button-tiny square info-button"
-              onClick={() => {}}
+              onClick={() => setModalMeta(meta)}
             >
               <Icon icon={infoIcon} className="info-icon" />
             </Button>
@@ -34,7 +34,8 @@ class LayerToggle extends PureComponent {
 }
 
 LayerToggle.propTypes = {
-  data: PropTypes.object
+  data: PropTypes.object,
+  setModalMeta: PropTypes.func
 };
 
 export default LayerToggle;

--- a/app/javascript/pages/map/menu/components/layer-toggle/layer-toggle.js
+++ b/app/javascript/pages/map/menu/components/layer-toggle/layer-toggle.js
@@ -1,4 +1,3 @@
-
 import { connect } from 'react-redux';
 
 import actions from 'components/modals/meta/meta-actions';

--- a/app/javascript/pages/map/menu/components/layer-toggle/layer-toggle.js
+++ b/app/javascript/pages/map/menu/components/layer-toggle/layer-toggle.js
@@ -1,3 +1,7 @@
+
+import { connect } from 'react-redux';
+
+import actions from 'components/modals/meta/meta-actions';
 import Component from './layer-toggle-component';
 
-export default Component;
+export default connect(null, actions)(Component);

--- a/app/javascript/pages/map/page/page-component.js
+++ b/app/javascript/pages/map/page/page-component.js
@@ -3,6 +3,9 @@ import React, { PureComponent } from 'react';
 import CountryDataProvider from 'providers/country-data-provider';
 import Map from 'components/map';
 import MapMenu from 'pages/map/menu';
+import ModalMeta from 'components/modals/meta';
+import Meta from 'components/meta';
+import Share from 'components/modals/share';
 
 import './page-styles.scss';
 
@@ -13,6 +16,12 @@ class Page extends PureComponent {
         <CountryDataProvider />
         <Map activeWidget={null} />
         <MapMenu />
+        <Share />
+        <ModalMeta />
+        {/* <Meta
+          title={title}
+          description="Data about forest change, tenure, forest related employment and land use in"
+        /> */}
       </div>
     );
   }

--- a/app/javascript/pages/map/page/page-component.js
+++ b/app/javascript/pages/map/page/page-component.js
@@ -1,30 +1,37 @@
 import React, { PureComponent } from 'react';
+import Proptypes from 'prop-types';
 
 import CountryDataProvider from 'providers/country-data-provider';
 import Map from 'components/map';
 import MapMenu from 'pages/map/menu';
 import ModalMeta from 'components/modals/meta';
-import Meta from 'components/meta';
 import Share from 'components/modals/share';
+import MapControls from 'components/map/components/map-controls';
 
 import './page-styles.scss';
 
 class Page extends PureComponent {
   render() {
+    const { setMapZoom } = this.props;
     return (
       <div className="l-map">
         <CountryDataProvider />
         <Map activeWidget={null} />
         <MapMenu />
+        <MapControls
+          className="map-controls"
+          handleZoomIn={() => setMapZoom({ sum: 1 })}
+          handleZoomOut={() => setMapZoom({ sum: -1 })}
+        />
         <Share />
         <ModalMeta />
-        {/* <Meta
-          title={title}
-          description="Data about forest change, tenure, forest related employment and land use in"
-        /> */}
       </div>
     );
   }
 }
+
+Page.propTypes = {
+  setMapZoom: Proptypes.bool.isRequired
+};
 
 export default Page;

--- a/app/javascript/pages/map/page/page-component.js
+++ b/app/javascript/pages/map/page/page-component.js
@@ -1,5 +1,4 @@
 import React, { PureComponent } from 'react';
-import Proptypes from 'prop-types';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { DragDropContextProvider } from 'react-dnd';
 
@@ -15,31 +14,22 @@ import './page-styles.scss';
 
 class Page extends PureComponent {
   render() {
-    const { setMapZoom } = this.props;
     return (
       <div className="l-map">
-        <CountryDataProvider />
-        <Map activeWidget={null} />
+        <Map />
         <MapMenu />
         <div className="map-actions">
-          <MapControls
-            className="map-controls"
-            handleZoomIn={() => setMapZoom({ sum: 1 })}
-            handleZoomOut={() => setMapZoom({ sum: -1 })}
-          />
+          <MapControls className="map-controls" share />
           <DragDropContextProvider backend={HTML5Backend}>
             <RecentImagery />
           </DragDropContextProvider>
         </div>
         <Share />
         <ModalMeta />
+        <CountryDataProvider />
       </div>
     );
   }
 }
-
-Page.propTypes = {
-  setMapZoom: Proptypes.func.isRequired
-};
 
 export default Page;

--- a/app/javascript/pages/map/page/page-component.js
+++ b/app/javascript/pages/map/page/page-component.js
@@ -1,5 +1,7 @@
 import React, { PureComponent } from 'react';
 import Proptypes from 'prop-types';
+import HTML5Backend from 'react-dnd-html5-backend';
+import { DragDropContextProvider } from 'react-dnd';
 
 import CountryDataProvider from 'providers/country-data-provider';
 import Map from 'components/map';
@@ -7,6 +9,7 @@ import MapMenu from 'pages/map/menu';
 import ModalMeta from 'components/modals/meta';
 import Share from 'components/modals/share';
 import MapControls from 'components/map/components/map-controls';
+import RecentImagery from 'pages/map/recent-imagery';
 
 import './page-styles.scss';
 
@@ -18,11 +21,16 @@ class Page extends PureComponent {
         <CountryDataProvider />
         <Map activeWidget={null} />
         <MapMenu />
-        <MapControls
-          className="map-controls"
-          handleZoomIn={() => setMapZoom({ sum: 1 })}
-          handleZoomOut={() => setMapZoom({ sum: -1 })}
-        />
+        <div className="map-actions">
+          <MapControls
+            className="map-controls"
+            handleZoomIn={() => setMapZoom({ sum: 1 })}
+            handleZoomOut={() => setMapZoom({ sum: -1 })}
+          />
+          <DragDropContextProvider backend={HTML5Backend}>
+            <RecentImagery />
+          </DragDropContextProvider>
+        </div>
         <Share />
         <ModalMeta />
       </div>
@@ -31,7 +39,7 @@ class Page extends PureComponent {
 }
 
 Page.propTypes = {
-  setMapZoom: Proptypes.bool.isRequired
+  setMapZoom: Proptypes.func.isRequired
 };
 
 export default Page;

--- a/app/javascript/pages/map/page/page-styles.scss
+++ b/app/javascript/pages/map/page/page-styles.scss
@@ -4,9 +4,13 @@
   width: 100%;
   height: 100vh;
 
-  .map-controls {
+  .map-actions {
     position: absolute;
     bottom: rem(15px);
     right: rem(15px);
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: flex-end;
   }
 }

--- a/app/javascript/pages/map/page/page-styles.scss
+++ b/app/javascript/pages/map/page/page-styles.scss
@@ -3,4 +3,10 @@
 .l-map {
   width: 100%;
   height: 100vh;
+
+  .map-controls {
+    position: absolute;
+    bottom: rem(15px);
+    right: rem(15px);
+  }
 }

--- a/app/javascript/pages/map/page/page.js
+++ b/app/javascript/pages/map/page/page.js
@@ -1,6 +1,8 @@
 import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 
+import actions from 'components/map/map-actions';
+
 import PageComponent from './page-component';
 
 const mapStateToProps = ({ location, countryData }) => ({
@@ -16,4 +18,4 @@ class PageContainer extends PureComponent {
   }
 }
 
-export default connect(mapStateToProps, {})(PageContainer);
+export default connect(mapStateToProps, actions)(PageContainer);

--- a/app/javascript/pages/map/reducers.js
+++ b/app/javascript/pages/map/reducers.js
@@ -6,15 +6,19 @@ import { handleActions } from 'utils/redux';
 import router from './router';
 
 // Components
+import * as recentImageryComponent from 'pages/map/recent-imagery';
 import * as MapComponent from 'components/map';
 import * as MapMenuComponent from 'pages/map/menu';
-import * as recentImageryComponent from 'pages/map/recent-imagery';
+import * as ShareComponent from 'components/modals/share';
+import * as ModalMetaComponent from 'components/modals/meta';
 
 // Providers
 import * as countryDataProviderComponent from 'providers/country-data-provider';
 
 // Component Reducers
 const componentsReducers = {
+  share: handleActions(ShareComponent),
+  modalMeta: handleActions(ModalMetaComponent),
   map: handleActions(MapComponent),
   mapMenu: handleActions(MapMenuComponent),
   recentImagery: handleActions(recentImageryComponent)

--- a/app/javascript/pages/map_legacy/recent-imagery/components/recent-imagery-settings/recent-imagery-settings-component.js
+++ b/app/javascript/pages/map_legacy/recent-imagery/components/recent-imagery-settings/recent-imagery-settings-component.js
@@ -1,0 +1,189 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+
+import Icon from 'components/ui/icon';
+import Slider from 'components/ui/slider';
+import Carousel from 'components/ui/carousel';
+import Dropdown from 'components/ui/dropdown';
+import Datepicker from 'components/ui/datepicker';
+import NoContent from 'components/ui/no-content';
+import RecentImageryThumbnail from 'pages/map/recent-imagery/components/recent-imagery-thumbnail';
+
+import WEEKS from 'data/weeks.json';
+import draggerIcon from 'assets/icons/dragger.svg';
+import closeIcon from 'assets/icons/close.svg';
+import RecentImageryDrag from './recent-imagery-settings-drag';
+import './recent-imagery-settings-styles.scss';
+
+class RecentImagerySettings extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      thumbnailsDescription: null
+    };
+  }
+
+  render() {
+    const {
+      selectedTile,
+      tiles,
+      settings: {
+        styles,
+        thumbsToShow,
+        selectedTileSource,
+        date,
+        weeks,
+        clouds
+      },
+      isDragging,
+      connectDragSource,
+      setRecentImagerySettings,
+      setRecentImageryShowSettings
+    } = this.props;
+    let opacity = 1;
+
+    if (isDragging) {
+      opacity = 0;
+    }
+
+    return connectDragSource(
+      <div className="c-recent-imagery-settings" style={{ ...styles, opacity }}>
+        <Icon icon={draggerIcon} className="dragger-icon" />
+        <button
+          className="close-btn"
+          onClick={() => setRecentImageryShowSettings(false)}
+        >
+          <Icon icon={closeIcon} className="close-icon" />
+        </button>
+        <div className="c-recent-imagery-settings__title">
+          RECENT HI-RES SATELLITE IMAGERY
+        </div>
+        <div className="c-recent-imagery-settings__dates">
+          <div className="c-recent-imagery-settings__dates__title">
+            ACQUISITION DATE
+          </div>
+          <div className="c-recent-imagery-settings__dates__buttons">
+            <Dropdown
+              theme="theme-dropdown-button"
+              value={weeks}
+              options={WEEKS}
+              onChange={option =>
+                setRecentImagerySettings({ weeks: option.value })
+              }
+            />
+            <div className="c-recent-imagery-settings__dates__before">
+              before
+            </div>
+            <Datepicker
+              date={date ? moment(date) : moment()}
+              handleOnDateChange={d =>
+                setRecentImagerySettings({ date: d.format('YYYY-MM-DD') })
+              }
+              settings={{
+                displayFormat: 'D MMM YYYY',
+                numberOfMonths: 1,
+                isOutsideRange: d => d.isAfter(moment()),
+                hideKeyboardShortcutsPanel: true,
+                noBorder: true,
+                readOnly: true
+              }}
+            />
+          </div>
+        </div>
+        <div className="c-recent-imagery-settings__clouds">
+          <div className="c-recent-imagery-settings__clouds__title">
+            MAXIMUM CLOUD COVER PERCENTAGE
+          </div>
+          <Slider
+            className="theme-slider-green"
+            settings={{
+              defaultValue: clouds,
+              marks: {
+                0: '0%',
+                25: '25%',
+                50: '50%',
+                75: '75%',
+                100: '100%'
+              },
+              marksOnTop: true,
+              step: 5,
+              dots: true,
+              tipFormatter: value => `${value}%`
+            }}
+            handleOnSliderChange={d => setRecentImagerySettings({ clouds: d })}
+          />
+        </div>
+        <div className="c-recent-imagery-settings__thumbnails">
+          {tiles.length >= 1 && (
+            <div>
+              <div className="c-recent-imagery-settings__thumbnails__description">
+                {this.state.thumbnailsDescription ||
+                  (selectedTile && selectedTile.description)}
+              </div>
+              <Carousel
+                settings={{
+                  slidesToShow: thumbsToShow,
+                  infinite: false,
+                  centerMode: false,
+                  centerPadding: '20px',
+                  dots: false,
+                  arrows: tiles.length > thumbsToShow,
+                  responsive: [
+                    {
+                      breakpoint: 620,
+                      settings: {
+                        slidesToShow: thumbsToShow - 2
+                      }
+                    }
+                  ]
+                }}
+              >
+                {tiles.map((tile, i) => (
+                  <div key={`recent-imagery-thumb-${tile.id}`}>
+                    <RecentImageryThumbnail
+                      id={i}
+                      tile={tile}
+                      selected={selectedTileSource === tile.id}
+                      handleClick={() => {
+                        setRecentImagerySettings({
+                          selectedTileSource: tile.id
+                        });
+                      }}
+                      handleMouseEnter={() => {
+                        this.setState({
+                          thumbnailsDescription: tile.description
+                        });
+                      }}
+                      handleMouseLeave={() => {
+                        this.setState({ thumbnailsDescription: null });
+                      }}
+                    />
+                  </div>
+                ))}
+              </Carousel>
+            </div>
+          )}
+          {tiles.length < 1 && (
+            <NoContent
+              className="c-recent-imagery-settings__empty-thumbnails"
+              message="We can't find additional images for the selection"
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+
+RecentImagerySettings.propTypes = {
+  selectedTile: PropTypes.object,
+  tiles: PropTypes.array.isRequired,
+  settings: PropTypes.object.isRequired,
+  isDragging: PropTypes.bool.isRequired,
+  connectDragSource: PropTypes.func.isRequired,
+  setRecentImagerySettings: PropTypes.func.isRequired,
+  setRecentImageryShowSettings: PropTypes.func.isRequired
+};
+
+export default RecentImageryDrag(RecentImagerySettings);

--- a/app/javascript/pages/map_legacy/recent-imagery/components/recent-imagery-settings/recent-imagery-settings-drag.js
+++ b/app/javascript/pages/map_legacy/recent-imagery/components/recent-imagery-settings/recent-imagery-settings-drag.js
@@ -1,0 +1,13 @@
+import { DragSource } from 'react-dnd';
+
+const dragSource = {
+  beginDrag(props) {
+    const { settings: { styles } } = props;
+    return styles;
+  }
+};
+
+export default DragSource('box', dragSource, (connect, monitor) => ({
+  connectDragSource: connect.dragSource(),
+  isDragging: monitor.isDragging()
+}));

--- a/app/javascript/pages/map_legacy/recent-imagery/components/recent-imagery-settings/recent-imagery-settings-styles.scss
+++ b/app/javascript/pages/map_legacy/recent-imagery/components/recent-imagery-settings/recent-imagery-settings-styles.scss
@@ -1,0 +1,161 @@
+@import '~styles/settings.scss';
+
+.c-recent-imagery-settings {
+  position: absolute;
+  width: calc(100% - #{rem(20px)});
+  max-width: rem(600px);
+  padding: rem(25px) 0 rem(22px) 0;
+  transform: translateX(-50%);
+  background-color: $white;
+  box-shadow: 0 1px 3px 0 rgba($black, 0.25);
+  z-index: 1001;
+
+  .dragger-icon {
+    display: none;
+    position: absolute;
+    top: rem(9px);
+    left: rem(10px);
+    width: rem(6px);
+    height: rem(10px);
+    fill: $slate;
+  }
+
+  .close-btn {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: rem(30px);
+    height: rem(30px);
+    cursor: pointer;
+
+    svg {
+      width: rem(9px);
+      height: rem(10px);
+      fill: $slate;
+    }
+  }
+
+  &__title {
+    padding-left: rem(20px);
+    margin-bottom: rem(11px);
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 21px;
+    color: $slate;
+  }
+
+  &__dates {
+    position: relative;
+    display: inline-block;
+    width: 100%;
+    padding: 0 rem(20px);
+    vertical-align: top;
+    z-index: 4;
+
+    &__title {
+      margin-bottom: rem(10px);
+    }
+
+    &__title,
+    &__before {
+      font-size: 11px;
+      font-weight: 500;
+      color: $warm-grey;
+    }
+
+    &__buttons {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+
+      .c-dropdown {
+        margin-top: rem(1px);
+      }
+    }
+  }
+
+  &__clouds {
+    position: relative;
+    display: inline-block;
+    width: 100%;
+    padding: 0 rem(20px);
+    margin-top: rem(11px);
+    vertical-align: top;
+
+    &__title {
+      font-size: 11px;
+      font-weight: 500;
+      color: $warm-grey;
+      margin-bottom: rem(10px);
+    }
+
+    .c-slider {
+      padding: 0 rem(5px);
+    }
+  }
+
+  &__thumbnails {
+    position: relative;
+    width: 100%;
+    min-height: rem(146px);
+    padding-top: rem(14px);
+    margin-top: rem(20px);
+    border-top: 1px solid rgba(#9e9e9e, 0.3);
+    z-index: 1;
+
+    &__description {
+      padding-left: rem(22px);
+      margin-bottom: rem(18px);
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 13px;
+      color: $slate;
+    }
+
+    .c-carousel {
+      margin: 0;
+
+      .slick-slide {
+        padding: 0 rem(5.5px);
+      }
+
+      .slick-arrow {
+        top: calc(50% - #{rem(20px)});
+      }
+
+      .slick-prev {
+        left: rem(20px);
+      }
+
+      .slick-next {
+        right: rem(20px);
+      }
+
+      .slick-track {
+        min-height: rem(100px);
+      }
+    }
+  }
+
+  &__empty-thumbnails {
+    padding-top: rem(11px);
+  }
+
+  @media screen and (min-width: rem(620px)) {
+    .dragger-icon {
+      display: block;
+    }
+
+    &__dates {
+      width: 50%;
+    }
+
+    &__clouds {
+      width: 50%;
+      margin-top: 0;
+    }
+  }
+}

--- a/app/javascript/pages/map_legacy/recent-imagery/components/recent-imagery-settings/recent-imagery-settings.js
+++ b/app/javascript/pages/map_legacy/recent-imagery/components/recent-imagery-settings/recent-imagery-settings.js
@@ -1,0 +1,3 @@
+import Component from './recent-imagery-settings-component';
+
+export default Component;

--- a/app/javascript/pages/map_legacy/recent-imagery/components/recent-imagery-thumbnail/recent-imagery-thumbnail-component.js
+++ b/app/javascript/pages/map_legacy/recent-imagery/components/recent-imagery-thumbnail/recent-imagery-thumbnail-component.js
@@ -1,0 +1,48 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import Loader from 'components/ui/loader';
+
+import './recent-imagery-thumbnail-styles.scss';
+
+class RecentImageryThumbnail extends PureComponent {
+  render() {
+    const {
+      id,
+      tile,
+      selected,
+      handleClick,
+      handleMouseEnter,
+      handleMouseLeave
+    } = this.props;
+
+    return (
+      <div
+        className={`c-recent-imagery-thumbnail ${
+          selected ? 'c-recent-imagery-thumbnail--selected' : ''
+        }`}
+        style={{
+          backgroundImage: `url('${tile.thumbnail}')`
+        }}
+        onClick={handleClick}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        role="button"
+        tabIndex={id}
+      >
+        {!tile.thumbnail && <Loader />}
+      </div>
+    );
+  }
+}
+
+RecentImageryThumbnail.propTypes = {
+  id: PropTypes.number.isRequired,
+  tile: PropTypes.object.isRequired,
+  selected: PropTypes.bool.isRequired,
+  handleClick: PropTypes.func.isRequired,
+  handleMouseEnter: PropTypes.func,
+  handleMouseLeave: PropTypes.func
+};
+
+export default RecentImageryThumbnail;

--- a/app/javascript/pages/map_legacy/recent-imagery/components/recent-imagery-thumbnail/recent-imagery-thumbnail-styles.scss
+++ b/app/javascript/pages/map_legacy/recent-imagery/components/recent-imagery-thumbnail/recent-imagery-thumbnail-styles.scss
@@ -1,0 +1,31 @@
+@import '~styles/settings.scss';
+
+.c-recent-imagery-thumbnail {
+  position: relative;
+  width: 100%;
+  height: rem(100px);
+  background-color: $border;
+  background-size: cover;
+  background-position: center center;
+  background-repeat: no-repeat;
+  cursor: pointer;
+  outline: none;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 4px solid transparent;
+  }
+
+  &:hover::before {
+    border-color: $slate;
+  }
+
+  &--selected::before {
+    border-color: $green-gfw !important;
+  }
+}

--- a/app/javascript/pages/map_legacy/recent-imagery/components/recent-imagery-thumbnail/recent-imagery-thumbnail.js
+++ b/app/javascript/pages/map_legacy/recent-imagery/components/recent-imagery-thumbnail/recent-imagery-thumbnail.js
@@ -1,0 +1,3 @@
+import Component from './recent-imagery-thumbnail-component';
+
+export default Component;

--- a/app/javascript/pages/map_legacy/recent-imagery/recent-imagery-actions.js
+++ b/app/javascript/pages/map_legacy/recent-imagery/recent-imagery-actions.js
@@ -1,0 +1,153 @@
+import { createAction } from 'redux-actions';
+import { createThunkAction } from 'utils/redux';
+import axios, { CancelToken } from 'axios';
+import findIndex from 'lodash/findIndex';
+
+import { getRecentTiles, getTiles, getThumbs } from 'services/recent-imagery';
+import { initialState } from './recent-imagery-reducers';
+
+const toogleRecentImagery = createAction('toogleRecentImagery');
+const setVisible = createAction('setVisible');
+const setTimelineFlag = createAction('setTimelineFlag');
+const setRecentImageryData = createAction('setRecentImageryData');
+const setRecentImageryDataStatus = createAction('setRecentImageryDataStatus');
+const setRecentImagerySettings = createAction('setRecentImagerySettings');
+const setRecentImageryShowSettings = createAction(
+  'setRecentImageryShowSettings'
+);
+
+const getData = createThunkAction('getData', params => dispatch => {
+  if (this.getDataSource) {
+    this.getDataSource.cancel();
+  }
+  this.getDataSource = CancelToken.source();
+
+  getRecentTiles({ ...params, token: this.getDataSource.token })
+    .then(response => {
+      if (response.data.data.tiles) {
+        const { clouds } = initialState.settings;
+        const { source } = response.data.data.tiles[0].attributes;
+        const cloud_score = Math.round(
+          response.data.data.tiles[0].attributes.cloud_score
+        );
+
+        dispatch(
+          setRecentImageryData({
+            data: response.data.data,
+            dataStatus: {
+              haveAllData: false,
+              requestedTiles: 0
+            },
+            settings: {
+              selectedTileSource: source,
+              clouds: cloud_score > clouds ? cloud_score : clouds
+            }
+          })
+        );
+      }
+    })
+    .catch(error => {
+      console.info(error);
+    });
+});
+
+const getMoreTiles = createThunkAction(
+  'getMoreTiles',
+  params => (dispatch, state) => {
+    if (this.getMoreTilesSource) {
+      this.getMoreTilesSource.cancel();
+    }
+    this.getMoreTilesSource = CancelToken.source();
+    const { sources, dataStatus } = params;
+
+    axios
+      .all([
+        getTiles({ sources, token: this.getMoreTilesSource.token }),
+        getThumbs({ sources, token: this.getMoreTilesSource.token })
+      ])
+      .then(
+        axios.spread((getTilesResponse, getThumbsResponse) => {
+          if (
+            getTilesResponse.data.data &&
+            getTilesResponse.data.data.attributes.length &&
+            getThumbsResponse.data.data &&
+            getThumbsResponse.data.data.attributes.length
+          ) {
+            const stateData = state().recentImagery.data;
+            const data = { ...stateData, tiles: stateData.tiles.slice() };
+            const tiles = getTilesResponse.data.data.attributes;
+            const thumbs = getThumbsResponse.data.data.attributes;
+            const requestedTiles = dataStatus.requestedTiles + tiles.length;
+            const haveAllData = requestedTiles === data.tiles.length;
+
+            tiles.forEach((item, i) => {
+              if (i > 0) {
+                const index = findIndex(
+                  data.tiles,
+                  d => d.attributes.source === item.source_id
+                );
+                if (index !== -1) {
+                  data.tiles[index].attributes.tile_url = item.tile_url;
+                }
+              }
+            });
+            thumbs.forEach(item => {
+              const index = findIndex(
+                data.tiles,
+                d => d.attributes.source === item.source
+              );
+              if (index !== -1) {
+                data.tiles[index].attributes.thumbnail_url = item.thumbnail_url;
+              }
+            });
+
+            dispatch(
+              setRecentImageryData({
+                data,
+                dataStatus: {
+                  haveAllData,
+                  requestedTiles
+                }
+              })
+            );
+          }
+        })
+      )
+      .catch(error => {
+        dispatch(
+          setRecentImageryData({
+            dataStatus: {
+              requestFails: params.dataStatus.requestFails + 1
+            }
+          })
+        );
+        console.info(error);
+      });
+  }
+);
+
+const resetData = createThunkAction('resetData', () => dispatch => {
+  dispatch(setRecentImageryShowSettings(false));
+  dispatch(
+    setRecentImageryData({
+      data: {},
+      dataStatus: {
+        haveAllData: false,
+        requestedTiles: 0
+      }
+    })
+  );
+});
+
+export default {
+  toogleRecentImagery,
+  setVisible,
+  setTimelineFlag,
+  setRecentImageryData,
+  setRecentImageryDataStatus,
+  setRecentImagerySettings,
+  setRecentImageryShowSettings,
+  getData,
+  getMoreTiles,
+  resetData
+};

--- a/app/javascript/pages/map_legacy/recent-imagery/recent-imagery-component.js
+++ b/app/javascript/pages/map_legacy/recent-imagery/recent-imagery-component.js
@@ -1,0 +1,74 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import Icon from 'components/ui/icon';
+import satelliteIcon from 'assets/icons/satellite.svg';
+import Button from 'components/ui/button';
+import RecentImagerySettings from './components/recent-imagery-settings';
+
+import './recent-imagery-styles.scss';
+
+class RecentImagery extends PureComponent {
+  render() {
+    const {
+      active,
+      showSettings,
+      isTimelineOpen,
+      tile,
+      allTiles,
+      settings,
+      canDrop,
+      connectDropTarget,
+      toogleRecentImagery,
+      setRecentImagerySettings,
+      setRecentImageryShowSettings
+    } = this.props;
+
+    return connectDropTarget(
+      <div
+        className={`c-recent-imagery ${
+          canDrop ? 'c-recent-imagery--dragging' : ''
+        }`}
+      >
+        <Button
+          className={`c-recent-imagery__button ${
+            isTimelineOpen ? 'c-recent-imagery__button--timeline-open' : ''
+          }`}
+          theme="theme-button-map-control"
+          active={active}
+          onClick={() => toogleRecentImagery()}
+        >
+          <Icon icon={satelliteIcon} className="satellite-icon" />
+          <span>
+            Recent<br />Imagery
+          </span>
+        </Button>
+        {showSettings && (
+          <RecentImagerySettings
+            selectedTile={tile}
+            tiles={allTiles}
+            settings={settings}
+            setRecentImagerySettings={setRecentImagerySettings}
+            setRecentImageryShowSettings={setRecentImageryShowSettings}
+          />
+        )}
+      </div>
+    );
+  }
+}
+
+RecentImagery.propTypes = {
+  active: PropTypes.bool.isRequired,
+  showSettings: PropTypes.bool.isRequired,
+  isTimelineOpen: PropTypes.bool.isRequired,
+  tile: PropTypes.object,
+  allTiles: PropTypes.array.isRequired,
+  settings: PropTypes.object.isRequired,
+  connectDropTarget: PropTypes.func.isRequired,
+  canDrop: PropTypes.bool.isRequired,
+  toogleRecentImagery: PropTypes.func.isRequired,
+  setRecentImagerySettings: PropTypes.func.isRequired,
+  setRecentImageryShowSettings: PropTypes.func.isRequired
+};
+
+export default RecentImagery;

--- a/app/javascript/pages/map_legacy/recent-imagery/recent-imagery-drag.js
+++ b/app/javascript/pages/map_legacy/recent-imagery/recent-imagery-drag.js
@@ -1,0 +1,17 @@
+import { DropTarget } from 'react-dnd';
+
+const dropTarget = {
+  drop(props, monitor) {
+    const { setRecentImagerySettings } = props;
+    const item = monitor.getItem();
+    const delta = monitor.getDifferenceFromInitialOffset();
+    const top = Math.round(item.top + delta.y);
+    const left = `calc(${item.left} + ${Math.round(delta.x)}px)`;
+    setRecentImagerySettings({ styles: { top, left } });
+  }
+};
+
+export default DropTarget('box', dropTarget, (connect, monitor) => ({
+  connectDropTarget: connect.dropTarget(),
+  canDrop: monitor.canDrop()
+}));

--- a/app/javascript/pages/map_legacy/recent-imagery/recent-imagery-reducers.js
+++ b/app/javascript/pages/map_legacy/recent-imagery/recent-imagery-reducers.js
@@ -1,0 +1,86 @@
+export const initialState = {
+  active: false,
+  visible: false,
+  showSettings: false,
+  isTimelineOpen: false,
+  data: {},
+  dataStatus: {
+    tilesPerRequest: 6,
+    haveAllData: false,
+    requestedTiles: 0,
+    requestFails: 0
+  },
+  settings: {
+    styles: {
+      top: 90,
+      left: '50%'
+    },
+    layerSlug: 'sentinel_tiles',
+    minZoom: 9,
+    thumbsToShow: 5,
+    selectedTileSource: null,
+    date: null,
+    weeks: 13,
+    clouds: 25
+  }
+};
+
+const toogleRecentImagery = state => ({
+  ...state,
+  active: !state.active,
+  visible: !state.active
+});
+
+const setVisible = (state, { payload }) => ({
+  ...state,
+  visible: payload
+});
+
+const setTimelineFlag = (state, { payload }) => ({
+  ...state,
+  isTimelineOpen: payload
+});
+
+const setRecentImageryData = (state, { payload }) => ({
+  ...state,
+  data: payload.data ? payload.data : state.data,
+  dataStatus: {
+    ...state.dataStatus,
+    ...payload.dataStatus
+  },
+  settings: {
+    ...state.settings,
+    ...payload.settings
+  }
+});
+
+const setRecentImageryDataStatus = (state, { payload }) => ({
+  ...state,
+  dataStatus: {
+    ...state.dataStatus,
+    ...payload
+  }
+});
+
+const setRecentImagerySettings = (state, { payload }) => ({
+  ...state,
+  settings: {
+    ...state.settings,
+    ...payload
+  }
+});
+
+const setRecentImageryShowSettings = (state, { payload }) => ({
+  ...state,
+  showSettings: payload
+});
+
+export default {
+  toogleRecentImagery,
+  setVisible,
+  setTimelineFlag,
+  setRecentImageryData,
+  setRecentImageryDataStatus,
+  setRecentImagerySettings,
+  setRecentImageryShowSettings
+};

--- a/app/javascript/pages/map_legacy/recent-imagery/recent-imagery-selectors.js
+++ b/app/javascript/pages/map_legacy/recent-imagery/recent-imagery-selectors.js
@@ -1,0 +1,102 @@
+import { createSelector } from 'reselect';
+import isEmpty from 'lodash/isEmpty';
+import findIndex from 'lodash/findIndex';
+import moment from 'moment';
+import { format } from 'd3-format';
+
+const getData = state => state.data || null;
+const getDataStatus = state => state.dataStatus || null;
+const getSettings = state => state.settings || null;
+
+const getFilteredData = createSelector(
+  [getData, getSettings],
+  (data, settings) => {
+    if (!data || isEmpty(data)) return null;
+
+    const { clouds } = settings;
+    return data
+      .filter(item => Math.round(item.attributes.cloud_score) <= clouds)
+      .map(item => item.attributes);
+  }
+);
+
+export const getAllTiles = createSelector([getFilteredData], data => {
+  if (!data || isEmpty(data)) return [];
+
+  return data.map(item => ({
+    id: item.source,
+    url: item.tile_url,
+    thumbnail: item.thumbnail_url,
+    cloudScore: item.cloud_score,
+    dateTime: item.date_time,
+    instrument: item.instrument,
+    description: `${moment(item.date_time)
+      .format('DD MMM YYYY')
+      .toUpperCase()} - ${format('.0f')(item.cloud_score)}% cloud coverage - ${
+      item.instrument
+    }`
+  }));
+});
+
+export const getTile = createSelector(
+  [getData, getSettings],
+  (data, settings) => {
+    if (!data || isEmpty(data)) return null;
+
+    const { selectedTileSource } = settings;
+    const index = findIndex(
+      data,
+      d => d.attributes.source === selectedTileSource
+    );
+
+    const selectedTile = data[index].attributes;
+    return {
+      url: selectedTile.tile_url,
+      cloudScore: selectedTile.cloud_score,
+      dateTime: selectedTile.date_time,
+      instrument: selectedTile.instrument,
+      description: `${moment(selectedTile.date_time)
+        .format('DD MMM YYYY')
+        .toUpperCase()} - ${format('.0f')(
+        selectedTile.cloud_score
+      )}% cloud coverage - ${selectedTile.instrument}`
+    };
+  }
+);
+
+export const getBounds = createSelector(
+  [getData, getSettings],
+  (data, settings) => {
+    if (!data || isEmpty(data)) return null;
+
+    const { selectedTileSource } = settings;
+    const index = findIndex(
+      data,
+      d => d.attributes.source === selectedTileSource
+    );
+
+    return data[index].attributes.bbox.geometry.coordinates;
+  }
+);
+
+export const getSources = createSelector(
+  [getData, getDataStatus],
+  (data, dataStatus) => {
+    if (!data || isEmpty(data)) return null;
+
+    const { tilesPerRequest, requestedTiles } = dataStatus;
+    return data
+      .slice(requestedTiles, requestedTiles + tilesPerRequest)
+      .map(item => ({ source: item.attributes.source }));
+  }
+);
+
+export const getDates = createSelector([getSettings], settings => {
+  const { date, weeks } = settings;
+  const currentDate = date ? moment(date) : moment();
+
+  return {
+    end: currentDate.format('YYYY-MM-DD'),
+    start: currentDate.subtract(weeks, 'weeks').format('YYYY-MM-DD')
+  };
+});

--- a/app/javascript/pages/map_legacy/recent-imagery/recent-imagery-styles.scss
+++ b/app/javascript/pages/map_legacy/recent-imagery/recent-imagery-styles.scss
@@ -2,6 +2,9 @@
 
 .c-recent-imagery {
   &__button {
+    position: absolute;
+    right: rem(10px);
+    bottom: rem(238px);
     width: rem(38px);
     transition: transform 0.25s cubic-bezier(0.445, 0.05, 0.55, 0.95);
     z-index: 19;
@@ -29,6 +32,9 @@
 
   @media screen and (min-width: rem(1000px)) {
     &__button {
+      right: auto;
+      left: rem(35px);
+      bottom: rem(172px);
       width: rem(76px);
 
       .satellite-icon {

--- a/app/javascript/pages/map_legacy/recent-imagery/recent-imagery.js
+++ b/app/javascript/pages/map_legacy/recent-imagery/recent-imagery.js
@@ -49,7 +49,7 @@ const mapStateToProps = ({ recentImagery }) => {
 
 class RecentImageryContainer extends PureComponent {
   componentDidMount() {
-    // this.middleView = window.App.Views.ReactMapMiddleView;
+    this.middleView = window.App.Views.ReactMapMiddleView;
     this.boundsPolygon = null;
     this.boundsPolygonInfowindow = null;
     this.activatedFromUrl = false;

--- a/app/javascript/pages/map_legacy/root/root-component.js
+++ b/app/javascript/pages/map_legacy/root/root-component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { DragDropContextProvider } from 'react-dnd';
 
-import RecentImagery from 'pages/map/recent-imagery';
+import RecentImagery from 'pages/map_legacy/recent-imagery';
 
 import './root-styles.scss';
 


### PR DESCRIPTION
Adds the new map controls in the new position and links new menu component to the meta modal:
- zoom controls: move map actions to component and simplify styles.
- share: introduce component
- meta model: open on click from new menu
- updates meta modal render component to add all missing fields such as info and download data buttons.

Also add the recent imagery button to map for styling layout of controls. Duplicated component due to upcoming architecture change for how the container interacts with the map.