### PR TITLE
Allows all forest change layers to be used in analysis

### DIFF
--- a/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
+++ b/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
@@ -149,7 +149,7 @@ define(
 
         // Alerts
         p.alerts = {};
-        p.alerts.totalAlerts = this.roundNumber(results.value || 0);
+        p.alerts.totalAlerts = this.roundNumber(results.loss || 0);
 
         // Options
         p.options = {};
@@ -208,7 +208,7 @@ define(
         }
 
         if (p.slug === 'forma250GFW') {
-          p.alerts.totalAlerts = this.roundNumber(results.alertCounts || 0);
+          p.alerts.totalAlerts = this.roundNumber(results.loss || 0);
         }
 
         return p;

--- a/app/assets/javascripts/map/services/AnalysisNewService.js
+++ b/app/assets/javascripts/map/services/AnalysisNewService.js
@@ -36,7 +36,17 @@ define(
       get: function(status) {
         if (
           (status.baselayers.indexOf('umd_as_it_happens') > -1 ||
-            status.baselayers.indexOf('places_to_watch') > -1) &&
+            status.baselayers.indexOf('places_to_watch') > -1 ||
+            status.baselayers.indexOf('terrailoss') > -1 ||
+            status.baselayers.indexOf('forma_month_3') > -1 ||
+            status.baselayers.indexOf('forma_activity') > -1 ||
+            status.baselayers.indexOf('imazon') > -1 ||
+            status.baselayers.indexOf('guyra') > -1 ||
+            status.baselayers.indexOf('viirs_fires_alerts') > -1 ||
+            status.baselayers.indexOf('umd_as_it_happens_per') > -1 ||
+            status.baselayers.indexOf('umd_as_it_happens_cog') > -1 ||
+            status.baselayers.indexOf('umd_as_it_happens_idn') > -1 ||
+            status.baselayers.indexOf('prodes') > -1) &&
           status.type === 'draw'
         ) {
           var umdUrl = UriTemplate(APIURLS['draw']).fillFromObject({
@@ -85,7 +95,9 @@ define(
                                 attributes: {
                                   areaHa: umdResponse.data.attributes.areaHa,
                                   gain: umdResponse.data.attributes.gain,
-                                  loss: response.data.attributes.value,
+                                  loss:
+                                    response.data.attributes.value ||
+                                    response.data.attributes.alertCounts,
                                   treeExtent:
                                     umdResponse.data.attributes.treeExtent,
                                   treeExtent2010:

--- a/app/assets/javascripts/map/templates/analysis/analysis-results.handlebars
+++ b/app/assets/javascripts/map/templates/analysis/analysis-results.handlebars
@@ -67,21 +67,14 @@
       </li>
     {{/if}}
 
-    <li>
-      <div class="stats-notice">This algorithm approximates the results by sampling the selected area. Results are more accurate at closer zoom levels.</div>
-    </li>
-
-    <li>
-      <div class="stats-notice">NOTE: tree cover loss and gain statistics cannot be compared against each other. <a href="#" class="source" data-source="loss-compare-gain">Learn more</a>.</div>
-    </li>
 
     {{!-- PRODES --}}
-    {{#ifCond resource.slug "===" 'prodes-loss'}}
+    {{#if resource.baselayers.prodes}}
       <li>
         <span class="stats-title">Prodes tree cover loss ({{resource.dates.dateRange}})</span>
         <span class="stats-count" style="color: {{resource.baselayers.prodes.title_color}};"><strong>{{resource.alerts.totalAlerts}}</strong> ha</span>
       </li>
-    {{/ifCond}}
+    {{/if}}
 
     {{!-- IMAZON --}}
     {{#ifCond resource.slug "===" 'imazon-alerts'}}
@@ -162,6 +155,15 @@
         <span class="stats-count" style="color: {{resource.baselayers.viirs_fires_alerts.title_color}};"><strong>{{resource.alerts.totalAlerts}}</strong> VIIRS active fire alerts</span>
       </li>
     {{/ifCond}}
+
+    <li>
+      <div class="stats-notice">This algorithm approximates the results by sampling the selected area. Results are more accurate at closer zoom levels.</div>
+    </li>
+
+    <li>
+      <div class="stats-notice">NOTE: tree cover loss and gain statistics cannot be compared against each other. <a href="#" class="source" data-source="loss-compare-gain">Learn more</a>.</div>
+    </li>
+    
   </ul>
 </div>
 


### PR DESCRIPTION
## Overview

Adds condition to allow multiple fetches in the case of All Forest Change layers, mapping the response values onto `results.loss`.

## Note

~SAD Alerts (aka IMAZON) does not work due to incorrect api response. Should work once fixed.~

This is now fixed and should work. See [example response](https://production-api.globalforestwatch.org/imazon-alerts?geostore=2d3970d94dd23b93697fef948da0cf6f&period=2008-01-01%2C2018-03-01&thresh=30&_=1530526547935).
