### PR TITLE
Fix/explore animation

### DIFF
--- a/app/javascript/pages/map/menu/components/menu-flap/menu-flap-styles.scss
+++ b/app/javascript/pages/map/menu/components/menu-flap/menu-flap-styles.scss
@@ -13,12 +13,11 @@ $map-menu-flap-close-size: rem(32px);
   height: 100vh;
   background-color: $white;
   z-index: 1;
-  transform: translateX(#{$map-menu-items-size - $map-menu-flap-close-size - $map-menu-flap-width});
-  transition: transform 0.3s ease-in-out;
+  transform: translateX(#{$map-menu-items-size - $map-menu-flap-close-size - $map-menu-flap-width-big});
+  transition: transform 0.3s linear;
 
   &.--big {
     width: $map-menu-flap-width-big;
-    transform: translateX(#{$map-menu-items-size - $map-menu-flap-close-size - $map-menu-flap-width-big});
   }
 
   &.--showed {


### PR DESCRIPTION
## Overview

CSS adjustments to prevent flickering in the animation of the explore tab