### PR TITLE
[Dashboards]: Fixes unit issue in employment pie-chart legend

### DIFF
--- a/app/javascript/components/widgets/components/widget-pie-chart-legend/component.jsx
+++ b/app/javascript/components/widgets/components/widget-pie-chart-legend/component.jsx
@@ -17,10 +17,10 @@ class WidgetTreeCover extends PureComponent {
           className="cover-legend"
           data={data}
           config={{
-            ...settings,
             format: '.3s',
             unit: 'ha',
-            key: 'value'
+            key: 'value',
+            ...settings
           }}
         />
         <PieChart

--- a/app/javascript/components/widgets/widgets/people/forestry-employment/initial-state.js
+++ b/app/javascript/components/widgets/widgets/people/forestry-employment/initial-state.js
@@ -22,7 +22,8 @@ export default {
     }
   },
   settings: {
-    year: 2010
+    year: 2010,
+    unit: ''
   },
   enabled: true
 };


### PR DESCRIPTION
## Overview

Pulls unit from `initial-state` config, instead of just `ha` for all widgets.
