### PR TITLE
Forestry employment widget: missing multiplication factor

### DIFF
--- a/app/javascript/components/widgets/widgets/people/forestry-employment/selectors.js
+++ b/app/javascript/components/widgets/widgets/people/forestry-employment/selectors.js
@@ -22,7 +22,7 @@ export const getFilteredData = createSelector(
       .map(item => ({
         male: item.femempl
           ? (item.forempl - item.femempl) * 1000
-          : item.forempl,
+          : item.forempl * 1000,
         female: item.femempl ? item.femempl * 1000 : null,
         year: item.year
       }));


### PR DESCRIPTION
Added a simple factor to the widget that was missing during one case.

After the PR the result for Guatemala should be:

![screen shot 2018-07-19 at 14 39 52](https://user-images.githubusercontent.com/6503031/42943068-17893796-8b62-11e8-8dec-d4355300b5c0.png)

Countries with gender data should be unaffected.