### PR TITLE
[Country Dashboards] Ranking statement calculation fix

### DIFF
--- a/app/javascript/components/widgets/widgets/forest-change/glad-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/glad-ranked/selectors.js
@@ -94,32 +94,22 @@ export const getSentence = createSelector(
     parseList,
     getSettings,
     getOptions,
-    getLocation,
     getIndicator,
     getCurrentLocation,
     getSentences
   ],
-  (
-    data,
-    list,
-    settings,
-    options,
-    location,
-    indicator,
-    currentLabel,
-    sentences
-  ) => {
+  (data, sortedList, settings, options, indicator, currentLabel, sentences) => {
     if (!data || !options || !currentLabel) return '';
     const { initial, withInd } = sentences;
     const totalCount = sumBy(data, 'count');
     let percentileCount = 0;
     let percentileLength = 0;
     while (
-      percentileLength < list.length &&
+      percentileLength < sortedList.length &&
       percentileCount / totalCount < 0.5 &&
       percentileLength !== 10
     ) {
-      percentileCount += list[percentileLength].count;
+      percentileCount += sortedList[percentileLength].count;
       percentileLength += 1;
     }
     const topCount = percentileCount / totalCount * 100;

--- a/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/selectors.js
@@ -94,11 +94,11 @@ export const getSentence = createSelector(
     let percentileLength = 0;
 
     while (
-      percentileLength < data.length &&
+      percentileLength < sortedData.length &&
       percentileGain / totalGain < 0.5 &&
       percentileLength !== 10
     ) {
-      percentileGain += data[percentileLength].gain;
+      percentileGain += sortedData[percentileLength].gain;
       percentileLength += 1;
     }
 

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/selectors.js
@@ -93,9 +93,10 @@ export const getSentence = createSelector(
       percentileLoss / totalLoss < 0.5 &&
       percentileLength !== 10
     ) {
-      percentileLoss += data[percentileLength].loss;
+      percentileLoss += sortedData[percentileLength].loss;
       percentileLength += 1;
     }
+
     const topLoss = percentileLoss / totalLoss * 100 || 0;
     let sentence = !indicator ? initialPercent : withIndicatorPercent;
 

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
@@ -53,7 +53,6 @@ export const getSentence = createSelector(
     parseData,
     getSettings,
     getOptions,
-    getLocation,
     getIndicator,
     getForestType,
     getLandCategory,
@@ -61,11 +60,10 @@ export const getSentence = createSelector(
     getSentences
   ],
   (
-    list,
+    sortedList,
     data,
     settings,
     options,
-    location,
     indicator,
     forestType,
     landCategory,
@@ -95,11 +93,11 @@ export const getSentence = createSelector(
     let percentileExtent = 0;
     let percentileLength = 0;
     while (
-      percentileLength < data.length &&
+      percentileLength < sortedList.length &&
       percentileExtent / totalExtent < 0.5 &&
       percentileLength !== 10
     ) {
-      percentileExtent += list[percentileLength].extent;
+      percentileExtent += sortedList[percentileLength].extent;
       percentileLength += 1;
     }
     const topExtent = percentileExtent / (totalExtent || 0) * 100;


### PR DESCRIPTION
## Overview

Ensures all widgets that make a statement like: *"The top 10 regions represent X% of total"*, sort data before calculating the percentage.

- Also removes some unused code
- and adds some better/clearer naming conventions

