### PR TITLE
[ANALYSIS]: Fixes loss & multiple analyses

### DIFF
--- a/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
+++ b/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
@@ -171,26 +171,24 @@ define(
         /**
          * Exceptions
          */
-
+        console.log('RESULT', results);
         // If glads enpoint; api response schema is different!
         if (
           p.baselayers &&
           typeof p.baselayers.places_to_watch !== 'undefined'
         ) {
           p.alerts.totalAlerts = this.roundNumber(results.alerts || 0);
-          p.alerts.treeExtent = this.roundNumber(results.areaHa || 0);
-          p.alerts.treeExtent2010 = this.roundNumber(results.areaHa || 0);
         } else {
           p.alerts.totalAlerts = this.roundNumber(results.loss || 0);
-          p.alerts.treeExtent = this.roundNumber(
-            results.extent2000 || results.treeExtent || 0
-          );
           p.alerts.treeExtent2010 = this.roundNumber(
             results.extent2010 || results.treeExtent2010 || 0
           );
         }
         p.areaHa = this.roundNumber(results.areaHa || 0);
         p.alerts.gainAlerts = this.roundNumber(results.gain || 0);
+        p.alerts.treeExtent = this.roundNumber(
+          results.extent2000 || results.treeExtent || 0
+        );
 
         // Dates
         p.dates.lossDateRange = '{0}-{1}'.format(

--- a/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
+++ b/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
@@ -171,24 +171,26 @@ define(
         /**
          * Exceptions
          */
+
+        // If glads enpoint; api response schema is different!
         if (
           p.baselayers &&
-          typeof p.baselayers.places_to_watch !== 'undefined' &&
-          type == 'country'
+          typeof p.baselayers.places_to_watch !== 'undefined'
         ) {
           p.alerts.totalAlerts = this.roundNumber(results.alerts || 0);
+          p.alerts.treeExtent = this.roundNumber(results.areaHa || 0);
+          p.alerts.treeExtent2010 = this.roundNumber(results.areaHa || 0);
+        } else {
+          p.alerts.totalAlerts = this.roundNumber(results.loss || 0);
+          p.alerts.treeExtent = this.roundNumber(
+            results.extent2000 || results.treeExtent || 0
+          );
+          p.alerts.treeExtent2010 = this.roundNumber(
+            results.extent2010 || results.treeExtent2010 || 0
+          );
         }
-        // var results =
-        //   type == 'country' ? results.totals || results.total : results;
         p.areaHa = this.roundNumber(results.areaHa || 0);
-        p.alerts.totalAlerts = this.roundNumber(results.loss || 0);
         p.alerts.gainAlerts = this.roundNumber(results.gain || 0);
-        p.alerts.treeExtent = this.roundNumber(
-          results.extent2000 || results.treeExtent || 0
-        );
-        p.alerts.treeExtent2010 = this.roundNumber(
-          results.extent2010 || results.treeExtent2010 || 0
-        );
 
         // Dates
         p.dates.lossDateRange = '{0}-{1}'.format(

--- a/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
+++ b/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
@@ -171,23 +171,19 @@ define(
         /**
          * Exceptions
          */
-        console.log('RESULT', results);
         // If glads enpoint; api response schema is different!
-        if (
-          p.baselayers &&
-          typeof p.baselayers.places_to_watch !== 'undefined'
-        ) {
-          p.alerts.totalAlerts = this.roundNumber(results.alerts || 0);
-        } else {
-          p.alerts.totalAlerts = this.roundNumber(results.loss || 0);
-          p.alerts.treeExtent2010 = this.roundNumber(
-            results.extent2010 || results.treeExtent2010 || 0
-          );
-        }
+        p.alerts.totalAlerts =
+          p.baselayers && typeof p.baselayers.umd_as_it_happens !== 'undefined'
+            ? this.roundNumber(results.alerts || 0)
+            : this.roundNumber(results.loss || 0);
+
         p.areaHa = this.roundNumber(results.areaHa || 0);
         p.alerts.gainAlerts = this.roundNumber(results.gain || 0);
         p.alerts.treeExtent = this.roundNumber(
           results.extent2000 || results.treeExtent || 0
+        );
+        p.alerts.treeExtent2010 = this.roundNumber(
+          results.extent2010 || results.treeExtent2010 || 0
         );
 
         // Dates
@@ -217,7 +213,6 @@ define(
         if (p.slug === 'forma250GFW') {
           p.alerts.totalAlerts = this.roundNumber(results.loss || 0);
         }
-
         return p;
       },
 

--- a/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
+++ b/app/assets/javascripts/map/presenters/analysis/AnalysisResultsNewPresenter.js
@@ -171,8 +171,15 @@ define(
         /**
          * Exceptions
          */
-        var results =
-          type == 'country' ? results.totals || results.total : results;
+        if (
+          p.baselayers &&
+          typeof p.baselayers.places_to_watch !== 'undefined' &&
+          type == 'country'
+        ) {
+          p.alerts.totalAlerts = this.roundNumber(results.alerts || 0);
+        }
+        // var results =
+        //   type == 'country' ? results.totals || results.total : results;
         p.areaHa = this.roundNumber(results.areaHa || 0);
         p.alerts.totalAlerts = this.roundNumber(results.loss || 0);
         p.alerts.gainAlerts = this.roundNumber(results.gain || 0);

--- a/app/assets/javascripts/map/services/AnalysisNewService.js
+++ b/app/assets/javascripts/map/services/AnalysisNewService.js
@@ -190,14 +190,13 @@ define(
                           }
                         };
                       } else {
-                        console.log('RESPONSE', response);
                         data = {
                           data: {
                             attributes: {
                               areaHa: response.data.attributes.areaHa,
                               gain: response.data.attributes.gain,
                               loss: response.data.attributes.loss,
-                              alerts: response.data.attributes.alertCounts,
+                              alerts: response.data.attributes.value,
                               treeExtent: response.data.attributes.treeExtent,
                               treeExtent2010:
                                 response.data.attributes.treeExtent2010,
@@ -207,7 +206,6 @@ define(
                           }
                         };
                       }
-                      console.log('PARSED DATA', data);
                       resolve(data, status);
                     }.bind(this),
                     error: function(errors) {

--- a/app/assets/javascripts/map/services/AnalysisNewService.js
+++ b/app/assets/javascripts/map/services/AnalysisNewService.js
@@ -55,6 +55,7 @@ define(
             useid: status.useid,
             dataset: 'umd-loss-gain',
             geostore: status.geostore || status.useGeostore,
+            wdpaid: status.wdpaid,
             period: status.period,
             thresh: status.threshold,
             gladConfirmOnly: status.gladConfirmOnly
@@ -97,8 +98,10 @@ define(
                                 attributes: {
                                   areaHa: umdResponse.data.attributes.areaHa,
                                   gain: umdResponse.data.attributes.gain,
-                                  loss: response.data.attributes.value,
-                                  alerts: response.data.attributes.alertCounts,
+                                  loss: umdResponse.data.attributes.loss,
+                                  alerts:
+                                    response.data.attributes.value ||
+                                    response.data.attributes.alertCounts,
                                   treeExtent:
                                     umdResponse.data.attributes.treeExtent,
                                   treeExtent2010:
@@ -108,7 +111,6 @@ define(
                                 }
                               }
                             };
-                            console.log(response, umdResponse);
                             resolve(data, status);
                           }.bind(this),
                           error: function(errors) {

--- a/app/assets/javascripts/map/services/AnalysisNewService.js
+++ b/app/assets/javascripts/map/services/AnalysisNewService.js
@@ -31,7 +31,6 @@ define(
       use: '/{dataset}/use{/use}{/useid}{?period,thresh,gladConfirmOnly}',
       'use-geostore': '/{dataset}{?geostore,period,thresh,gladConfirmOnly}'
     };
-
     var AnalysisService = Class.extend({
       get: function(status) {
         if (
@@ -86,49 +85,25 @@ define(
                             }
                           }
                         });
-
                         var requestConfig = {
                           resourceId: GET_REQUEST_ID,
                           success: function(response, status) {
-                            var data = {};
-                            if (this.analysis.type === 'country') {
-                              data = {
-                                data: {
-                                  attributes: {
-                                    areaHa:
-                                      response.data.attributes.totals.areaHa,
-                                    gain: response.data.attributes.totals.gain,
-                                    loss: response.data.attributes.totals.loss,
-                                    alerts:
-                                      response.data.attributes.totals
-                                        .gladAlerts,
-                                    treeExtent:
-                                      response.data.attributes.totals
-                                        .extent2000,
-                                    treeExtent2010:
-                                      response.data.attributes.totals.extent2010
-                                  }
+                            var data = {
+                              data: {
+                                attributes: {
+                                  areaHa: umdResponse.data.attributes.areaHa,
+                                  gain: umdResponse.data.attributes.gain,
+                                  loss: response.data.attributes.value,
+                                  alerts: response.data.attributes.alertCounts,
+                                  treeExtent:
+                                    umdResponse.data.attributes.treeExtent,
+                                  treeExtent2010:
+                                    umdResponse.data.attributes.treeExtent2010,
+                                  downloadUrls:
+                                    response.data.attributes.downloadUrls
                                 }
-                              };
-                            } else {
-                              data = {
-                                data: {
-                                  attributes: {
-                                    areaHa: response.data.attributes.areaHa,
-                                    gain: response.data.attributes.gain,
-                                    loss: response.data.attributes.value,
-                                    alerts:
-                                      response.data.attributes.alertCounts,
-                                    treeExtent:
-                                      response.data.attributes.treeExtent,
-                                    treeExtent2010:
-                                      response.data.attributes.treeExtent2010,
-                                    downloadUrls:
-                                      response.data.attributes.downloadUrls
-                                  }
-                                }
-                              };
-                            }
+                              }
+                            };
                             resolve(data, status);
                           }.bind(this),
                           error: function(errors) {

--- a/app/assets/javascripts/map/services/AnalysisNewService.js
+++ b/app/assets/javascripts/map/services/AnalysisNewService.js
@@ -86,27 +86,51 @@ define(
                             }
                           }
                         });
+                        console.log('UMD', umdResponse);
+                        console.log('RESPONSE', response);
 
                         var requestConfig = {
                           resourceId: GET_REQUEST_ID,
                           success: function(response, status) {
-                            var data = {
-                              data: {
-                                attributes: {
-                                  areaHa: umdResponse.data.attributes.areaHa,
-                                  gain: umdResponse.data.attributes.gain,
-                                  loss:
-                                    response.data.attributes.value ||
-                                    response.data.attributes.alertCounts,
-                                  treeExtent:
-                                    umdResponse.data.attributes.treeExtent,
-                                  treeExtent2010:
-                                    umdResponse.data.attributes.treeExtent2010,
-                                  downloadUrls:
-                                    response.data.attributes.downloadUrls
+                            var data = {};
+                            if (this.analysis.type === 'country') {
+                              data = {
+                                data: {
+                                  attributes: {
+                                    areaHa:
+                                      response.data.attributes.totals.areaHa,
+                                    gain: response.data.attributes.totals.gain,
+                                    loss: response.data.attributes.totals.loss,
+                                    alerts:
+                                      response.data.attributes.totals
+                                        .gladAlerts,
+                                    treeExtent:
+                                      response.data.attributes.totals
+                                        .extent2000,
+                                    treeExtent2010:
+                                      response.data.attributes.totals.extent2010
+                                  }
                                 }
-                              }
-                            };
+                              };
+                            } else {
+                              data = {
+                                data: {
+                                  attributes: {
+                                    areaHa: response.data.attributes.areaHa,
+                                    gain: response.data.attributes.gain,
+                                    loss: response.data.attributes.value,
+                                    alerts:
+                                      response.data.attributes.alertCounts,
+                                    treeExtent:
+                                      response.data.attributes.treeExtent,
+                                    treeExtent2010:
+                                      response.data.attributes.treeExtent2010,
+                                    downloadUrls:
+                                      response.data.attributes.downloadUrls
+                                  }
+                                }
+                              };
+                            }
                             resolve(data, status);
                           }.bind(this),
                           error: function(errors) {
@@ -148,21 +172,42 @@ define(
                   var requestConfig = {
                     resourceId: GET_REQUEST_ID,
                     success: function(response, status) {
-                      var data = {
-                        data: {
-                          attributes: {
-                            areaHa: response.data.attributes.areaHa,
-                            gain: response.data.attributes.gain,
-                            loss:
-                              response.data.attributes.value ||
-                              response.data.attributes.alertCounts,
-                            treeExtent: response.data.attributes.treeExtent,
-                            treeExtent2010:
-                              response.data.attributes.treeExtent2010,
-                            downloadUrls: response.data.attributes.downloadUrls
+                      var data = {};
+                      if (this.analysis.type === 'country') {
+                        data = {
+                          data: {
+                            attributes: {
+                              areaHa: response.data.attributes.totals.areaHa,
+                              gain: response.data.attributes.totals.gain,
+                              loss: response.data.attributes.totals.loss,
+                              alerts:
+                                response.data.attributes.totals.gladAlerts,
+                              treeExtent:
+                                response.data.attributes.totals.extent2000,
+                              treeExtent2010:
+                                response.data.attributes.totals.extent2010
+                            }
                           }
-                        }
-                      };
+                        };
+                      } else {
+                        console.log('RESPONSE', response);
+                        data = {
+                          data: {
+                            attributes: {
+                              areaHa: response.data.attributes.areaHa,
+                              gain: response.data.attributes.gain,
+                              loss: response.data.attributes.loss,
+                              alerts: response.data.attributes.alertCounts,
+                              treeExtent: response.data.attributes.treeExtent,
+                              treeExtent2010:
+                                response.data.attributes.treeExtent2010,
+                              downloadUrls:
+                                response.data.attributes.downloadUrls
+                            }
+                          }
+                        };
+                      }
+                      console.log('PARSED DATA', data);
                       resolve(data, status);
                     }.bind(this),
                     error: function(errors) {

--- a/app/assets/javascripts/map/services/AnalysisNewService.js
+++ b/app/assets/javascripts/map/services/AnalysisNewService.js
@@ -28,7 +28,7 @@ define(
       country:
         '/{dataset}/admin{/country}{/region}{/subRegion}{?period,thresh,gladConfirmOnly}',
       wdpaid: '/{dataset}/wdpa{/wdpaid}{?period,thresh,gladConfirmOnly}',
-      use: '/{dataset}/use{/use}{/useid}{?period,thresh,gladConfirmOnly}',
+      use: '/{dataset}{?geostore,period,thresh,gladConfirmOnly}',
       'use-geostore': '/{dataset}{?geostore,period,thresh,gladConfirmOnly}'
     };
     var AnalysisService = Class.extend({
@@ -46,11 +46,15 @@ define(
             status.baselayers.indexOf('umd_as_it_happens_cog') > -1 ||
             status.baselayers.indexOf('umd_as_it_happens_idn') > -1 ||
             status.baselayers.indexOf('prodes') > -1) &&
-          status.type === 'draw'
+          (status.type === 'draw' ||
+            status.type === 'use-geostore' ||
+            status.type === 'wdpaid' ||
+            status.type === 'use')
         ) {
-          var umdUrl = UriTemplate(APIURLS['draw']).fillFromObject({
+          var umdUrl = UriTemplate(APIURLS[status.type]).fillFromObject({
+            useid: status.useid,
             dataset: 'umd-loss-gain',
-            geostore: status.geostore,
+            geostore: status.geostore || status.useGeostore,
             period: status.period,
             thresh: status.threshold,
             gladConfirmOnly: status.gladConfirmOnly
@@ -104,6 +108,7 @@ define(
                                 }
                               }
                             };
+                            console.log(response, umdResponse);
                             resolve(data, status);
                           }.bind(this),
                           error: function(errors) {

--- a/app/assets/javascripts/map/services/AnalysisNewService.js
+++ b/app/assets/javascripts/map/services/AnalysisNewService.js
@@ -86,8 +86,6 @@ define(
                             }
                           }
                         });
-                        console.log('UMD', umdResponse);
-                        console.log('RESPONSE', response);
 
                         var requestConfig = {
                           resourceId: GET_REQUEST_ID,


### PR DESCRIPTION
## Overview

The hottest, dirtiest fix you'll see this year - _guaranteed!_

- Fixes loss for country/adm shapes, custom shapes, wdpa, tcl - you name it!
- Allows multiple layers to be analysed simultaneously in the above cases

**Note**: one issue remains...

When analysing GLAD, the api currently only returns 2000 extent, so switching between 2000 & 2010 is broken. Requires multiple fetches in this instance... but thats for another PR.