### PR TITLE
update to emissions widget defaults and calculation order

### DIFF
--- a/app/javascript/components/widgets/widgets/climate/emissions-deforestation/initial-state.js
+++ b/app/javascript/components/widgets/widgets/climate/emissions-deforestation/initial-state.js
@@ -13,7 +13,7 @@ export default {
       'endYears',
       'units'
     ],
-    units: ['biomassCarbon', 'co2Emissions'],
+    units: ['co2Emissions', 'biomassCarbon'],
     yearRange: ['2001', '2017'],
     metaKey: 'widget_carbon_emissions_tree_cover_loss',
     type: 'loss',
@@ -26,7 +26,7 @@ export default {
     }
   },
   settings: {
-    unit: 'biomassCarbon',
+    unit: 'co2Emissions',
     threshold: 30,
     startYear: 2001,
     endYear: 2017

--- a/app/javascript/components/widgets/widgets/climate/emissions-deforestation/selectors.js
+++ b/app/javascript/components/widgets/widgets/climate/emissions-deforestation/selectors.js
@@ -23,7 +23,8 @@ export const parseData = createSelector(
       .map(d => ({
         ...d,
         biomassCarbon: biomassToC(d.emissions),
-        co2Emissions: biomassToCO2(d.emissions)
+        co2Emissions: biomassToCO2(d.emissions),
+        biomass: d.emissions
       }));
   }
 );
@@ -66,10 +67,14 @@ export const getSentence = createSelector(
     if (!data || isEmpty(data)) return null;
     const { initial, containsIndicator } = sentences;
     const { startYear, endYear, unit } = settings;
-    const totalEmissions = data
-      .map(d => d[unit])
+    const totalBiomass = data
+      .map(d => d.biomass)
       .reduce((sum, d) => (d ? sum + d : sum));
     const emissionType = unit === 'biomassCarbon' ? 'carbon' : 'CO2';
+    const totalEmissions =
+      unit === 'biomassCarbon'
+        ? biomassToC(totalBiomass)
+        : biomassToCO2(totalBiomass);
     let indicatorText = '';
     if (indicator && indicator.value === 'mining') {
       indicatorText = ` ${indicator.label.toLowerCase()} regions`;

--- a/app/javascript/data/forest-types.json
+++ b/app/javascript/data/forest-types.json
@@ -2,21 +2,25 @@
   {
     "label": "Plantations",
     "value": "plantations",
-    "metaKey": "gfw_plantations"
+    "metaKey": "gfw_plantations",
+    "global": false
   },
   {
     "label": "Intact Forest Landscapes",
     "value": "ifl",
-    "metaKey": "intact_forest_landscapes_change"
+    "metaKey": "intact_forest_landscapes_change",
+    "global": true
   },
   {
     "label": "Primary Forests",
     "value": "primary_forest",
-    "metaKey": "primary_forest"
+    "metaKey": "primary_forest",
+    "global": false
   },
   {
     "label": "Mangrove forests",
     "value": "mangroves",
-    "metaKey": "mangrove_2010_gmw"
+    "metaKey": "mangrove_2010_gmw",
+    "global": false
   }
 ]

--- a/app/javascript/data/forest-types.json
+++ b/app/javascript/data/forest-types.json
@@ -3,7 +3,7 @@
     "label": "Plantations",
     "value": "plantations",
     "metaKey": "gfw_plantations",
-    "global": false
+    "global": true
   },
   {
     "label": "Intact Forest Landscapes",
@@ -15,12 +15,12 @@
     "label": "Primary Forests",
     "value": "primary_forest",
     "metaKey": "primary_forest",
-    "global": false
+    "global": true
   },
   {
     "label": "Mangrove forests",
     "value": "mangroves",
     "metaKey": "mangrove_2010_gmw",
-    "global": false
+    "global": true
   }
 ]

--- a/app/javascript/data/land-categories.json
+++ b/app/javascript/data/land-categories.json
@@ -3,7 +3,7 @@
     "label": "Mining concessions",
     "value": "mining",
     "metaKey": "gfw_mining",
-    "global": true
+    "global": false
   },
   {
     "label": "Protected Areas",
@@ -21,7 +21,7 @@
     "label": "Tiger Conservation Landscapes",
     "value": "tiger_cl",
     "metaKey": "tiger_conservation_landscapes",
-    "global": true
+    "global": false
   },
   {
     "label": "Alliance for Zero Extinction",
@@ -33,7 +33,7 @@
     "label": "Indigenous Lands",
     "value": "landmark",
     "metaKey": "gfw_land_rights",
-    "global": true
+    "global": false
   },
   {
     "label": "Indonesia peat lands",
@@ -51,18 +51,18 @@
     "label": "Oil palm concessions",
     "value": "oil_palm",
     "metaKey": "gfw_oil_palm",
-    "global": true
+    "global": false
   },
   {
     "label": "Wood fiber concessions",
     "value": "wood_fiber",
     "metaKey": "gfw_wood_fiber",
-    "global": true
+    "global": false
   },
   {
     "label": "Managed forests",
     "value": "managed_forests",
     "metaKey": "gfw_logging",
-    "global": true
+    "global": false
   }
 ]

--- a/app/javascript/data/land-categories.json
+++ b/app/javascript/data/land-categories.json
@@ -3,7 +3,7 @@
     "label": "Mining concessions",
     "value": "mining",
     "metaKey": "gfw_mining",
-    "global": false
+    "global": true
   },
   {
     "label": "Protected Areas",
@@ -21,7 +21,7 @@
     "label": "Tiger Conservation Landscapes",
     "value": "tiger_cl",
     "metaKey": "tiger_conservation_landscapes",
-    "global": false
+    "global": true
   },
   {
     "label": "Alliance for Zero Extinction",
@@ -33,7 +33,7 @@
     "label": "Indigenous Lands",
     "value": "landmark",
     "metaKey": "gfw_land_rights",
-    "global": false
+    "global": true
   },
   {
     "label": "Indonesia peat lands",
@@ -51,18 +51,18 @@
     "label": "Oil palm concessions",
     "value": "oil_palm",
     "metaKey": "gfw_oil_palm",
-    "global": false
+    "global": true
   },
   {
     "label": "Wood fiber concessions",
     "value": "wood_fiber",
     "metaKey": "gfw_wood_fiber",
-    "global": false
+    "global": true
   },
   {
     "label": "Managed forests",
     "value": "managed_forests",
     "metaKey": "gfw_logging",
-    "global": false
+    "global": true
   }
 ]


### PR DESCRIPTION
Emissions from Charlies table comes back in Mg/ha (i.e. tonnes/ha). This value, converted to CO2 should be the default for the emissions widget. This PR makes it default, and also calculates it in a different way (summing the annual values in Mg/ha first, and then converting) so that the values are consistent with the values quoted in the loss widget too.

Emissions loss value should match value quoted in TC loss widget.
![screen shot 2018-08-01 at 16 20 44](https://user-images.githubusercontent.com/6503031/43527895-f90a046c-95a7-11e8-8685-6b1193df7bec.png)

CO2 should be default choice.
![screen shot 2018-08-01 at 16 20 50](https://user-images.githubusercontent.com/6503031/43527889-f70715b0-95a7-11e8-81ff-fd0cd80e3037.png)