### PR TITLE
Fix/map in dashboards

### DIFF
--- a/app/javascript/components/map-old/actions.js
+++ b/app/javascript/components/map-old/actions.js
@@ -1,0 +1,34 @@
+import { createAction } from 'redux-actions';
+import { createThunkAction } from 'utils/redux';
+import { fetchLayerSpec } from 'services/layer-spec';
+
+const setLayerSpecLoading = createAction('setLayerSpecLoading');
+const setLayerSpec = createAction('setLayerSpec');
+const setMapOptions = createAction('setMapOptions');
+const setMapZoom = createAction('setMapZoom');
+const setShowMapMobile = createAction('setShowMapMobile');
+
+const getLayerSpec = createThunkAction('getLayerSpec', () => dispatch => {
+  dispatch(setLayerSpecLoading({ loading: true, error: false }));
+  fetchLayerSpec()
+    .then(response => {
+      const layerSpec = {};
+      (response.data.rows || []).forEach(layer => {
+        layerSpec[layer.slug] = layer;
+      });
+      dispatch(setLayerSpec(layerSpec));
+    })
+    .catch(error => {
+      console.info(error);
+      dispatch(setLayerSpecLoading({ loading: false, error: true }));
+    });
+});
+
+export default {
+  setLayerSpecLoading,
+  setLayerSpec,
+  setMapOptions,
+  setMapZoom,
+  getLayerSpec,
+  setShowMapMobile
+};

--- a/app/javascript/components/map-old/assets/cartocss/intact-forest.cartocss
+++ b/app/javascript/components/map-old/assets/cartocss/intact-forest.cartocss
@@ -1,0 +1,11 @@
+#intact_forest_landscapes {
+  polygon-opacity: 0.7;
+  polygon-fill: #136400;
+  line-width: 0;
+  line-opacity: 1;
+}
+
+#intact_forest_landscapes[class_name="IFL change 2000-2013"] {
+  polygon-fill:  rgb(152, 155, 5);
+}
+

--- a/app/javascript/components/map-old/assets/cartocss/plantations-by-species.cartocss
+++ b/app/javascript/components/map-old/assets/cartocss/plantations-by-species.cartocss
@@ -1,0 +1,377 @@
+#gfw_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+#gfw_plantations[spec_simp="Fruit"] {
+  polygon-fill: #b2b300;
+}
+#gfw_plantations[spec_simp="Fruit mix"] {
+  polygon-fill: #FF0;
+}
+#gfw_plantations[spec_simp="Hevea (rubber)"] {
+  polygon-fill: #00bdbd;
+}
+#gfw_plantations[spec_simp="Oil palm"] {
+  polygon-fill: #f44c43;
+}
+#gfw_plantations[spec_simp="Oil palm mix"] {
+  polygon-fill: #f7837d;
+}
+#gfw_plantations[spec_simp="Other"] {
+  polygon-fill: #9ECC49;
+}
+#gfw_plantations[spec_simp="Other mix"] {
+  polygon-fill: #c1df8b;
+}
+#gfw_plantations[spec_simp="Recently cleared"] {
+  polygon-fill: #A53ED5;
+}
+#gfw_plantations[spec_simp="Rubber"] {
+  polygon-fill: #11002F;
+}
+#gfw_plantations[spec_simp="Rubber mix"] {
+  polygon-fill: #0FF;
+}
+#gfw_plantations[spec_simp="Unknown"] {
+  polygon-fill: #b5b0b0;
+}
+#gfw_plantations[spec_simp="Wood fiber / timber"] {
+  polygon-fill: #0F3B82;
+}
+#gfw_plantations[spec_simp="Wood fiber / timber mix"] {
+  polygon-fill: #246ee6;
+}
+
+
+#bra_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+#bra_plantations[spec_simp="Fruit"] {
+  polygon-fill: #b2b300;
+}
+#bra_plantations[spec_simp="Fruit mix"] {
+  polygon-fill: #FF0;
+}
+#bra_plantations[spec_simp="Hevea (rubber)"] {
+  polygon-fill: #00bdbd;
+}
+#bra_plantations[spec_simp="Oil palm"] {
+  polygon-fill: #f44c43;
+}
+#bra_plantations[spec_simp="Oil palm mix"] {
+  polygon-fill: #f7837d;
+}
+#bra_plantations[spec_simp="Other"] {
+  polygon-fill: #9ECC49;
+}
+#bra_plantations[spec_simp="Other mix"] {
+  polygon-fill: #c1df8b;
+}
+#bra_plantations[spec_simp="Recently cleared"] {
+  polygon-fill: #A53ED5;
+}
+#bra_plantations[spec_simp="Rubber"] {
+  polygon-fill: #11002F;
+}
+#bra_plantations[spec_simp="Rubber mix"] {
+  polygon-fill: #0FF;
+}
+#bra_plantations[spec_simp="Unknown"] {
+  polygon-fill: #b5b0b0;
+}
+#bra_plantations[spec_simp="Wood fiber / timber"] {
+  polygon-fill: #0F3B82;
+}
+#bra_plantations[spec_simp="Wood fiber / timber mix"] {
+  polygon-fill: #246ee6;
+}
+
+#per_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+#per_plantations[spec_simp="Fruit"] {
+  polygon-fill: #b2b300;
+}
+#per_plantations[spec_simp="Fruit mix"] {
+  polygon-fill: #FF0;
+}
+#per_plantations[spec_simp="Hevea (rubber)"] {
+  polygon-fill: #00bdbd;
+}
+#per_plantations[spec_simp="Oil palm"] {
+  polygon-fill: #f44c43;
+}
+#per_plantations[spec_simp="Oil palm mix"] {
+  polygon-fill: #f7837d;
+}
+#per_plantations[spec_simp="Other"] {
+  polygon-fill: #9ECC49;
+}
+#per_plantations[spec_simp="Other mix"] {
+  polygon-fill: #c1df8b;
+}
+#per_plantations[spec_simp="Recently cleared"] {
+  polygon-fill: #A53ED5;
+}
+#per_plantations[spec_simp="Rubber"] {
+  polygon-fill: #11002F;
+}
+#per_plantations[spec_simp="Rubber mix"] {
+  polygon-fill: #0FF;
+}
+#per_plantations[spec_simp="Unknown"] {
+  polygon-fill: #b5b0b0;
+}
+#per_plantations[spec_simp="Wood fiber / timber"] {
+  polygon-fill: #0F3B82;
+}
+#per_plantations[spec_simp="Wood fiber / timber mix"] {
+  polygon-fill: #246ee6;
+}
+
+
+#lbr_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+#lbr_plantations[spec_simp="Fruit"] {
+  polygon-fill: #b2b300;
+}
+#lbr_plantations[spec_simp="Fruit mix"] {
+  polygon-fill: #FF0;
+}
+#lbr_plantations[spec_simp="Hevea (rubber)"] {
+  polygon-fill: #00bdbd;
+}
+#lbr_plantations[spec_simp="Oil palm"] {
+  polygon-fill: #f44c43;
+}
+#lbr_plantations[spec_simp="Oil palm mix"] {
+  polygon-fill: #f7837d;
+}
+#lbr_plantations[spec_simp="Other"] {
+  polygon-fill: #9ECC49;
+}
+#lbr_plantations[spec_simp="Other mix"] {
+  polygon-fill: #c1df8b;
+}
+#lbr_plantations[spec_simp="Recently cleared"] {
+  polygon-fill: #A53ED5;
+}
+#lbr_plantations[spec_simp="Rubber"] {
+  polygon-fill: #11002F;
+}
+#lbr_plantations[spec_simp="Rubber mix"] {
+  polygon-fill: #0FF;
+}
+#lbr_plantations[spec_simp="Unknown"] {
+  polygon-fill: #b5b0b0;
+}
+#lbr_plantations[spec_simp="Wood fiber / timber"] {
+  polygon-fill: #0F3B82;
+}
+#lbr_plantations[spec_simp="Wood fiber / timber mix"] {
+  polygon-fill: #246ee6;
+}
+
+#col_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+#col_plantations[spec_simp="Fruit"] {
+  polygon-fill: #b2b300;
+}
+#col_plantations[spec_simp="Fruit mix"] {
+  polygon-fill: #FF0;
+}
+#col_plantations[spec_simp="Hevea (rubber)"] {
+  polygon-fill: #00bdbd;
+}
+#col_plantations[spec_simp="Oil palm"] {
+  polygon-fill: #f44c43;
+}
+#col_plantations[spec_simp="Oil palm mix"] {
+  polygon-fill: #f7837d;
+}
+#col_plantations[spec_simp="Other"] {
+  polygon-fill: #9ECC49;
+}
+#col_plantations[spec_simp="Other mix"] {
+  polygon-fill: #c1df8b;
+}
+#col_plantations[spec_simp="Recently cleared"] {
+  polygon-fill: #A53ED5;
+}
+#col_plantations[spec_simp="Rubber"] {
+  polygon-fill: #11002F;
+}
+#col_plantations[spec_simp="Rubber mix"] {
+  polygon-fill: #0FF;
+}
+#col_plantations[spec_simp="Unknown"] {
+  polygon-fill: #b5b0b0;
+}
+#col_plantations[spec_simp="Wood fiber / timber"] {
+  polygon-fill: #0F3B82;
+}
+#col_plantations[spec_simp="Wood fiber / timber mix"] {
+  polygon-fill: #246ee6;
+}
+
+#khm_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+#khm_plantations[spec_simp="Fruit"] {
+  polygon-fill: #b2b300;
+}
+#khm_plantations[spec_simp="Fruit mix"] {
+  polygon-fill: #FF0;
+}
+#khm_plantations[spec_simp="Hevea (rubber)"] {
+  polygon-fill: #00bdbd;
+}
+#khm_plantations[spec_simp="Oil palm"] {
+  polygon-fill: #f44c43;
+}
+#khm_plantations[spec_simp="Oil palm mix"] {
+  polygon-fill: #f7837d;
+}
+#khm_plantations[spec_simp="Other"] {
+  polygon-fill: #9ECC49;
+}
+#khm_plantations[spec_simp="Other mix"] {
+  polygon-fill: #c1df8b;
+}
+#khm_plantations[spec_simp="Recently cleared"] {
+  polygon-fill: #A53ED5;
+}
+#khm_plantations[spec_simp="Rubber"] {
+  polygon-fill: #11002F;
+}
+#khm_plantations[spec_simp="Rubber mix"] {
+  polygon-fill: #0FF;
+}
+#khm_plantations[spec_simp="Unknown"] {
+  polygon-fill: #b5b0b0;
+}
+#khm_plantations[spec_simp="Wood fiber / timber"] {
+  polygon-fill: #0F3B82;
+}
+#khm_plantations[spec_simp="Wood fiber / timber mix"] {
+  polygon-fill: #246ee6;
+}
+
+#idn_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+#idn_plantations[spec_simp="Fruit"] {
+  polygon-fill: #b2b300;
+}
+#idn_plantations[spec_simp="Fruit mix"] {
+  polygon-fill: #FF0;
+}
+#idn_plantations[spec_simp="Hevea (rubber)"] {
+  polygon-fill: #00bdbd;
+}
+#idn_plantations[spec_simp="Oil palm"] {
+  polygon-fill: #f44c43;
+}
+#idn_plantations[spec_simp="Oil palm mix"] {
+  polygon-fill: #f7837d;
+}
+#idn_plantations[spec_simp="Other"] {
+  polygon-fill: #9ECC49;
+}
+#idn_plantations[spec_simp="Other mix"] {
+  polygon-fill: #c1df8b;
+}
+#idn_plantations[spec_simp="Recently cleared"] {
+  polygon-fill: #A53ED5;
+}
+#idn_plantations[spec_simp="Rubber"] {
+  polygon-fill: #11002F;
+}
+#idn_plantations[spec_simp="Rubber mix"] {
+  polygon-fill: #0FF;
+}
+#idn_plantations[spec_simp="Unknown"] {
+  polygon-fill: #b5b0b0;
+}
+#idn_plantations[spec_simp="Wood fiber / timber"] {
+  polygon-fill: #0F3B82;
+}
+#idn_plantations[spec_simp="Wood fiber / timber mix"] {
+  polygon-fill: #246ee6;
+}
+
+#mys_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+#mys_plantations[spec_simp="Fruit"] {
+  polygon-fill: #b2b300;
+}
+#mys_plantations[spec_simp="Fruit mix"] {
+  polygon-fill: #FF0;
+}
+#mys_plantations[spec_simp="Hevea (rubber)"] {
+  polygon-fill: #00bdbd;
+}
+#mys_plantations[spec_simp="Oil palm"] {
+  polygon-fill: #f44c43;
+}
+#mys_plantations[spec_simp="Oil palm mix"] {
+  polygon-fill: #f7837d;
+}
+#mys_plantations[spec_simp="Other"] {
+  polygon-fill: #9ECC49;
+}
+#mys_plantations[spec_simp="Other mix"] {
+  polygon-fill: #c1df8b;
+}
+#mys_plantations[spec_simp="Recently cleared"] {
+  polygon-fill: #A53ED5;
+}
+#mys_plantations[spec_simp="Rubber"] {
+  polygon-fill: #11002F;
+}
+#mys_plantations[spec_simp="Rubber mix"] {
+  polygon-fill: #0FF;
+}
+#mys_plantations[spec_simp="Unknown"] {
+  polygon-fill: #b5b0b0;
+}
+#mys_plantations[spec_simp="Wood fiber / timber"] {
+  polygon-fill: #0F3B82;
+}
+#mys_plantations[spec_simp="Wood fiber / timber mix"] {
+  polygon-fill: #246ee6;
+}

--- a/app/javascript/components/map-old/assets/cartocss/plantations-by-type.cartocss
+++ b/app/javascript/components/map-old/assets/cartocss/plantations-by-type.cartocss
@@ -1,0 +1,171 @@
+#gfw_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+
+#gfw_plantations[type_text="Large industrial plantation"] {
+   polygon-fill: #F84F40;
+}
+#gfw_plantations[type_text="Mosaic of medium-sized plantations"] {
+   polygon-fill: #A53ED5;
+}
+#gfw_plantations[type_text="Mosaic of small-sized plantations"] {
+   polygon-fill: #33A02C;
+}
+#gfw_plantations[type_text="Clearing/ very young plantation"] {
+   polygon-fill: #a7652a;
+}
+
+
+#bra_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+
+#bra_plantations[type_text="Large industrial plantation"] {
+   polygon-fill: #F84F40;
+}
+#bra_plantations[type_text="Mosaic of medium-sized plantations"] {
+   polygon-fill: #A53ED5;
+}
+#bra_plantations[type_text="Mosaic of small-sized plantations"] {
+   polygon-fill: #33A02C;
+}
+#bra_plantations[type_text="Clearing/ very young plantation"] {
+   polygon-fill: #a7652a;
+}
+
+
+#per_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+
+#per_plantations[type_text="Large industrial plantation"] {
+   polygon-fill: #F84F40;
+}
+#per_plantations[type_text="Mosaic of medium-sized plantations"] {
+   polygon-fill: #A53ED5;
+}
+#per_plantations[type_text="Mosaic of small-sized plantations"] {
+   polygon-fill: #33A02C;
+}
+#per_plantations[type_text="Clearing/ very young plantation"] {
+   polygon-fill: #a7652a;
+}
+
+
+#lbr_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+
+#lbr_plantations[type_text="Large industrial plantation"] {
+   polygon-fill: #F84F40;
+}
+#lbr_plantations[type_text="Mosaic of medium-sized plantations"] {
+   polygon-fill: #A53ED5;
+}
+#lbr_plantations[type_text="Mosaic of small-sized plantations"] {
+   polygon-fill: #33A02C;
+}
+#lbr_plantations[type_text="Clearing/ very young plantation"] {
+   polygon-fill: #a7652a;
+}
+
+
+#col_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+
+#col_plantations[type_text="Large industrial plantation"] {
+   polygon-fill: #F84F40;
+}
+#col_plantations[type_text="Mosaic of medium-sized plantations"] {
+   polygon-fill: #A53ED5;
+}
+#col_plantations[type_text="Mosaic of small-sized plantations"] {
+   polygon-fill: #33A02C;
+}
+#col_plantations[type_text="Clearing/ very young plantation"] {
+   polygon-fill: #a7652a;
+}
+
+#khm_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+
+#khm_plantations[type_text="Large industrial plantation"] {
+   polygon-fill: #F84F40;
+}
+#khm_plantations[type_text="Mosaic of medium-sized plantations"] {
+   polygon-fill: #A53ED5;
+}
+#khm_plantations[type_text="Mosaic of small-sized plantations"] {
+   polygon-fill: #33A02C;
+}
+#khm_plantations[type_text="Clearing/ very young plantation"] {
+   polygon-fill: #a7652a;
+}
+
+#idn_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+
+#idn_plantations[type_text="Large industrial plantation"] {
+   polygon-fill: #F84F40;
+}
+#idn_plantations[type_text="Mosaic of medium-sized plantations"] {
+   polygon-fill: #A53ED5;
+}
+#idn_plantations[type_text="Mosaic of small-sized plantations"] {
+   polygon-fill: #33A02C;
+}
+#idn_plantations[type_text="Clearing/ very young plantation"] {
+   polygon-fill: #a7652a;
+}
+
+#mys_plantations {
+   polygon-opacity: 0.5;
+   line-color: #FFF;
+   line-width: 0.5;
+   line-opacity: 0;
+   polygon-fill: transparent;
+}
+
+#mys_plantations[type_text="Large industrial plantation"] {
+   polygon-fill: #F84F40;
+}
+#mys_plantations[type_text="Mosaic of medium-sized plantations"] {
+   polygon-fill: #A53ED5;
+}
+#mys_plantations[type_text="Mosaic of small-sized plantations"] {
+   polygon-fill: #33A02C;
+}
+#mys_plantations[type_text="Clearing/ very young plantation"] {
+   polygon-fill: #a7652a;
+}

--- a/app/javascript/components/map-old/assets/cartocss/protected-areas.cartocss
+++ b/app/javascript/components/map-old/assets/cartocss/protected-areas.cartocss
@@ -1,0 +1,45 @@
+#wdpa_protected_areas {
+   polygon-opacity: 0.5;
+   line-width: 0.2;
+   line-opacity: 1;
+}
+#wdpa_protected_areas[iucn_cat="Ia"] {
+   polygon-fill: #5ca2d1;
+  line-color: #5ca2d1;
+}
+#wdpa_protected_areas[iucn_cat="Ib"] {
+   polygon-fill: #3e7bb6;
+  line-color: #3e7bb6;
+}
+#wdpa_protected_areas[iucn_cat="II"] {
+   polygon-fill: #0f3b82;
+  line-color: #0f3b82;
+}
+#wdpa_protected_areas[iucn_cat="III"] {
+   polygon-fill: #c9ddff;
+  line-color: #c9ddff;
+}
+#wdpa_protected_areas[iucn_cat="IV"] {
+   polygon-fill: #b9b2a1;
+  line-color: #b9b2a1;
+}
+#wdpa_protected_areas[iucn_cat="V"] {
+   polygon-fill: #ae847e;
+  line-color: #ae847e;
+}
+#wdpa_protected_areas[iucn_cat="VI"] {
+   polygon-fill: #daa89b;
+  line-color: #daa89b;
+}
+#wdpa_protected_areas[iucn_cat="Not Applicable"] {
+   polygon-fill: #eed54c;
+  line-color: #eed54c;
+}
+#wdpa_protected_areas[iucn_cat="Not Assigned"] {
+  polygon-fill: #e7ab36;
+  line-color: #e7ab36;
+}
+#wdpa_protected_areas[iucn_cat="Not Reported"] {
+   polygon-fill: #fa894b;
+  line-color: #fa894b;
+}

--- a/app/javascript/components/map-old/assets/cartocss/style.cartocss
+++ b/app/javascript/components/map-old/assets/cartocss/style.cartocss
@@ -1,0 +1,730 @@
+#table_layer {
+  polygon-fill: #FF6600;
+  polygon-opacity: 0.7;
+  line-width: 0.2;
+  line-opacity: 0.6;
+
+  [zoom>3] {
+    line-width: 0.3;
+    line-opacity: 0.7;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [zoom>5] {
+    line-width: 0.4;
+    line-clip: false;
+  }
+
+  [zoom>6] {
+    line-width: 0.6;
+    line-opacity: 0.8;
+    line-clip: false;
+  }
+
+  [zoom>7] {
+    line-width: 0.8;
+    line-clip: false;
+  }
+
+  [zoom>8] {
+    line-width: 1;
+    line-opacity: 1;
+    line-clip: false;
+  }
+
+  //deprecated
+  [layer='logging_gcs_wgs84'] {
+    polygon-fill: #fecc5c;
+    line-color: #B38E3B;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='gran_chaco_extent'] {
+    polygon-fill: #f69;
+    polygon-opacity: 0.3;
+    line-width: 1;
+    line-color: #FFF;
+    line-opacity: 0;
+  }
+
+  [layer='prodes_extent'] {
+    polygon-fill: #f69;
+    polygon-opacity: 0.3;
+    line-width: 1;
+    line-color: #FFF;
+    line-opacity: 0;
+  }
+
+  [layer='gfw_landsat_alerts_extent'],
+  [layer='glad_coverage'], [layer='glad_coverage_copy'],
+  [layer='geographic_coverage_pantropical'],[layer='forma_coverage'] {
+    polygon-fill: #f69;
+    polygon-opacity: 0.3;
+    line-width: 1;
+    line-color: #FFF;
+    line-opacity: 0;
+  }
+
+  //deprecated
+  [layer='logging'] {
+    polygon-fill: #fecc5c;
+    line-color: #B38E3B;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='gfw_logging'] {
+    polygon-fill: #fecc5c;
+    line-color: #B38E3B;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='caf_logging'] {
+    polygon-fill: #fecc5c;
+    line-color: #B38E3B;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='cmr_logging'] {
+    polygon-fill: #fecc5c;
+    line-color: #B38E3B;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='cod_logging'] {
+    polygon-fill: #fecc5c;
+    line-color: #B38E3B;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='gab_logging'] {
+    polygon-fill: #fecc5c;
+    line-color: #B38E3B;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='gnq_logging'] {
+    polygon-fill: #fecc5c;
+    line-color: #B38E3B;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='idn_logging'] {
+    polygon-fill: #fecc5c;
+    line-color: #B38E3B;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='lbr_logging'] {
+    polygon-fill: #fecc5c;
+    line-color: #B38E3B;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='cog_logging'] {
+    polygon-fill: #fecc5c;
+    line-color: #B38E3B;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='mys_logging'] {
+    polygon-fill: #fecc5c;
+    line-color: #B38E3B;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='mys_logging_sabah'] {
+    polygon-fill: #fecc5c;
+    line-color: #B38E3B;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='gfw2_drc_conc'] {
+    polygon-fill: #EC7014;
+    line-color: #EC7014;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  //deprecated
+  [layer='mining_permits_merge'] {
+    polygon-fill: #fd8d3c;
+    line-color: #fd8d3c;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='oil_palm_permits_merge'] {
+    polygon-fill: #ee9587;
+    line-color: #ee9587;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  //deprecated
+  [layer='mining'] {
+    polygon-fill: #fd8d3c;
+    line-color: #fd8d3c;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='gfw_mining'] {
+    polygon-fill: #fd8d3c;
+    line-color: #fd8d3c;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='mex_mining'] {
+    polygon-fill: #fd8d3c;
+    line-color: #fd8d3c;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='can_mining'],
+  [layer='can_mining_1']  {
+    polygon-fill: #fd8d3c;
+    line-color: #fd8d3c;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='can_oil'] {
+     polygon-fill: #d980ff;
+     line-color: #c233ff;
+     line-clip: false;
+     polygon-clip: false;
+  }
+
+  [layer='cmr_mining'] {
+    polygon-fill: #fd8d3c;
+    line-color: #fd8d3c;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='cod_mining'] {
+    polygon-fill: #fd8d3c;
+    line-color: #fd8d3c;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='cog_mining'] {
+    polygon-fill: #fd8d3c;
+    line-color: #fd8d3c;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='gab_mining'] {
+    polygon-fill: #fd8d3c;
+    line-color: #fd8d3c;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='col_mining'] {
+    polygon-fill: #fd8d3c;
+    line-color: #fd8d3c;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='khm_mining'] {
+    polygon-fill: #fd8d3c;
+    line-color: #fd8d3c;
+    marker-fill: #fd8d3c;
+    marker-line-color: #fff;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  //deprecated
+  [layer='oilpalm'] {
+    polygon-fill: #ee9587;
+    line-color: #ee9587;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='gfw_oil_palm'] {
+    polygon-fill: #ee9587;
+    line-color: #ee9587;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='cog_oil_palm'] {
+    polygon-fill: #ee9587;
+    line-color: #ee9587;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='cmr_oil_palm'] {
+    polygon-fill: #ee9587;
+    line-color: #ee9587;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='idn_oil_palm'] {
+    polygon-fill: #ee9587;
+    line-color: #ee9587;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='lbr_oil_palm'] {
+    polygon-fill: #ee9587;
+    line-color: #ee9587;
+    line-clip: false;
+    polygon-clip: false;
+  }
+  [layer='mys_oil_palm'] {
+    polygon-fill: #ee9587;
+    line-color: #ee9587;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='caf_lc_1'] {
+    polygon-fill: #fe9929;
+    line-color: #fe9929;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='idn_tc_1'] {
+    polygon-fill: #BDBDBD;
+    line-color: #BDBDBD;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='world_ifl'] {
+    polygon-fill: #BBD973;
+    line-color: #BBD973;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='fiber_all_merged'] {
+    polygon-fill: #e6adb9;
+    line-color: #e6adb9;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  //deprecated
+  [layer='woodfiber'] {
+    polygon-fill: #e6adb9;
+    line-color: #e6adb9;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='gfw_wood_fiber'] {
+    polygon-fill: #e6adb9;
+    line-color: #e6adb9;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='cog_wood_fiber'] {
+    polygon-fill: #e6adb9;
+    line-color: #e6adb9;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='idn_wood_fiber'] {
+    polygon-fill: #e6adb9;
+    line-color: #e6adb9;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='gab_wood_fiber'] {
+    polygon-fill: #e6adb9;
+    line-color: #e6adb9;
+    line-clip: false;
+    polygon-clip: false;
+  }
+  [layer='mys_wood_fiber'] {
+    polygon-fill: #e6adb9;
+    line-color: #e6adb9;
+    line-clip: false;
+    polygon-clip: false;
+  }
+  [layer='mys_wood_fiber_sabah'] {
+    polygon-fill: #e6adb9;
+    line-color: #e6adb9;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='forma_extent'] {
+    polygon-fill: #f69;
+    polygon-opacity: 0.3;
+    line-width: 1;
+    line-color: #FFF;
+    line-opacity: 0;
+  }
+
+  [layer='biodiversity_hotspots'] {
+    polygon-fill: #49A39A;
+    line-color: #49A39A;
+    polygon-clip: false;
+    polygon-opacity: 0.5;
+    line-clip: false;
+    polygon-clip: false;
+    line-width: 0.6;
+    line-opacity: 0.8;
+  }
+
+
+  [layer='imazon_sad_geografic_extent'] {
+    polygon-fill: #f69;
+    polygon-opacity: 0.3;
+    line-width: 0;
+    line-color: #FFF;
+    line-opacity: 1;
+  }
+
+  //deprecated
+  [layer='resource_rights'] {
+    polygon-fill: #707d92;
+    polygon-opacity: 0.9;
+    line-width: 0;
+    line-color: #FFF;
+    line-opacity: 1;
+  }
+
+  [layer='gfw_resource_rights'] {
+    polygon-fill: #707d92;
+    polygon-opacity: 0.9;
+    line-width: 0;
+    line-color: #FFF;
+    line-opacity: 1;
+  }
+  [layer='cmr_resource_rights'] {
+    polygon-fill: #707d92;
+    polygon-opacity: 0.9;
+    line-width: 0;
+    line-color: #FFF;
+    line-opacity: 1;
+  }
+  [layer='lbr_resource_rights'] {
+    polygon-fill: #707d92;
+    polygon-opacity: 0.9;
+    line-width: 0;
+    line-color: #FFF;
+    line-opacity: 1;
+  }
+  [layer='gnq_resource_rights'] {
+    polygon-fill: #707d92;
+    polygon-opacity: 0.9;
+    line-width: 0;
+    line-color: #FFF;
+    line-opacity: 1;
+  }
+  [layer='nam_resource_rights'] {
+    polygon-fill: #707d92;
+    polygon-opacity: 0.9;
+    line-width: 0;
+    line-color: #FFF;
+    line-opacity: 1;
+  }
+
+
+
+  [layer='aus_land_rights'] {
+    polygon-fill: #4d658f;
+    polygon-opacity: 0.7;
+    line-color: #4d658f;
+    line-width: 1;
+    line-opacity: 1;
+  }
+  [layer='pan_land_rights'] {
+    polygon-fill: #4d658f;
+    polygon-opacity: 0.7;
+    line-color: #4d658f;
+    line-width: 1;
+    line-opacity: 1;
+  }
+  [layer='bra_land_rights'] {
+    polygon-fill: #4d658f;
+    polygon-opacity: 0.7;
+    line-color: #4d658f;
+    line-width: 1;
+    line-opacity: 1;
+  }
+  [layer='bra_soy_vector']{
+  polygon-fill: #ca9024;
+  polygon-opacity: 0.9;
+  line-color: #FFF;
+  line-width: 0.0;
+  line-opacity: 0.0;
+}
+  [layer='can_land_rights'] {
+    polygon-fill: #4d658f;
+    polygon-opacity: 0.7;
+    line-color: #4d658f;
+    line-width: 1;
+    line-opacity: 1;
+  }
+  [layer='cri_land_rights'] {
+    polygon-fill: #4d658f;
+    polygon-opacity: 0.7;
+    line-color: #4d658f;
+    line-width: 1;
+    line-opacity: 1;
+  }
+  [layer='nzl_land_rights'] {
+    polygon-fill: #4d658f;
+    polygon-opacity: 0.7;
+    line-color: #4d658f;
+    line-width: 1;
+    line-opacity: 1;
+  }
+
+  [layer='gfw_land_rights_sync'] {
+    polygon-fill: #4d658f;
+    polygon-opacity: 0.7;
+    line-color: #4d658f;
+    line-width: 1;
+    line-opacity: 1;
+  }
+
+  [layer='ifl_2000'] {
+    polygon-opacity: 0.7;
+    polygon-fill: #136400;
+    line-width: 0;
+    line-opacity: 1;
+  }
+  //deprecated
+  [layer='wcmc_010_mangroveusgs2011'] {
+      polygon-fill: #05ffaa;
+      polygon-opacity: 0.7;
+      line-color: #05ffaa;
+      line-width: 1;
+      line-opacity: 1;
+  }
+
+  [layer='global_mangroves'] {
+      polygon-fill: #05ffaa;
+      polygon-opacity: 0.7;
+      line-color: #05ffaa;
+      line-width: 1;
+      line-opacity: 1;
+  }
+
+  [layer='wdpa_protected_areas'] {
+    polygon-fill: #2167AB;
+    polygon-opacity: 0.5;
+    line-color: #2167AB;
+    line-width: 1;
+    line-opacity: 1;
+  }
+
+  [layer='protected_areas'] {
+    polygon-fill: #2167AB;
+    polygon-opacity: 0.5;
+    line-color: #2167AB;
+    line-width: 1;
+    line-opacity: 1;
+  }
+
+  [layer='endemic_bird_areas'] {
+    polygon-fill: #055D00;
+    polygon-opacity: 1;
+    polygon-comp-op: lighten;
+    line-color: #FF9900;
+    line-width: 1.5;
+    line-opacity: 0.3;
+  }
+
+  [layer='alliance_for_zero_extinction_sites_species_joi'] {
+    polygon-fill: #b2d26e;
+    polygon-opacity: 0.9;
+    line-color: #b2d26e;
+    line-width: 1.5;
+    line-opacity: 1;
+  }
+
+  [layer='verifed_carbon_standard'] {
+    polygon-fill: #247490;
+    polygon-opacity: 0.7;
+    line-color: #247490;
+    line-width: 1;
+    line-opacity: 1;
+  }
+
+  [layer='usa_conservation_easements']{
+    polygon-fill: #1a4075;
+    polygon-opacity: 0.7;
+    line-color: #1a4075;
+    line-width: 0.1;
+    line-opacity: 1;
+  }
+
+  [layer='idn_leuser'],
+  [layer='leuser_ecosystem_province_boundary']{
+    polygon-fill: #5CA2AA;
+    polygon-opacity: 0.7;
+    line-color: #5CA0AA;
+    line-width: 0.5;
+    line-opacity: 1;
+  }
+
+  [layer='per_permanent_production_forests'] {
+    polygon-opacity: 0.7;
+    line-color: #FFF;
+    line-width: 0.5;
+    line-opacity: 1;
+    polygon-fill: #91b290;
+  }
+
+  [layer='per_regional_protected_areas'] {
+    polygon-fill: #2167AB;
+    polygon-opacity: 0.7;
+    line-color: #FFF;
+    line-width: 0.5;
+    line-opacity: 1;
+  }
+
+  [layer='per_private_protected_areas'] {
+    polygon-fill: #94cecb;
+    polygon-opacity: 0.7;
+    line-color: #FFF;
+    line-width: 0;
+    line-opacity: 1;
+  }
+
+  [layer='per_national_protected_areas'] {
+    polygon-fill: #4d94c4;
+    polygon-opacity: 0.7;
+    line-color: #FFF;
+    line-width: 0.5;
+    line-opacity: 1;
+  }
+
+  [layer='per_buffer_zones'] {
+    polygon-fill: #00ceff;
+    polygon-opacity: 0.7;
+    line-color: #5CA2D1;
+    line-width: 0.1;
+    line-opacity: 1;
+  }
+
+  [layer='idn_forest_moratorium'] {
+    polygon-fill: #aa7c5d;
+    polygon-opacity: 0.7;
+    line-color: #FFF;
+    line-width: 0;
+    line-opacity: 1;
+  }
+
+  [layer='khm_protected_areas'] {
+    polygon-fill: #3182BD;
+    polygon-opacity: 0.6;
+    line-color: #FFF;
+    line-width: 0.25;
+    line-opacity: 1;
+  }
+
+  [layer='gfw_land_rights'] {
+    polygon-fill: #4d658f;
+    polygon-opacity: 0.7;
+    line-color: #4d658f;
+    line-width: 1;
+    line-opacity: 1;
+  }
+
+  [layer='logging_roads_extent'] {
+    polygon-fill: #B2D26E;
+    polygon-opacity: 0.3;
+    line-width: 1;
+    line-color: #FFF;
+    line-opacity: 0;
+  }
+
+  [layer='mys_protected_areas_sabah'],[layer='uga_protected_areas'] {
+    polygon-fill: #1F78B4;
+    polygon-opacity: 0.7;
+    line-color: #FFF;
+    line-width: 0.5;
+    line-opacity: 1;
+  }
+
+  [layer='mex_psa'] {
+    polygon-fill: #3182BD;
+    polygon-opacity: 0.7;
+    line-color: #3182BD;
+    line-width: 0.5;
+    line-opacity: 1;
+  }
+
+  [layer='bra_logging'] {
+    polygon-fill: #fecc5c;
+    line-color: #B38E3B;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='lbr_mineral_development_agreements'] {
+    polygon-fill: #fdbf6f;
+    line-color: #fdbf6f;
+    line-clip: false;
+    polygon-clip: false;
+  }
+  [layer='lbr_development_exploration_license'] {
+    polygon-fill: #b15928;
+    line-color: #b15928;
+    line-clip: false;
+    polygon-clip: false;
+  }
+  [layer='pak_user_mangroves'] {
+    polygon-fill: #fecc5c;
+    polygon-opacity: 0.7;
+    line-color: #FFF;
+    line-width: 0.5;
+    line-opacity: 1;
+  }
+
+  [layer='sen_user_protected_areas'],[layer='hti_user_watersheds'] {
+    polygon-fill: #fecc5c;
+    line-color: #b15928;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  [layer='ecu_user_protected_areas'] {
+    polygon-fill: #fecc5c;
+    line-color: #b15928;
+    line-clip: false;
+    polygon-clip: false;
+  }
+
+  #tal_corridor {
+    polygon-fill: #229A00;
+    polygon-opacity: 0.7;
+  }
+}

--- a/app/javascript/components/map-old/assets/cartocss/viirs.cartocss
+++ b/app/javascript/components/map-old/assets/cartocss/viirs.cartocss
@@ -1,0 +1,24 @@
+#vnp14imgt_nrt_global_7d {
+  marker-fill: #FFCC00;
+  marker-width: 1.5;
+  marker-line-color: #FFF;
+  marker-line-width: 1;
+  marker-line-opacity: 1;
+  marker-opacity: 0.9;
+  marker-comp-op: multiply;
+  marker-type: ellipse;
+  marker-placement: point;
+  marker-allow-overlap: true;
+  marker-clip: false;
+  marker-multi-policy: largest;
+}
+
+#vnp14imgt_nrt_global_7d[zoom>6]{ marker-width: 3; }
+#vnp14imgt_nrt_global_7d[zoom>8]{ marker-width: 6; }
+#vnp14imgt_nrt_global_7d[zoom>11]{ marker-width: 13; }
+#vnp14imgt_nrt_global_7d[zoom>12]{ marker-width: 25; }
+#vnp14imgt_nrt_global_7d[zoom>13]{ marker-width: 50; }
+#vnp14imgt_nrt_global_7d[zoom>14]{ marker-width: 100; }
+#vnp14imgt_nrt_global_7d[zoom>15]{ marker-width: 200; }
+#vnp14imgt_nrt_global_7d[zoom>16]{ marker-width: 400; }
+#vnp14imgt_nrt_global_7d[zoom>17]{ marker-width: 800; }

--- a/app/javascript/components/map-old/assets/layers.js
+++ b/app/javascript/components/map-old/assets/layers.js
@@ -1,0 +1,27 @@
+import ForestCover from './layers/forest-cover';
+import ForestCover2010 from './layers/forest-cover-2010';
+import ForestGain from './layers/forest-gain';
+import IntactForest from './layers/intact-forest';
+import Loss from './layers/loss';
+import PlantationsByType from './layers/plantations-by-type';
+import PlantationsBySpecies from './layers/plantations-by-species';
+import Glad from './layers/glad';
+import Viirs from './layers/viirs';
+import Mining from './layers/mining';
+import ProtectedAreas from './layers/protected-areas';
+
+const layersMap = {
+  forest2000: ForestCover,
+  forest2010: ForestCover2010,
+  forestgain: ForestGain,
+  ifl_2013_deg: IntactForest,
+  loss: Loss,
+  plantations_by_type: PlantationsByType,
+  plantations_by_species: PlantationsBySpecies,
+  umd_as_it_happens: Glad,
+  viirs_fires_alerts: Viirs,
+  mining: Mining,
+  protected_areasCDB: ProtectedAreas
+};
+
+export default layersMap;

--- a/app/javascript/components/map-old/assets/layers/abstract/canvas.js
+++ b/app/javascript/components/map-old/assets/layers/abstract/canvas.js
@@ -1,0 +1,163 @@
+import axios from 'axios';
+import Overlay from './overlay';
+
+const OPTIONS = {
+  dataMaxZoom: 17
+};
+
+class Canvas extends Overlay {
+  constructor(map, options) {
+    super(map, OPTIONS);
+    this.options = { ...OPTIONS, ...options };
+    this.tiles = {};
+    this.updateTilesEnable = true;
+  }
+
+  getTile(coord, zoom, ownerDocument) {
+    const { x, y } = coord;
+    const tileId = `${x}_${y}_${zoom}`;
+    this.deleteOtherZoomTiles(zoom);
+
+    if (this.tiles[tileId]) {
+      return this.tiles[tileId].canvas;
+    }
+
+    const div = ownerDocument.createElement('div');
+    div.style.width = this.tileSize.width;
+    div.style.height = this.tileSize.height;
+    div.style.position = 'relative';
+    div.style.overflow = 'hidden';
+
+    const canvas = ownerDocument.createElement('canvas');
+    canvas.style.border = 'none';
+    canvas.style.margin = '0';
+    canvas.style.padding = '0';
+    canvas.width = this.tileSize.width;
+    canvas.height = this.tileSize.height;
+    div.appendChild(canvas);
+
+    const tileCoords = this.getTileCoords(coord.x, coord.y, zoom);
+    const url = this.getUrl(tileCoords.x, tileCoords.y, tileCoords.z);
+
+    this.getImage(url, image => {
+      const canvasData = {
+        tileId,
+        canvas,
+        image,
+        x: coord.x,
+        y: coord.y,
+        z: zoom
+      };
+      this.cacheTile(canvasData);
+      this.drawCanvasImage(canvasData);
+    });
+
+    return div;
+  }
+
+  deleteOtherZoomTiles(zoom) {
+    const tilesKeys = Object.keys(this.tiles);
+
+    for (let i = 0; i < tilesKeys.length; i++) {
+      if (this.tiles[tilesKeys[i]].z !== zoom) {
+        delete this.tiles[tilesKeys[i]];
+      }
+    }
+  }
+
+  getUrl(x, y, z) {
+    return this.options.urlTemplate
+      .replace('{x}', x)
+      .replace('{y}', y)
+      .replace('{z}', z);
+  }
+
+  getTileCoords(x, y, z) {
+    const tile = { x, y, z };
+    if (z > this.options.dataMaxZoom) {
+      tile.x = Math.floor(x / 2 ** (z - this.options.dataMaxZoom));
+      tile.y = Math.floor(y / 2 ** (z - this.options.dataMaxZoom));
+      tile.z = this.options.dataMaxZoom;
+    } else {
+      tile.y = y > 2 ** z ? y % 2 ** z : y;
+      if (x >= 2 ** z) {
+        tile.z %= 2 ** z;
+      } else if (x < 0) {
+        tile.x = 2 ** z - Math.abs(x);
+      }
+    }
+
+    return tile;
+  }
+
+  getImage(url, callback) {
+    return axios
+      .get(url, { responseType: 'blob' })
+      .then(response => {
+        const image = new Image();
+        const imageUrl = URL.createObjectURL(response.data);
+        image.onload = () => {
+          image.crossOrigin = '';
+          callback(image);
+          URL.revokeObjectURL(url);
+        };
+        image.src = imageUrl;
+
+        return image;
+      })
+      .catch(error => {
+        console.warn(error);
+      });
+  }
+
+  cacheTile(canvasData) {
+    canvasData.canvas.setAttribute('id', canvasData.tileId);
+    this.tiles[canvasData.tileId] = canvasData;
+  }
+
+  drawCanvasImage(canvasData) {
+    const canvas = canvasData.canvas;
+    const ctx = canvas.getContext('2d');
+    const image = canvasData.image;
+    const zsteps = this.getZoomSteps(canvasData.z) || 0;
+
+    ctx.clearRect(0, 0, 256, 256);
+
+    if (zsteps < 0) {
+      ctx.drawImage(image, 0, 0);
+    } else {
+      ctx.imageSmoothingEnabled = false;
+      ctx.mozImageSmoothingEnabled = false;
+
+      const srcX = 256 / 2 ** zsteps * (canvasData.x % 2 ** zsteps) || 0;
+      const srcY = 256 / 2 ** zsteps * (canvasData.y % 2 ** zsteps) || 0;
+      const srcW = 256 / 2 ** zsteps || 0;
+      const srcH = 256 / 2 ** zsteps || 0;
+
+      ctx.drawImage(image, srcX, srcY, srcW, srcH, 0, 0, 256, 256);
+    }
+
+    const I = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    this.filterCanvasImgdata(I.data, canvas.width, canvas.height, canvasData.z);
+    ctx.putImageData(I, 0, 0);
+  }
+
+  getZoomSteps(z) {
+    return z - this.options.dataMaxZoom;
+  }
+
+  updateTiles() {
+    const tilesKeys = Object.keys(this.tiles);
+    for (let i = 0; i < tilesKeys.length; i++) {
+      this.drawCanvasImage(this.tiles[tilesKeys[i]]);
+    }
+  }
+
+  setOptions(options) {
+    this.options = { ...this.options, ...options };
+  }
+
+  filterCanvasImgdata() {}
+}
+
+export default Canvas;

--- a/app/javascript/components/map-old/assets/layers/abstract/cartoDB.js
+++ b/app/javascript/components/map-old/assets/layers/abstract/cartoDB.js
@@ -1,0 +1,58 @@
+import Overlay from './overlay';
+import CartoCSS from '../../cartocss/style.cartocss';
+
+const OPTIONS = {
+  user_name: 'wri-01',
+  type: 'cartodb',
+  sql: null,
+  cartocss: CartoCSS,
+  interactivity: 'cartodb_id, name',
+  infowindow: false,
+  cartodb_logo: false,
+  raster: false,
+  analysis: false,
+  actions: {},
+  queryTemplate:
+    "SELECT cartodb_id||':' ||'{tableName}' as cartodb_id, the_geom_webmercator,'{tableName}' AS layer, {analysis} AS analysis, name FROM {tableName}" // eslint-disable-line
+};
+
+class CartoDB extends Overlay {
+  constructor(map, options) {
+    super(map, options);
+    this.options = { ...options, ...OPTIONS };
+  }
+
+  getLayer() {
+    const cartodbOptions = {
+      type: this.options.type,
+      cartodb_logo: this.options.cartodb_logo,
+      user_name: this.options.user_name,
+      sublayers: [
+        {
+          sql: this.getQuery(),
+          cartocss: this.options.cartocss,
+          interactivity: this.options.interactivity,
+          raster: this.options.raster,
+          raster_band: this.options.raster_band
+        }
+      ]
+    };
+
+    return new Promise(resolve => {
+      cartodb // eslint-disable-line
+        .createLayer(this.map, cartodbOptions, { https: true })
+        .on('done', layer => {
+          resolve(layer);
+        });
+    });
+  }
+
+  getQuery() {
+    const query = (this.options.sql || this.options.queryTemplate)
+      .replace(/{tableName}/g, this.options.table_name)
+      .replace('{analysis}', this.options.analysis);
+    return query;
+  }
+}
+
+export default CartoDB;

--- a/app/javascript/components/map-old/assets/layers/abstract/image-layer.js
+++ b/app/javascript/components/map-old/assets/layers/abstract/image-layer.js
@@ -1,0 +1,88 @@
+import Overlay from './overlay';
+
+const OPTIONS = {
+  dataMaxZoom: 17
+};
+
+class ImageLayer extends Overlay {
+  constructor(map, options) {
+    super(map, OPTIONS);
+    this.options = { ...OPTIONS, ...options };
+    this.tiles = {};
+  }
+
+  getTile(coord, zoom, ownerDocument) {
+    const zsteps = this.getZoomSteps(zoom);
+
+    const tileCoords = this.getTileCoords(coord.x, coord.y, zoom, {});
+    const url = this.getUrl({ ...tileCoords });
+    const image = new Image();
+    image.src = url;
+    image.className += this.name;
+
+    image.onerror = () => {
+      this.style.display = 'none';
+    };
+
+    if (zsteps <= 0) {
+      return image;
+    }
+
+    image.width = 256 * 2 ** zsteps;
+    image.height = 256 * 2 ** zsteps;
+
+    const srcX = 256 * (coord.x % 2 ** zsteps);
+    const srcY = 256 * (coord.y % 2 ** zsteps);
+
+    image.style.position = 'absolute';
+    image.style.top = `${-srcY}px`;
+    image.style.left = `${-srcX}px`;
+
+    const div = ownerDocument.createElement('div');
+    div.appendChild(image);
+    div.style.width = `${this.tileSize.width}px`;
+    div.style.height = `${this.tileSize.height}px`;
+    div.style.position = 'relative';
+    div.style.overflow = 'hidden';
+    div.className += this.name;
+
+    return div;
+  }
+
+  getZoomSteps(z) {
+    return z - this.options.dataMaxZoom;
+  }
+
+  getUrl({ x, y, z }) {
+    return this.options.urlTemplate
+      .replace('{x}', x)
+      .replace('{y}', y)
+      .replace('{z}', z);
+  }
+
+  getTileCoords(x, y, z) {
+    let tileX = x;
+    let tileY = y;
+    let tileZ = z;
+    if (z > this.options.dataMaxZoom) {
+      tileX = Math.floor(x / 2 ** (z - this.options.dataMaxZoom));
+      tileY = Math.floor(y / 2 ** (z - this.options.dataMaxZoom));
+      tileZ = this.options.dataMaxZoom;
+    } else {
+      tileY = y > 2 ** z ? y % 2 ** z : y;
+      if (x >= 2 ** z) {
+        tileX = x % 2 ** z;
+      } else if (x < 0) {
+        tileX = 2 ** z - Math.abs(x);
+      }
+    }
+
+    return {
+      x: tileX,
+      y: tileY,
+      z: tileZ
+    };
+  }
+}
+
+export default ImageLayer;

--- a/app/javascript/components/map-old/assets/layers/abstract/overlay.js
+++ b/app/javascript/components/map-old/assets/layers/abstract/overlay.js
@@ -1,0 +1,24 @@
+class Overlay {
+  constructor(map, options) {
+    this.map = map;
+    this.tileSize = new google.maps.Size(256, 256); // eslint-disable-line
+    this.options = { ...options };
+  }
+
+  getLayer() {
+    return new Promise(resolve => {
+      resolve(this);
+    });
+  }
+
+  getTile(coord, zoom, ownerDocument) {
+    const div = ownerDocument.createElement('div');
+    div.innerHTML = coord;
+    div.style.width = `${this.tileSize.width}px`;
+    div.style.height = `${this.tileSize.height}px`;
+    div.style.backgroundColor = '#ff0000';
+    return div;
+  }
+}
+
+export default Overlay;

--- a/app/javascript/components/map-old/assets/layers/forest-cover-2010.js
+++ b/app/javascript/components/map-old/assets/layers/forest-cover-2010.js
@@ -1,0 +1,18 @@
+import ForestCover from './forest-cover';
+
+const OPTIONS = {
+  threshold: 30,
+  dataMaxZoom: 12,
+  urlTemplate:
+    'https://storage.googleapis.com/wri-public/treecover/2010/{threshold}/{z}/{x}/{y}.png'
+};
+
+class ForestCover2010 extends ForestCover {
+  constructor(map, options) {
+    super(map, options);
+    this.options = { ...OPTIONS, ...options };
+    this.threshold = this.options.threshold;
+  }
+}
+
+export default ForestCover2010;

--- a/app/javascript/components/map-old/assets/layers/forest-cover.js
+++ b/app/javascript/components/map-old/assets/layers/forest-cover.js
@@ -1,0 +1,62 @@
+import { scalePow } from 'd3-scale';
+import Canvas from './abstract/canvas';
+
+const OPTIONS = {
+  threshold: 30,
+  dataMaxZoom: 12,
+  urlTemplate:
+    'https://earthengine.google.org/static/hansen_2014/gfw_loss_tree_year_{threshold}_2014/{z}/{x}/{y}.png'
+};
+
+class ForestCover extends Canvas {
+  constructor(map, options) {
+    super(map, options);
+    this.options = { ...OPTIONS, ...options };
+  }
+
+  filterCanvasImgdata(imgdata, w, h) {
+    const components = 4;
+    const zoom = this.map.getZoom();
+    const exp = zoom < 11 ? 0.3 + (zoom - 3) / 20 : 1;
+
+    const myscale = scalePow()
+      .exponent(exp)
+      .domain([0, 256])
+      .range([0, 256]);
+
+    for (let i = 0; i < w; ++i) {
+      for (let j = 0; j < h; ++j) {
+        const pixelPos = (j * w + i) * components;
+        const intensity = imgdata[pixelPos + 1];
+
+        imgdata[pixelPos] = 151; // eslint-disable-line
+        imgdata[pixelPos + 1] = 189; // eslint-disable-line
+        imgdata[pixelPos + 2] = 61; // eslint-disable-line
+
+        imgdata[pixelPos + 3] = // eslint-disable-line
+          zoom < 13 ? myscale(intensity) * 0.8 : intensity * 0.8;
+      }
+    }
+  }
+
+  setThreshold(threshold) {
+    this.threshold = threshold;
+  }
+
+  getUrl(x, y, z) {
+    return this.options.urlTemplate
+      .replace('{x}', x)
+      .replace('{y}', y)
+      .replace('{z}', z)
+      .replace('{threshold}', this.options.threshold);
+  }
+
+  setOptions(options) {
+    if (this.options.threshold !== options.threshold) {
+      this.updateTilesEnable = false;
+    }
+    this.options = { ...this.options, ...options };
+  }
+}
+
+export default ForestCover;

--- a/app/javascript/components/map-old/assets/layers/forest-gain.js
+++ b/app/javascript/components/map-old/assets/layers/forest-gain.js
@@ -1,0 +1,16 @@
+import ImageLayer from './abstract/image-layer';
+
+const OPTIONS = {
+  dataMaxZoom: 12,
+  urlTemplate:
+    'https://earthengine.google.org/static/hansen_2013/gain_alpha/{z}/{x}/{y}.png'
+};
+
+class ForestGain extends ImageLayer {
+  constructor(map, options) {
+    super(map, options);
+    this.options = { ...OPTIONS, ...options };
+  }
+}
+
+export default ForestGain;

--- a/app/javascript/components/map-old/assets/layers/glad.js
+++ b/app/javascript/components/map-old/assets/layers/glad.js
@@ -1,0 +1,121 @@
+import { fetchGLADLatest } from 'services/alerts';
+import moment from 'moment';
+import isEmpty from 'lodash/isEmpty';
+import Canvas from './abstract/canvas';
+
+const OPTIONS = {
+  dataMaxZoom: 12,
+  urlTemplate: `https://wri-tiles.s3.amazonaws.com/glad_${
+    process.env.RAILS_ENV === 'production' ? 'prod' : 'staging'
+  }/tiles/{z}/{x}/{y}.png`,
+  startDate: '2015-01-01'
+};
+
+const getConfidence = number => {
+  let confidence = -1;
+  if (number >= 100 && number < 200) {
+    confidence = 0;
+  } else if (number >= 200) {
+    confidence = 1;
+  }
+  return confidence;
+};
+
+const getIntensity = number => {
+  let intensity = (number % 100) * 50;
+  if (intensity > 255) {
+    intensity = 255;
+  }
+  return intensity;
+};
+
+class Glad extends Canvas {
+  constructor(map, options) {
+    super(map, options);
+    this.options = { ...OPTIONS, ...options };
+    this.tiles = {};
+  }
+
+  getLayer() {
+    return fetchGLADLatest()
+      .then(result => {
+        const { attributes } = result.data.data;
+        if (!attributes || !attributes.length) return this;
+        this.endDate = attributes[0].date;
+
+        return this;
+      })
+      .catch(error => {
+        console.error(error);
+      });
+  }
+
+  getUrl(x, y, z) {
+    return this.options.urlTemplate
+      .replace('{x}', x)
+      .replace('{y}', y)
+      .replace('{z}', z);
+  }
+
+  filterCanvasImgdata(imgdata, w, h) {
+    // fixed variables
+    const imageData = imgdata;
+    const absStartDate = this.options.startDate;
+    const absEndDate = moment(this.endDate);
+    const numberOfDays = absEndDate.diff(absStartDate, 'days');
+
+    // timeline or hover effect active range
+    const { activeData } = this.options;
+    const activeStartDay =
+      !isEmpty(activeData) &&
+      numberOfDays - absEndDate.diff(activeData.startDate, 'days');
+    const activeEndDay =
+      !isEmpty(activeData) &&
+      numberOfDays - absEndDate.diff(activeData.endDate, 'days');
+
+    // show specified weeks from end date
+    const { weeks } = this.options;
+    const rangeStartDate = weeks && numberOfDays - 7 * weeks;
+
+    // get start and end day
+    const startDay = activeStartDay || rangeStartDate || 0;
+    const endDay = activeEndDay || numberOfDays;
+
+    const confidenceValue = -1;
+    const pixelComponents = 4; // RGBA
+    let pixelPos = 0;
+    for (let i = 0; i < w; ++i) {
+      for (let j = 0; j < h; ++j) {
+        pixelPos = (j * w + i) * pixelComponents;
+        // day 0 is 2015-01-01 until latest date from fetch
+        const day = imageData[pixelPos] * 255 + imageData[pixelPos + 1];
+        const band3 = imgdata[pixelPos + 2];
+        const confidence = getConfidence(imgdata[band3]);
+
+        if (
+          confidence >= confidenceValue &&
+          day > 0 &&
+          (day >= startDay || (0 && day <= endDay))
+        ) {
+          const intensity = getIntensity(band3);
+          if (day >= numberOfDays - 7 && day <= numberOfDays) {
+            imageData[pixelPos] = 219;
+            imageData[pixelPos + 1] = 168;
+            imageData[pixelPos + 2] = 0;
+            imageData[pixelPos + 3] = intensity;
+          } else {
+            imageData[pixelPos] = 220;
+            imageData[pixelPos + 1] = 102;
+            imageData[pixelPos + 2] = 153;
+            imageData[pixelPos + 3] = intensity;
+          }
+          continue; // eslint-disable-line
+        }
+
+        imageData[pixelPos + 3] = 0;
+      }
+    }
+  }
+}
+
+export default Glad;

--- a/app/javascript/components/map-old/assets/layers/intact-forest.js
+++ b/app/javascript/components/map-old/assets/layers/intact-forest.js
@@ -1,0 +1,26 @@
+import CartoDB from './abstract/cartoDB';
+import IntactForestCartoCSS from '../cartocss/intact-forest.cartocss';
+
+const OPTIONS = {
+  user_name: 'wri-01',
+  type: 'cartodb',
+  cartodb_logo: false,
+  raster: false,
+  actions: {},
+  queryTemplate:
+    "SELECT cartodb_id||':' ||'{tableName}' as cartodb_id, the_geom_webmercator,'{tableName}' AS layer, {analysis} AS analysis, name FROM {tableName}", // eslint-disable-line
+  analysis: true,
+  infowindow: true,
+  sql:
+    "SELECT *, '{tableName}' as layer, '{tableName}' as name FROM {tableName}",
+  cartocss: IntactForestCartoCSS
+};
+
+class IntactForest extends CartoDB {
+  constructor(map, options) {
+    super(map, options);
+    this.options = { ...OPTIONS, ...options };
+  }
+}
+
+export default IntactForest;

--- a/app/javascript/components/map-old/assets/layers/loss.js
+++ b/app/javascript/components/map-old/assets/layers/loss.js
@@ -1,0 +1,64 @@
+import { scalePow } from 'd3-scale';
+import Canvas from './abstract/canvas';
+
+const OPTIONS = {
+  threshold: 30,
+  dataMaxZoom: 12,
+  urlTemplate:
+    'https://storage.googleapis.com/wri-public/Hansen15/tiles/hansen_world/v1/tc{threshold}/{z}/{x}/{y}.png',
+  startYear: 2001,
+  endYear: 2017
+};
+
+class Loss extends Canvas {
+  constructor(map, options) {
+    super(map, options);
+    this.options = { ...OPTIONS, ...options };
+  }
+
+  filterCanvasImgdata(imgdata, w, h, z) {
+    const components = 4;
+    const exp = z < 11 ? 0.3 + (z - 3) / 20 : 1;
+    const startYear = this.options.startYear;
+    const endYear = this.options.endYear;
+
+    const myscale = scalePow()
+      .exponent(exp)
+      .domain([0, 256])
+      .range([0, 256]);
+
+    for (let i = 0; i < w; ++i) {
+      for (let j = 0; j < h; ++j) {
+        const pixelPos = (j * w + i) * components;
+        const intensity = imgdata[pixelPos];
+        const yearLoss = 2000 + imgdata[pixelPos + 2];
+
+        if (yearLoss >= startYear && yearLoss < endYear) {
+          imgdata[pixelPos] = 220; // eslint-disable-line
+          imgdata[pixelPos + 1] = 72 - z + 102 - 3 * myscale(intensity) / z; // eslint-disable-line
+          imgdata[pixelPos + 2] = 33 - z + 153 - intensity / z; // eslint-disable-line
+          imgdata[pixelPos + 3] = z < 13 ? myscale(intensity) : intensity; // eslint-disable-line
+        } else {
+          imgdata[pixelPos + 3] = 0; // eslint-disable-line
+        }
+      }
+    }
+  }
+
+  getUrl(x, y, z) {
+    return this.options.urlTemplate
+      .replace('{x}', x)
+      .replace('{y}', y)
+      .replace('{z}', z)
+      .replace('{threshold}', this.options.threshold);
+  }
+
+  setOptions(options) {
+    if (this.options.threshold !== options.threshold) {
+      this.updateTilesEnable = false;
+    }
+    this.options = { ...this.options, ...options };
+  }
+}
+
+export default Loss;

--- a/app/javascript/components/map-old/assets/layers/mining.js
+++ b/app/javascript/components/map-old/assets/layers/mining.js
@@ -1,0 +1,26 @@
+import CartoDB from './abstract/cartoDB';
+
+const OPTIONS = {
+  user_name: 'wri-01',
+  type: 'cartodb',
+  cartodb_logo: false,
+  raster: false,
+  actions: {},
+  queryTemplate:
+    "SELECT cartodb_id||':' ||'{tableName}' as cartodb_id, the_geom_webmercator,'{tableName}' AS layer, {analysis} AS analysis, name FROM {tableName}", // eslint-disable-line
+  analysis: true,
+  sql:
+    "SELECT cartodb_id, 'mining' as tablename, the_geom_webmercator, status, company, country, round(area_ha::float) as area_ha, name, permit as permit_num, mineral, type, province, '{tableName}' AS layer, {analysis} AS analysis FROM {tableName}",
+  infowindow: true,
+  interactivity:
+    'cartodb_id, tablename, name, status, company, country, permit_num, mineral, type, province, area_ha, analysis'
+};
+
+class Mining extends CartoDB {
+  constructor(map, options) {
+    super(map, options);
+    this.options = { ...OPTIONS, ...options };
+  }
+}
+
+export default Mining;

--- a/app/javascript/components/map-old/assets/layers/plantations-by-species.js
+++ b/app/javascript/components/map-old/assets/layers/plantations-by-species.js
@@ -1,0 +1,28 @@
+import CartoDB from './abstract/cartoDB';
+import PlantationsBySpeciesCartoCSS from '../cartocss/plantations-by-species.cartocss';
+
+const OPTIONS = {
+  user_name: 'wri-01',
+  type: 'cartodb',
+  cartodb_logo: false,
+  raster: false,
+  actions: {},
+  queryTemplate:
+    "SELECT cartodb_id||':' ||'{tableName}' as cartodb_id, the_geom_webmercator,'{tableName}' AS layer, {analysis} AS analysis, name FROM {tableName}", // eslint-disable-line
+  sql:
+    "SELECT the_geom_webmercator, cartodb_id, type_text, spec_org, spec_simp, round(area_ha::numeric,1) as area_ha, percent, '{tableName}' AS tablename, '{tableName}' AS layer, {analysis} AS analysis FROM {tableName}",
+  cartocss: PlantationsBySpeciesCartoCSS,
+  infowindow: true,
+  interactivity:
+    'cartodb_id, tablename, layer, analysis, type_text, spec_org, spec_simp, area_ha, percent',
+  analysis: true
+};
+
+class PlantationsBySpecies extends CartoDB {
+  constructor(map, options) {
+    super(map, options);
+    this.options = { ...options, ...OPTIONS };
+  }
+}
+
+export default PlantationsBySpecies;

--- a/app/javascript/components/map-old/assets/layers/plantations-by-type.js
+++ b/app/javascript/components/map-old/assets/layers/plantations-by-type.js
@@ -1,0 +1,28 @@
+import CartoDB from './abstract/cartoDB';
+import PlantationsByTypeCartoCSS from '../cartocss/plantations-by-type.cartocss';
+
+const OPTIONS = {
+  user_name: 'wri-01',
+  type: 'cartodb',
+  cartodb_logo: false,
+  raster: false,
+  actions: {},
+  queryTemplate:
+    "SELECT cartodb_id||':' ||'{tableName}' as cartodb_id, the_geom_webmercator,'{tableName}' AS layer, {analysis} AS analysis, name FROM {tableName}", // eslint-disable-line
+  sql:
+    "SELECT the_geom_webmercator, cartodb_id, type_text, spec_org, spec_simp, percent, round(area_ha::numeric,1) as area_ha, '{tableName}' AS tablename, '{tableName}' AS layer, {analysis} AS analysis FROM {tableName}",
+  cartocss: PlantationsByTypeCartoCSS,
+  infowindow: true,
+  interactivity:
+    'cartodb_id, tablename, layer, analysis, type_text, spec_org, spec_simp, percent, area_ha',
+  analysis: true
+};
+
+class PlantationsByType extends CartoDB {
+  constructor(map, options) {
+    super(map, options);
+    this.options = { ...options, ...OPTIONS };
+  }
+}
+
+export default PlantationsByType;

--- a/app/javascript/components/map-old/assets/layers/protected-areas.js
+++ b/app/javascript/components/map-old/assets/layers/protected-areas.js
@@ -1,0 +1,27 @@
+import CartoDB from './abstract/cartoDB';
+import ProtectedAreasCartoCSS from '../cartocss/protected-areas.cartocss';
+
+const OPTIONS = {
+  user_name: 'wri-01',
+  type: 'cartodb',
+  cartodb_logo: false,
+  raster: false,
+  actions: {},
+  queryTemplate:
+    "SELECT cartodb_id||':' ||'{tableName}' as cartodb_id, the_geom_webmercator,'{tableName}' AS layer, {analysis} AS analysis, name FROM {tableName}", // eslint-disable-line
+  analysis: true,
+  sql:
+    "SELECT the_geom_webmercator, the_geom,iucn_cat, desig_eng, iso3 as country, name, wdpaid as id, {analysis} AS analysis, '{tableName}' as layer FROM {tableName}",
+  cartocss: ProtectedAreasCartoCSS,
+  infowindow: true,
+  interactivity: 'desig_eng, country, name, id, analysis, iucn_cat'
+};
+
+class ProtectedAreas extends CartoDB {
+  constructor(map, options) {
+    super(map, options);
+    this.options = { ...OPTIONS, ...options };
+  }
+}
+
+export default ProtectedAreas;

--- a/app/javascript/components/map-old/assets/layers/viirs.js
+++ b/app/javascript/components/map-old/assets/layers/viirs.js
@@ -1,0 +1,41 @@
+import moment from 'moment';
+import { getRangeForDates } from 'utils/dates';
+import CartoDB from './abstract/cartoDB';
+import ViirsCartoCSS from '../cartocss/viirs.cartocss';
+
+const OPTIONS = {
+  user_name: 'wri-01',
+  type: 'cartodb',
+  cartodb_logo: false,
+  raster: false,
+  actions: {},
+  queryTemplate:
+    "SELECT cartodb_id||':' ||'{tableName}' as cartodb_id, the_geom_webmercator,'{tableName}' AS layer, {analysis} AS analysis, name FROM {tableName}", // eslint-disable-line
+  analysis: true,
+  sql:
+    "SELECT the_geom_webmercator, '{tableName}' as tablename,'{tableName}' AS layer, (SUBSTR(acq_time, 1, 2) || ':' || SUBSTR(acq_time, 3, 4)) as acq_time,  COALESCE(to_char(acq_date, 'DD Mon, YYYY')) as acq_date, confidence, bright_ti4 brightness, longitude, latitude FROM {tableName} WHERE acq_date >= '{year}-{month}-{day}' AND confidence != 'low'",
+  cartocss: ViirsCartoCSS,
+  interactivity:
+    'acq_time, acq_date, confidence, brightness, longitude, latitude',
+  infowindow: true
+};
+
+class Viirs extends CartoDB {
+  constructor(map, options) {
+    super(map, options);
+    this.options = { ...OPTIONS, ...options };
+    this.currentDate = getRangeForDates(
+      options.currentDate || [moment().subtract(8, 'days'), moment()]
+    );
+  }
+
+  getQuery() {
+    return this.options.sql
+      .replace(/{tableName}/g, this.options.table_name)
+      .replace('{year}', moment(this.currentDate[0]).year())
+      .replace('{month}', moment(this.currentDate[0]).format('MM'))
+      .replace('{day}', moment(this.currentDate[0]).format('DD'));
+  }
+}
+
+export default Viirs;

--- a/app/javascript/components/map-old/assets/maptypes/GFWLabels.js
+++ b/app/javascript/components/map-old/assets/maptypes/GFWLabels.js
@@ -1,0 +1,119 @@
+const labelStyle = [
+  {
+    featureType: 'administrative',
+    stylers: [
+      {
+        saturation: '-100'
+      }
+    ]
+  },
+  {
+    featureType: 'administrative',
+    elementType: 'geometry.fill',
+    stylers: [
+      {
+        visibility: 'simplified'
+      }
+    ]
+  },
+  {
+    featureType: 'administrative.land_parcel',
+    stylers: [
+      {
+        visibility: 'off'
+      }
+    ]
+  },
+  {
+    featureType: 'administrative.neighborhood',
+    stylers: [
+      {
+        visibility: 'off'
+      }
+    ]
+  },
+  {
+    featureType: 'landscape',
+    stylers: [
+      {
+        saturation: '-100'
+      },
+      {
+        lightness: '90'
+      }
+    ]
+  },
+  {
+    featureType: 'landscape',
+    elementType: 'geometry.fill',
+    stylers: [
+      {
+        visibility: 'off'
+      }
+    ]
+  },
+  {
+    featureType: 'landscape',
+    elementType: 'labels',
+    stylers: [
+      {
+        color: '#333333'
+      },
+      {
+        saturation: '50'
+      },
+      {
+        invert_lightness: true
+      },
+      {
+        lightness: '50'
+      },
+      {
+        weight: '0.3'
+      }
+    ]
+  },
+  {
+    featureType: 'poi',
+    stylers: [
+      {
+        visibility: 'off'
+      }
+    ]
+  },
+  {
+    featureType: 'road',
+    stylers: [
+      {
+        saturation: -100
+      },
+      {
+        visibility: 'off'
+      }
+    ]
+  },
+  {
+    featureType: 'transit',
+    stylers: [
+      {
+        saturation: -100
+      },
+      {
+        visibility: 'off'
+      }
+    ]
+  },
+  {
+    featureType: 'water',
+    elementType: 'geometry.fill',
+    stylers: [
+      {
+        visibility: 'simplified'
+      }
+    ]
+  }
+];
+
+const GFWLabels = () => new google.maps.StyledMapType(labelStyle, { name }); // eslint-disable-line
+
+export default GFWLabels;

--- a/app/javascript/components/map-old/assets/maptypes/GFWdefault.js
+++ b/app/javascript/components/map-old/assets/maptypes/GFWdefault.js
@@ -1,0 +1,121 @@
+const name = 'GFWdefault';
+const baseStyle = [
+  {
+    elementType: 'labels',
+    stylers: [
+      {
+        visibility: 'off'
+      }
+    ]
+  },
+  {
+    featureType: 'administrative',
+    stylers: [
+      {
+        saturation: '-100'
+      }
+    ]
+  },
+  {
+    featureType: 'administrative.land_parcel',
+    stylers: [
+      {
+        visibility: 'off'
+      }
+    ]
+  },
+  {
+    featureType: 'administrative.neighborhood',
+    stylers: [
+      {
+        visibility: 'off'
+      }
+    ]
+  },
+  {
+    featureType: 'landscape',
+    stylers: [
+      {
+        saturation: '-100'
+      },
+      {
+        lightness: '90'
+      }
+    ]
+  },
+  {
+    featureType: 'landscape',
+    elementType: 'labels',
+    stylers: [
+      {
+        color: '#333333'
+      },
+      {
+        saturation: '50'
+      },
+      {
+        invert_lightness: true
+      },
+      {
+        lightness: '50'
+      },
+      {
+        weight: '0.3'
+      }
+    ]
+  },
+  {
+    featureType: 'poi',
+    stylers: [
+      {
+        visibility: 'off'
+      }
+    ]
+  },
+  {
+    featureType: 'poi.park',
+    elementType: 'geometry',
+    stylers: [
+      {
+        visibility: 'off'
+      }
+    ]
+  },
+  {
+    featureType: 'poi.park',
+    elementType: 'labels',
+    stylers: [
+      {
+        visibility: 'off'
+      }
+    ]
+  },
+  {
+    featureType: 'road',
+    stylers: [
+      {
+        saturation: '-100'
+      }
+    ]
+  },
+  {
+    featureType: 'transit',
+    stylers: [
+      {
+        saturation: '-100'
+      }
+    ]
+  },
+  {
+    featureType: 'water',
+    stylers: [
+      {
+        hue: '#B3E2FF'
+      }
+    ]
+  }
+];
+
+const GFWdefault = () => new google.maps.StyledMapType(baseStyle, { name }); // eslint-disable-line
+
+export default GFWdefault;

--- a/app/javascript/components/map-old/component.js
+++ b/app/javascript/components/map-old/component.js
@@ -1,0 +1,35 @@
+import React, { PureComponent } from 'react';
+import Proptypes from 'prop-types';
+
+import Loader from 'components/ui/loader';
+import NoContent from 'components/ui/no-content';
+import MiniLegend from 'components/map-old/components/mini-legend';
+
+import './styles.scss';
+
+class Map extends PureComponent {
+  render() {
+    const { loading, error, layers } = this.props;
+    return (
+      <div className="c-map">
+        {loading && (
+          <Loader className="map-loader" theme="theme-loader-light" />
+        )}
+        {!loading &&
+          error && (
+            <NoContent message="An error occured. Please try again later." />
+          )}
+        <div id="map" className="c-map" />
+        {!loading && layers && layers.length && <MiniLegend layers={layers} />}
+      </div>
+    );
+  }
+}
+
+Map.propTypes = {
+  loading: Proptypes.bool.isRequired,
+  error: Proptypes.bool.isRequired,
+  layers: Proptypes.array
+};
+
+export default Map;

--- a/app/javascript/components/map-old/components/map-controls/map-controls-component.jsx
+++ b/app/javascript/components/map-old/components/map-controls/map-controls-component.jsx
@@ -1,0 +1,42 @@
+import React, { PureComponent } from 'react';
+import Proptypes from 'prop-types';
+import Sticky from 'react-stickynode';
+
+import Button from 'components/ui/button';
+import Icon from 'components/ui/icon';
+
+import plusIcon from 'assets/icons/plus.svg';
+import minusIcon from 'assets/icons/minus.svg';
+import './map-controls-styles.scss';
+
+class MapControls extends PureComponent {
+  render() {
+    const {
+      handleZoomIn,
+      handleZoomOut,
+      className,
+      stickyOptions
+    } = this.props;
+    return (
+      <div className={`c-map-controls ${className || ''}`}>
+        <Sticky enabled={false} {...stickyOptions}>
+          <Button theme="theme-button-map-control" onClick={handleZoomIn}>
+            <Icon icon={plusIcon} className="plus-icon" />
+          </Button>
+          <Button theme="theme-button-map-control" onClick={handleZoomOut}>
+            <Icon icon={minusIcon} className="minus-icon" />
+          </Button>
+        </Sticky>
+      </div>
+    );
+  }
+}
+
+MapControls.propTypes = {
+  className: Proptypes.string,
+  handleZoomIn: Proptypes.func,
+  handleZoomOut: Proptypes.func,
+  stickyOptions: Proptypes.object
+};
+
+export default MapControls;

--- a/app/javascript/components/map-old/components/map-controls/map-controls-styles.scss
+++ b/app/javascript/components/map-old/components/map-controls/map-controls-styles.scss
@@ -1,0 +1,18 @@
+@import '~styles/settings.scss';
+
+.c-map-controls {
+  width: rem(38px);
+
+  button:first-child {
+    border-bottom: solid 1px rgba($medium-grey, 0.2);
+  }
+
+  .plus-icon {
+    width: rem(13px);
+    height: rem(13px);
+  }
+
+  .minus-icon {
+    width: rem(13px);
+  }
+}

--- a/app/javascript/components/map-old/components/map-controls/map-controls.js
+++ b/app/javascript/components/map-old/components/map-controls/map-controls.js
@@ -1,0 +1,3 @@
+import Component from './map-controls-component';
+
+export default Component;

--- a/app/javascript/components/map-old/components/mini-legend/mini-legend-component.jsx
+++ b/app/javascript/components/map-old/components/mini-legend/mini-legend-component.jsx
@@ -1,0 +1,57 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { isTouch } from 'utils/browser';
+
+import Button from 'components/ui/button';
+import Icon from 'components/ui/icon';
+import Tip from 'components/ui/tip';
+
+import linkIcon from 'assets/icons/link.svg';
+import './mini-legend-styles.scss';
+
+class MiniLegend extends PureComponent {
+  // eslint-disable-line react/prefer-stateless-function
+  render() {
+    const { layers } = this.props;
+    const layersKeys =
+      layers && layers.length && layers.map(l => l.slug).join(',');
+    const isDeviceTouch = isTouch();
+    return (
+      <div className="c-mini-legend">
+        <ul>
+          {layers.map(l => (
+            <li key={l.slug}>
+              <span style={{ backgroundColor: l.title_color }} />
+              {l.title}
+            </li>
+          ))}
+        </ul>
+        <div className="link-to-map">
+          <Button
+            theme="theme-button-small square"
+            extLink={`/map/3/15.00/27.00/ALL/grayscale/${layersKeys}`}
+            trackingData={{
+              title: 'view-full-map',
+              layers: layersKeys
+            }}
+            tooltip={{
+              theme: 'tip',
+              position: 'top',
+              arrow: true,
+              disabled: isDeviceTouch,
+              html: <Tip text="Explore the data on the global map" />
+            }}
+          >
+            <Icon icon={linkIcon} className="info-icon" />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}
+
+MiniLegend.propTypes = {
+  layers: PropTypes.array
+};
+
+export default MiniLegend;

--- a/app/javascript/components/map-old/components/mini-legend/mini-legend-styles.scss
+++ b/app/javascript/components/map-old/components/mini-legend/mini-legend-styles.scss
@@ -1,0 +1,42 @@
+@import '~styles/settings.scss';
+
+.c-mini-legend {
+  background-color: $white;
+  box-shadow: 0 1px 3px 0 rgba($black, 0.25);
+  padding: rem(10px);
+  padding-bottom: rem(5px);
+  position: absolute;
+  left: rem(15px);
+  right: rem(15px);
+  bottom: rem(30px);
+  max-width: rem(400px);
+
+  ul {
+    font-size: rem(13px);
+    font-weight: 400;
+    color: $slate;
+
+    li {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: flex-start;
+      margin-bottom: rem(5px);
+
+      span {
+        height: rem(10px);
+        width: rem(10px);
+        min-height: rem(10px);
+        min-width: rem(10px);
+        border-radius: 50%;
+        margin-right: rem(10px);
+      }
+    }
+  }
+
+  .link-to-map {
+    position: absolute;
+    top: rem(10px);
+    right: rem(10px);
+  }
+}

--- a/app/javascript/components/map-old/components/mini-legend/mini-legend.js
+++ b/app/javascript/components/map-old/components/mini-legend/mini-legend.js
@@ -1,0 +1,3 @@
+import Component from './mini-legend-component';
+
+export default Component;

--- a/app/javascript/components/map-old/index.js
+++ b/app/javascript/components/map-old/index.js
@@ -15,14 +15,17 @@ import actions from './actions';
 import reducers, { initialState } from './reducers';
 import { getLayers } from './selectors';
 
-const mapStateToProps = ({ map, countryData, widgets }, { widgetKey }) => {
+const mapStateToProps = (
+  { map, countryData, widgets, geostore },
+  { widgetKey }
+) => {
   const widget = widgets[widgetKey];
   const widgetSettings = widget && widget.settings;
   const activeLayers = widgetSettings && widgetSettings.layers;
 
   return {
     ...map,
-    ...countryData.geostore,
+    ...geostore.geostore,
     loading: map.loading || countryData.isGeostoreLoading,
     settings: { ...map.settings, ...widgetSettings },
     layers: getLayers({ layers: activeLayers, layerSpec: map.layerSpec }),

--- a/app/javascript/components/map-old/index.js
+++ b/app/javascript/components/map-old/index.js
@@ -1,0 +1,191 @@
+import { createElement, PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import isEqual from 'lodash/isEqual';
+import isEmpty from 'lodash/isEmpty';
+import difference from 'lodash/difference';
+import findIndex from 'lodash/findIndex';
+
+import Layers from './assets/layers';
+import GFWdefault from './assets/maptypes/GFWdefault';
+import GFWLabels from './assets/maptypes/GFWLabels';
+
+import MapComponent from './component';
+import actions from './actions';
+import reducers, { initialState } from './reducers';
+import { getLayers } from './selectors';
+
+const mapStateToProps = ({ map, countryData, widgets }, { widgetKey }) => {
+  const widget = widgets[widgetKey];
+  const widgetSettings = widget && widget.settings;
+  const activeLayers = widgetSettings && widgetSettings.layers;
+
+  return {
+    ...map,
+    ...countryData.geostore,
+    loading: map.loading || countryData.isGeostoreLoading,
+    settings: { ...map.settings, ...widgetSettings },
+    layers: getLayers({ layers: activeLayers, layerSpec: map.layerSpec }),
+    layersKeys: activeLayers
+  };
+};
+
+class MapContainer extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.runningLayers = [];
+  }
+
+  componentDidMount() {
+    const { layersKeys, getLayerSpec } = this.props;
+    getLayerSpec();
+    this.buildMap();
+    this.setLayers(layersKeys);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { bounds, layersKeys, settings, options, geojson } = nextProps;
+    const { zoom } = options;
+    // sync geostore with map
+    if (!isEmpty(bounds) && !isEqual(bounds, this.props.bounds)) {
+      this.boundMap(bounds);
+      this.setAreaHighlight(geojson);
+    } else if (!bounds && !isEqual(bounds, this.props.bounds)) {
+      this.resetMap();
+    }
+
+    // sync layers with map
+    if (
+      !isEqual(layersKeys, this.props.layersKeys) ||
+      !isEqual(settings, this.props.settings)
+    ) {
+      this.updateLayers(layersKeys, this.props.layersKeys, settings);
+    }
+
+    // sync zoom with map
+    if (
+      zoom &&
+      this.props.options.zoom !== zoom &&
+      this.map.getZoom() !== zoom
+    ) {
+      this.map.setZoom(zoom);
+    }
+  }
+
+  buildMap() {
+    const { options } = this.props;
+    this.map = new google.maps.Map(document.getElementById('map'), options); // eslint-disable-line
+    this.map.mapTypes.set('GFWdefault', GFWdefault());
+    this.map.setMapTypeId(options.mapTypeId);
+    this.map.overlayMapTypes.setAt(10, GFWLabels());
+  }
+
+  boundMap(bounds) {
+    const { setMapZoom } = this.props;
+    const boundsMap = new google.maps.LatLngBounds(); // eslint-disable-line
+    bounds.forEach(item => {
+      boundsMap.extend(new google.maps.LatLng(item[1], item[0])); // eslint-disable-line
+    });
+    this.map.fitBounds(boundsMap);
+    setMapZoom({ value: this.map.getZoom() });
+  }
+
+  removeDataLayers() {
+    this.map.data.forEach(feature => {
+      this.map.data.remove(feature);
+    });
+  }
+
+  resetMap() {
+    const { setMapZoom } = this.props;
+    const { center, zoom } = initialState.options;
+    setMapZoom({ value: zoom });
+    this.map.setCenter(center);
+    this.removeDataLayers();
+  }
+
+  setAreaHighlight(geojson) {
+    this.removeDataLayers();
+    this.map.data.addGeoJson(geojson);
+    this.map.data.setStyle({
+      strokeWeight: 1.5,
+      stroke: '#333',
+      fillColor: 'transparent'
+    });
+  }
+
+  updateLayers(newLayers, oldLayers, settings) {
+    const layersToRemove = difference(oldLayers, newLayers);
+    if (layersToRemove && layersToRemove.length) {
+      this.removeLayers(layersToRemove);
+    }
+    this.setLayers(newLayers, settings);
+  }
+
+  removeLayers(layers) {
+    this.map.overlayMapTypes.forEach((l, index) => {
+      if (l && l.options && layers.indexOf(l.options.slug)) {
+        this.map.overlayMapTypes.removeAt(index);
+      }
+    });
+  }
+
+  setLayers = (layers, settings) => {
+    const { layerSpec } = this.props;
+    if (layers && layers.length) {
+      layers.forEach((slug, index) => {
+        const layerSettings = { ...layerSpec[slug], ...settings };
+        const newLayer = new Layers[slug](this.map, layerSettings);
+        newLayer.getLayer().then(res => {
+          const runningLayerIndex = findIndex(
+            this.runningLayers,
+            d => d.slug === slug
+          );
+          if (
+            runningLayerIndex !== -1 &&
+            this.runningLayers[runningLayerIndex].layer.updateTiles
+          ) {
+            const { layer } = this.runningLayers[runningLayerIndex];
+            layer.setOptions(res.options);
+            if (layer.updateTilesEnable) {
+              layer.updateTiles();
+            } else {
+              this.setRunningLayer(index, slug, res);
+            }
+          } else {
+            this.setRunningLayer(index, slug, res);
+          }
+        });
+      });
+    }
+  };
+
+  setRunningLayer = (index, slug, layer) => {
+    this.runningLayers[index] = {
+      slug,
+      layer
+    };
+    this.map.overlayMapTypes.setAt(index, this.runningLayers[index].layer);
+  };
+
+  render() {
+    return createElement(MapComponent, {
+      ...this.props
+    });
+  }
+}
+
+MapContainer.propTypes = {
+  layerSpec: PropTypes.object.isRequired,
+  bounds: PropTypes.array,
+  layersKeys: PropTypes.array,
+  settings: PropTypes.object,
+  options: PropTypes.object,
+  getLayerSpec: PropTypes.func.isRequired,
+  setMapZoom: PropTypes.func.isRequired,
+  geojson: PropTypes.object
+};
+
+export { reducers, initialState, actions };
+
+export default connect(mapStateToProps, actions)(MapContainer);

--- a/app/javascript/components/map-old/reducers.js
+++ b/app/javascript/components/map-old/reducers.js
@@ -1,0 +1,72 @@
+export const initialState = {
+  loading: true,
+  error: false,
+  layerSpec: {},
+  options: {
+    mapTypeId: 'GFWdefault',
+    backgroundColor: '#A4DBFD',
+    disableDefaultUI: true,
+    panControl: false,
+    zoomControl: false,
+    mapTypeControl: false,
+    scaleControl: true,
+    streetViewControl: false,
+    overviewMapControl: false,
+    tilt: 0,
+    scrollwheel: false,
+    center: { lat: 15, lng: 27 },
+    zoom: 2,
+    minZoom: 2,
+    maxZoom: 14
+  },
+  settings: {},
+  showMapMobile: false
+};
+
+const setLayerSpecLoading = (state, { payload }) => ({
+  ...state,
+  ...payload
+});
+
+const setLayerSpec = (state, { payload }) => ({
+  ...state,
+  layerSpec: payload,
+  loading: false
+});
+
+const setMapOptions = (state, { payload }) => ({
+  ...state,
+  options: payload
+});
+
+const setShowMapMobile = (state, { payload }) => ({
+  ...state,
+  showMapMobile: payload
+});
+
+const setMapZoom = (state, { payload }) => {
+  const { maxZoom, minZoom, zoom } = state.options;
+  const { value, sum } = payload;
+  let newZoom = sum ? zoom + sum : value;
+  if (zoom > maxZoom) {
+    newZoom = minZoom;
+  } else if (zoom < minZoom) {
+    newZoom = minZoom;
+  }
+
+  return {
+    ...state,
+    options: {
+      ...state.options,
+      zoom: newZoom
+    }
+  };
+};
+
+export default {
+  setLayerSpecLoading,
+  setLayerSpec,
+  setMapOptions,
+  setMapZoom,
+  setShowMapMobile
+};

--- a/app/javascript/components/map-old/selectors.js
+++ b/app/javascript/components/map-old/selectors.js
@@ -1,0 +1,18 @@
+import { createSelector } from 'reselect';
+import isEmpty from 'lodash/isEmpty';
+
+// get list data
+const getLayerSlugs = state => state.layers || null;
+const getLayerSpec = state => state.layerSpec || null;
+
+// get lists selected
+export const getLayers = createSelector(
+  [getLayerSlugs, getLayerSpec],
+  (layers, layerSpec) => {
+    if (!layers || isEmpty(layers)) return null;
+    return layers.map(l => ({
+      slug: l,
+      ...layerSpec[l]
+    }));
+  }
+);

--- a/app/javascript/components/map-old/styles.scss
+++ b/app/javascript/components/map-old/styles.scss
@@ -1,0 +1,13 @@
+@import '~styles/settings.scss';
+
+.c-map {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background-color: #b3e2ff;
+}
+
+.map-loader {
+  z-index: 10;
+  background-color: rgba($slate, 0.2);
+}

--- a/app/javascript/components/ui/switch/switch-component.jsx
+++ b/app/javascript/components/ui/switch/switch-component.jsx
@@ -5,30 +5,23 @@ import Toggle from 'react-toggle';
 import './react-toggle.scss';
 import './switch-styles.scss';
 import './themes/switch-light.scss';
-import './themes/switch-toggle.scss';
 
 class Switch extends PureComponent {
   render() {
-    const { theme, label, options, onChange, checked } = this.props;
-    const icons = options
-      ? {
-        checked: options[0].label,
-        unchecked: options[1].label
-      }
-      : false;
-
+    const { theme, label, value, options, onChange } = this.props;
     return (
       <div className={`c-switch ${theme || ''}`}>
         {label && <div className="label">{label}</div>}
         <Toggle
-          icons={icons}
-          checked={checked}
+          icons={{
+            checked: options[0].label,
+            unchecked: options[1].label
+          }}
+          defaultChecked={options[1].value === value}
           onChange={e => {
-            let result = e.target.checked;
-            if (options) {
-              result = result ? options[1].value : options[0].value;
-            }
-
+            const result = e.target.checked
+              ? options[1].value
+              : options[0].value;
             onChange(result);
           }}
         />
@@ -40,7 +33,7 @@ class Switch extends PureComponent {
 Switch.propTypes = {
   theme: PropTypes.string,
   label: PropTypes.string,
-  checked: PropTypes.bool,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   options: PropTypes.array,
   onChange: PropTypes.func
 };

--- a/app/javascript/components/widgets/components/widget-settings/widget-settings-styles.scss
+++ b/app/javascript/components/widgets/components/widget-settings/widget-settings-styles.scss
@@ -33,6 +33,10 @@ $settings-items-margin: rem(25px);
     padding-top: rem(10px);
     font-size: 13px;
 
+    .label {
+      margin-right: rem(10px);
+    }
+
     .select-container {
       display: flex;
       flex-direction: row;
@@ -56,6 +60,7 @@ $settings-items-margin: rem(25px);
 
     .container {
       margin-bottom: 0;
+      max-width: rem(90px);
     }
 
     .dd__wrapper {

--- a/app/javascript/pages/dashboards/page/page-component.js
+++ b/app/javascript/pages/dashboards/page/page-component.js
@@ -11,8 +11,8 @@ import DatasetsProvider from 'providers/datasets-provider';
 import Meta from 'components/meta';
 import Widgets from 'components/widgets';
 import Share from 'components/modals/share';
-import Map from 'components/map';
-import MapControls from 'components/map/components/map-controls';
+import Map from 'components/map-old';
+import MapControls from 'components/map-old/components/map-controls';
 import SubNavMenu from 'components/subnav-menu';
 import Button from 'components/ui/button';
 import Icon from 'components/ui/icon';
@@ -33,6 +33,7 @@ class Page extends PureComponent {
       isGeostoreLoading,
       widgetAnchor,
       activeWidget,
+      setMapZoom,
       widgets,
       title,
       payload,
@@ -88,6 +89,8 @@ class Page extends PureComponent {
               enabled: true,
               top: window.innerWidth >= SCREEN_MOBILE ? 15 : 73
             }}
+            handleZoomIn={() => setMapZoom({ sum: 1 })}
+            handleZoomOut={() => setMapZoom({ sum: -1 })}
           />
         )}
         <Share />
@@ -117,7 +120,8 @@ Page.propTypes = {
   activeWidget: PropTypes.string,
   title: PropTypes.string,
   payload: PropTypes.object,
-  query: PropTypes.object
+  query: PropTypes.object,
+  setMapZoom: PropTypes.func
 };
 
 export default Page;

--- a/app/javascript/pages/dashboards/page/page-component.js
+++ b/app/javascript/pages/dashboards/page/page-component.js
@@ -7,6 +7,7 @@ import CountryDataProvider from 'providers/country-data-provider';
 import WhitelistsProvider from 'providers/whitelists-provider';
 import LayerSpecProvider from 'providers/layerspec-provider';
 import DatasetsProvider from 'providers/datasets-provider';
+import GeostoreProvider from 'providers/geostore-provider';
 
 import Meta from 'components/meta';
 import Widgets from 'components/widgets';
@@ -100,6 +101,7 @@ class Page extends PureComponent {
         <WhitelistsProvider />
         <LayerSpecProvider />
         <DatasetsProvider />
+        <GeostoreProvider />
         <Meta
           title={title}
           description="Data about forest change, tenure, forest related employment and land use in"

--- a/app/javascript/pages/dashboards/page/page.js
+++ b/app/javascript/pages/dashboards/page/page.js
@@ -4,7 +4,7 @@ import replace from 'lodash/replace';
 import CATEGORIES from 'data/categories.json';
 
 import { filterWidgets } from 'components/widgets/selectors';
-import mapActions from 'components/map/map-actions';
+import mapActions from 'components/map-old/actions';
 
 import * as ownActions from './page-actions';
 import reducers, { initialState } from './page-reducers';

--- a/app/javascript/pages/dashboards/reducers.js
+++ b/app/javascript/pages/dashboards/reducers.js
@@ -13,6 +13,7 @@ import * as HeaderComponent from 'pages/dashboards/header';
 import * as ShareComponent from 'components/modals/share';
 import * as ModalMetaComponent from 'components/modals/meta';
 import * as WidgetsComponent from 'components/widgets';
+import * as MapComponent from 'components/map-old';
 
 // Providers
 import * as countryDataProviderComponent from 'providers/country-data-provider';
@@ -30,7 +31,8 @@ const componentsReducers = {
   share: handleActions(ShareComponent),
   modalMeta: handleActions(ModalMetaComponent),
   header: handleActions(HeaderComponent),
-  widgets: handleActions(WidgetsComponent)
+  widgets: handleActions(WidgetsComponent),
+  map: handleActions(MapComponent)
 };
 
 // Provider Reducers

--- a/app/javascript/pages/dashboards/reducers.js
+++ b/app/javascript/pages/dashboards/reducers.js
@@ -20,6 +20,7 @@ import * as countryDataProviderComponent from 'providers/country-data-provider';
 import * as whitelistsProviderComponent from 'providers/whitelists-provider';
 import * as layerSpecProviderComponent from 'providers/layerspec-provider';
 import * as datasetsProviderComponent from 'providers/datasets-provider';
+import * as geostoreProviderComponent from 'providers/geostore-provider';
 
 // Page Reducers
 const pageReducers = {
@@ -40,7 +41,8 @@ const providersReducers = {
   countryData: handleActions(countryDataProviderComponent),
   whitelists: handleActions(whitelistsProviderComponent),
   layerSpec: handleActions(layerSpecProviderComponent),
-  datasets: handleActions(datasetsProviderComponent)
+  datasets: handleActions(datasetsProviderComponent),
+  geostore: handleActions(geostoreProviderComponent)
 };
 
 export default combineReducers({

--- a/app/javascript/providers/geostore-provider/actions.js
+++ b/app/javascript/providers/geostore-provider/actions.js
@@ -3,6 +3,8 @@ import { createThunkAction } from 'utils/redux';
 
 import { getGeostoreProvider } from 'services/geostore';
 
+import BOUNDS from 'data/bounds.json';
+
 export const setGeostoreLoading = createAction('setGeostoreLoading');
 export const setGeostore = createAction('setGeostore');
 
@@ -15,7 +17,12 @@ export const getGeostore = createThunkAction(
         .then(response => {
           const { data } = response.data;
           if (data && data.attributes) {
-            dispatch(setGeostore({ ...data.attributes }));
+            dispatch(
+              setGeostore({
+                ...data.attributes,
+                bounds: getBoxBounds(data.attributes.bbox, country, region)
+              })
+            );
           }
           dispatch(setGeostoreLoading(false));
         })
@@ -26,3 +33,16 @@ export const getGeostore = createThunkAction(
     }
   }
 );
+
+const getBoxBounds = (cornerBounds, country, region) => {
+  if (!region && Object.keys(BOUNDS).includes(country)) {
+    return BOUNDS[country];
+  }
+  return [
+    [cornerBounds[0], cornerBounds[1]],
+    [cornerBounds[0], cornerBounds[3]],
+    [cornerBounds[2], cornerBounds[3]],
+    [cornerBounds[2], cornerBounds[1]],
+    [cornerBounds[0], cornerBounds[1]]
+  ];
+};

--- a/app/views/shared/_google_carto.html.erb
+++ b/app/views/shared/_google_carto.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_include_tag "//maps.googleapis.com/maps/api/js?libraries=places,visualization,drawing&key=#{ENV['GOOGLE_MAPS_API_KEY']}&v=3.31" %>
+<%= javascript_include_tag "//maps.googleapis.com/maps/api/js?libraries=places,visualization,drawing&key=#{ENV['GOOGLE_MAPS_API_KEY']}&v=3.34" %>
 <%= javascript_include_tag "https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15.8/cartodb.js" %>
 <%= javascript_include_tag "https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.mod.torque.js" %>
 <%= stylesheet_link_tag "https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css", :media => 'all' %>


### PR DESCRIPTION
After many updates to the new map it had broken the map in the dashboards. As we aren't certain exactly how we are going to integrate the two and what feature we want on the dashboards with the new map I have rolled the dashboards map back (now `map-old` inside the react components. This means we can build the new as we like and not have to worry about version v3 affecting production when we release the demo.

- Add `map-old`
- Integrate new Geostore provider back into old map
- Fix some small bugs in the widget settings menu

This also allows us to put the new map on staging without any risk off affecting external pages.