### PR TITLE
Fix: widget settings not closing in firefox

### DIFF
--- a/app/javascript/components/ui/with-tooltip-evt/component.jsx
+++ b/app/javascript/components/ui/with-tooltip-evt/component.jsx
@@ -1,0 +1,33 @@
+import React, { PureComponent } from 'react';
+
+const withTooltipEvt = Component => {
+  class TooltipContent extends PureComponent {
+    evt = null;
+
+    clearEvt() {
+      this.evt = null;
+    }
+
+    setEvt = e => {
+      e.persist();
+      this.evt = e.target;
+    };
+
+    getTooltipContentProps = () => ({
+      onClickCapture: this.setEvt
+    });
+
+    render() {
+      return (
+        <Component
+          {...this.props}
+          getTooltipContentProps={this.getTooltipContentProps}
+        />
+      );
+    }
+  }
+
+  return TooltipContent;
+};
+
+export default withTooltipEvt;

--- a/app/javascript/components/ui/with-tooltip-evt/index.js
+++ b/app/javascript/components/ui/with-tooltip-evt/index.js
@@ -1,0 +1,3 @@
+import Component from './component';
+
+export default Component;

--- a/app/javascript/components/widgets/components/widget-header/widget-header-component.js
+++ b/app/javascript/components/widgets/components/widget-header/widget-header-component.js
@@ -108,8 +108,10 @@ class WidgetHeader extends PureComponent {
                 onRequestClose={() => {
                   const isTargetOnTooltip = isParent(
                     this.widgetSettingsRef,
-                    window.event.path
+                    this.widgetSettingsRef.evt
                   );
+                  this.widgetSettingsRef.clearEvt();
+
                   if (!modalClosing && !isTargetOnTooltip) {
                     this.setState({ tooltipOpen: false });
                   }

--- a/app/javascript/components/widgets/components/widget-settings/widget-settings-component.jsx
+++ b/app/javascript/components/widgets/components/widget-settings/widget-settings-component.jsx
@@ -4,6 +4,7 @@ import isEmpty from 'lodash/isEmpty';
 
 import Dropdown from 'components/ui/dropdown';
 import Switch from 'components/ui/switch';
+import withTooltipEvt from 'components/ui/with-tooltip-evt';
 
 import './widget-settings-styles.scss';
 
@@ -104,7 +105,8 @@ class WidgetSettings extends PureComponent {
       loading,
       onSettingsChange,
       widget,
-      setModalMeta
+      setModalMeta,
+      getTooltipContentProps
     } = this.props;
     const {
       units,
@@ -133,7 +135,7 @@ class WidgetSettings extends PureComponent {
       datasets;
 
     return (
-      <div className="c-widget-settings">
+      <div className="c-widget-settings" {...getTooltipContentProps()}>
         {(!isEmpty(forestTypes) || !isEmpty(landCategories)) && (
           <div className="intersections">
             {!isEmpty(forestTypes) && (
@@ -351,7 +353,8 @@ WidgetSettings.propTypes = {
   options: PropTypes.object,
   onSettingsChange: PropTypes.func,
   widget: PropTypes.string,
-  setModalMeta: PropTypes.func
+  setModalMeta: PropTypes.func,
+  getTooltipContentProps: PropTypes.func.isRequired
 };
 
-export default WidgetSettings;
+export default withTooltipEvt(WidgetSettings);

--- a/app/javascript/utils/dom.js
+++ b/app/javascript/utils/dom.js
@@ -1,7 +1,8 @@
 import ReactDOM from 'react-dom';
 
-export const isParent = (node, parents) => {
-  const possibleParent = ReactDOM.findDOMNode(node);
-  const haveParent = parents.filter(el => el === possibleParent);
-  return haveParent.length !== 0;
+export const isParent = (node, target) => {
+  if (!target) return false;
+  const parent = ReactDOM.findDOMNode(node);
+  const hasParent = parent.contains(target);
+  return !hasParent;
 };


### PR DESCRIPTION
The widget settings menu wouldnt close in firefox due to `window.event` being undefined. 

Solution: create high order component to wrap the tooltip and pass the children click event to the requesutCloseFunc. Simple ey?!