### PR TITLE
move setInteraction events for layers to the layer manager layers com…

### DIFF
--- a/app/javascript/components/map/map-component.js
+++ b/app/javascript/components/map/map-component.js
@@ -1,10 +1,12 @@
 import React, { PureComponent, Fragment } from 'react';
 import PropTypes from 'prop-types';
+import isEmpty from 'lodash/isEmpty';
+
 import Map from 'wri-api-components/dist/map';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { DragDropContextProvider } from 'react-dnd';
 
-import { LayerManager } from 'layer-manager/dist/react';
+import { LayerManager, Layer } from 'layer-manager/dist/react';
 import { PluginLeaflet } from 'layer-manager';
 
 import Loader from 'components/ui/loader';
@@ -33,7 +35,8 @@ class MapComponent extends PureComponent {
       label,
       setMapSettings,
       bbox,
-      recentImagery
+      recentImagery,
+      setInteraction
     } = this.props;
     return (
       <Fragment>
@@ -57,11 +60,32 @@ class MapComponent extends PureComponent {
         >
           {map => (
             <Fragment>
-              <LayerManager
-                map={map}
-                plugin={PluginLeaflet}
-                layersSpec={activeLayers}
-              />
+              <LayerManager map={map} plugin={PluginLeaflet}>
+                {activeLayers.map(l => {
+                  const { interactionConfig } = l;
+                  const { output, article } = interactionConfig || {};
+                  const layer = {
+                    ...l,
+                    ...(!isEmpty(output) && {
+                      interactivity: output.map(i => i.column),
+                      events: {
+                        click: e => {
+                          setInteraction({
+                            ...e,
+                            label: l.name,
+                            article,
+                            id: l.id,
+                            value: l.id,
+                            config: output
+                          });
+                        }
+                      }
+                    })
+                  };
+
+                  return <Layer key={l.id} {...layer} />;
+                })}
+              </LayerManager>
               <Popup map={map} />
               <MapControlButtons className="map-controls" map={map} share />
               {recentImagery && (
@@ -92,6 +116,7 @@ MapComponent.propTypes = {
   basemap: PropTypes.object,
   label: PropTypes.object,
   setMapSettings: PropTypes.func,
+  setInteraction: PropTypes.func,
   bbox: PropTypes.object,
   recentImagery: PropTypes.bool
 };

--- a/app/javascript/components/map/map.js
+++ b/app/javascript/components/map/map.js
@@ -1,10 +1,16 @@
 import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
-// import PropTypes from 'prop-types';
 
 import MapComponent from './map-component';
-import actions from './map-actions';
 import { getMapProps } from './map-selectors';
+
+import { setInteraction } from './components/popup/actions';
+import ownActions from './map-actions';
+
+const actions = {
+  setInteraction,
+  ...ownActions
+};
 
 const mapStateToProps = ({ location, datasets, geostore, latest }) => ({
   ...getMapProps({

--- a/app/javascript/providers/datasets-provider/datasets-provider-actions.js
+++ b/app/javascript/providers/datasets-provider/datasets-provider-actions.js
@@ -1,10 +1,8 @@
 import { createAction } from 'redux-actions';
 import { createThunkAction } from 'utils/redux';
 import wriAPISerializer from 'wri-json-api-serializer';
-import isEmpty from 'lodash/isEmpty';
 
 import { getDatasetsProvider } from 'services/datasets';
-import { setInteraction } from 'components/map/components/popup/actions';
 
 export const setDatasetsLoading = createAction('setDatasetsLoading');
 export const setDatasets = createAction('setDatasets');
@@ -25,36 +23,7 @@ export const getDatasets = createThunkAction(
         if (!Array.isArray(datasets)) {
           datasets = [datasets];
         }
-
-        datasets = datasets.filter(d => d.layer.length).map(d => ({
-          ...d,
-          dataset: d.id,
-          layer: d.layer.map(l => {
-            const { interactionConfig } = l;
-            const { output, article } = interactionConfig || {};
-            return {
-              ...l,
-              ...(!isEmpty(output) && {
-                interactivity: output.map(i => i.column),
-                events: {
-                  click: e => {
-                    dispatch(
-                      setInteraction({
-                        ...e,
-                        label: l.name,
-                        article,
-                        id: l.id,
-                        value: l.id,
-                        config: output
-                      })
-                    );
-                  }
-                }
-              })
-            };
-          })
-        }));
-        dispatch(setDatasets(datasets));
+        dispatch(setDatasets(datasets.filter(d => d.layer.length)));
       })
       .catch(err => {
         dispatch(setDatasetsLoading({ loading: false, error: true }));


### PR DESCRIPTION
I was wrong. Time to make GFW datasets provider actions dispatch to state function great again.

This moves the interaction events setting to the layer manager layer component