### PR TITLE
[ANALYSIS] Fix adm2 geostore fetch

### DIFF
--- a/app/assets/javascripts/map/presenters/tabs/AnalysisNewPresenter.js
+++ b/app/assets/javascripts/map/presenters/tabs/AnalysisNewPresenter.js
@@ -857,7 +857,11 @@ define(
           var iso = this.status.get('iso');
           // Send request to the Analysis Service
           if (iso && iso.subRegion) {
-            GeostoreService.iso(iso)
+            GeostoreService.iso({
+              country: iso.country,
+              region: iso.region,
+              subRegion: iso.subRegion
+            })
               .then(
                 function(geostoreId) {
                   this.status.set('useGeostore', geostoreId);

--- a/app/assets/javascripts/map/services/GeostoreService.js
+++ b/app/assets/javascripts/map/services/GeostoreService.js
@@ -13,9 +13,12 @@ define(['Class', 'uri', 'bluebird', 'map/services/DataService'], function(
 
   var URL = window.gfw.config.GFW_API + '/geostore/{id}';
   var USE_URL = window.gfw.config.GFW_API + '/geostore/use/{use}/{useid}';
-  var COUNTRY_URL =
+  var COUNTRY_URL = window.gfw.config.GFW_API + '/v2/geostore/admin/{country}';
+  var REGION_URL =
+    window.gfw.config.GFW_API + '/v2/geostore/admin/{country}/{region}';
+  var SUBREGION_URL =
     window.gfw.config.GFW_API +
-    '/geostore/admin/{country}{?/region}{?/subRegion}';
+    '/v2/geostore/admin/{country}/{region}/{subRegion}';
 
   var GeostoreService = Class.extend({
     get: function(id) {
@@ -65,11 +68,23 @@ define(['Class', 'uri', 'bluebird', 'map/services/DataService'], function(
 
     iso: function(iso) {
       return new Promise(function(resolve, reject) {
-        var url = new UriTemplate(COUNTRY_URL).fillFromObject({
-          country: iso.country,
-          region: iso.region,
-          subRegion: iso.subRegion
-        });
+        var url = '';
+        if (iso.country && iso.region && iso.subRegion) {
+          url = new UriTemplate(SUBREGION_URL).fillFromObject({
+            country: iso.country,
+            region: iso.region,
+            subRegion: iso.subRegion
+          });
+        } else if (iso.country && iso.region && !iso.subRegion) {
+          url = new UriTemplate(REGION_URL).fillFromObject({
+            country: iso.country,
+            region: iso.region
+          });
+        } else if (iso.country && !iso.region && !iso.subRegion) {
+          url = new UriTemplate(COUNTRY_URL).fillFromObject({
+            country: iso.country
+          });
+        }
 
         ds.define(GET_ISO_REQUEST_ID, {
           cache: false,


### PR DESCRIPTION
## Overview

VIIRS was using the ISO shape when analysing adm2 regions.

# Testing

Please test that this does not break other adm2 analyses (looks good to me so far)