### PR TITLE
check for env key for datasets

### DIFF
--- a/app/javascript/pages/map/components/menu/menu-selectors.js
+++ b/app/javascript/pages/map/components/menu/menu-selectors.js
@@ -125,8 +125,13 @@ export const getDatasetSections = createSelector(
 );
 
 export const getDatasetSectionsWithData = createSelector(
-  [getDatasetSections, getActiveDatasetsState, getDatasetCategory],
-  (sections, activeDatasets, datasetCategory) => {
+  [
+    getDatasetSections,
+    getActiveDatasetsState,
+    getDatasetCategory,
+    getMenuSection
+  ],
+  (sections, activeDatasets, datasetCategory, menuSection) => {
     if (!activeDatasets) return sections;
     const datasetIds = activeDatasets.map(d => d.dataset);
 
@@ -134,7 +139,7 @@ export const getDatasetSectionsWithData = createSelector(
       const { datasets, subCategories } = s;
       return {
         ...s,
-        active: datasetCategory === s.category,
+        active: datasetCategory === s.category && menuSection === s.slug,
         layerCount:
           datasets &&
           datasets.filter(d => activeDatasets && datasetIds.includes(d.id))

--- a/app/javascript/providers/datasets-provider/datasets-provider-actions.js
+++ b/app/javascript/providers/datasets-provider/datasets-provider-actions.js
@@ -64,7 +64,9 @@ export const getDatasets = createThunkAction('getDatasets', () => dispatch => {
         }, {});
 
         const parsedDatasets = serializedDatasets
-          .filter(d => d.env === 'production')
+          .filter(
+            d => d.env === 'production' || d.env === process.env.FEATURE_ENV
+          )
           .map(d => {
             const { layer, metadata } = d;
             const appMeta =
@@ -74,7 +76,8 @@ export const getDatasets = createThunkAction('getDatasets', () => dispatch => {
               (layer &&
                 layer.find(
                   l =>
-                    l.env === 'production' &&
+                    (l.env === 'production' ||
+                      l.env === process.env.FEATURE_ENV) &&
                     l.applicationConfig &&
                     l.applicationConfig.default
                 )) ||
@@ -127,7 +130,12 @@ export const getDatasets = createThunkAction('getDatasets', () => dispatch => {
                 layer &&
                 sortBy(
                   layer
-                    .filter(l => l.env === 'production' && l.published)
+                    .filter(
+                      l =>
+                        (l.env === 'production' ||
+                          l.env === process.env.FEATURE_ENV) &&
+                        l.published
+                    )
                     .map((l, i) => {
                       const { layerConfig } = l;
                       const { position, confirmedOnly, multiConfig } =

--- a/app/javascript/services/analysis.js
+++ b/app/javascript/services/analysis.js
@@ -39,19 +39,19 @@ const buildAnalysisUrl = ({
 
   const queryParams = hasParams
     ? qs.stringify({
-        ...(period && {
-          period
-        }),
-        ...(thresh && {
-          thresh
-        }),
-        ...(geostore && {
-          geostore
-        }),
-        ...(query && {
-          [query.param]: query.value
-        })
+      ...(period && {
+        period
+      }),
+      ...(thresh && {
+        thresh
+      }),
+      ...(geostore && {
+        geostore
+      }),
+      ...(query && {
+        [query.param]: query.value
       })
+    })
     : '';
 
   return urlTemplate

--- a/app/javascript/services/datasets.js
+++ b/app/javascript/services/datasets.js
@@ -6,7 +6,6 @@ export const getDatasetsProvider = () =>
   request.get(
     `${
       REQUEST_URL
-    }/dataset?application=gfw&includes=metadata,vocabulary,layer&page[size]=9999&hash=${
-      process.env.API_CACHE
-    }`
+    }/dataset?application=gfw&includes=metadata,vocabulary,layer&page[size]=9999&hash=${process
+      .env.API_CACHE || new Date()}`
   );


### PR DESCRIPTION
Extends filtering for datasets in the dataset provider to compare the FEATURE_ENV key against the layers`env` key from the API. This allows us to have staging layers on staging.