### PR TITLE
Catch 500s in latest responses

### DIFF
--- a/app/javascript/services/alerts.js
+++ b/app/javascript/services/alerts.js
@@ -1,4 +1,5 @@
 import request from 'utils/request';
+import moment from 'moment';
 import { getIndicator } from 'utils/strings';
 
 const REQUEST_URL = process.env.GFW_API;
@@ -23,9 +24,7 @@ const getLocationQuery = (adm0, adm1, adm2) =>
   `${adm0}${adm1 ? `/${adm1}` : ''}${adm2 ? `/${adm2}` : ''}`;
 
 const getLocation = (adm0, adm1, adm2) =>
-  `iso = '${adm0}'${adm1 ? ` AND adm1 = ${adm1}` : ''}${
-    adm2 ? ` AND adm2 = ${adm2}` : ''
-  }`;
+  `iso = '${adm0}'${adm1 ? ` AND adm1 = ${adm1}` : ''}${adm2 ? ` AND adm2 = ${adm2}` : ''}`;
 
 export const fetchGladAlerts = ({ adm0, adm1, adm2 }) => {
   let glad_summary_table = GLAD_ISO_DATASET;
@@ -34,9 +33,7 @@ export const fetchGladAlerts = ({ adm0, adm1, adm2 }) => {
   } else if (adm1) {
     glad_summary_table = GLAD_ADM1_DATASET;
   }
-  const url = `${REQUEST_URL}/query/${glad_summary_table}?sql=${
-    QUERIES.gladIntersectionAlerts
-  }`
+  const url = `${REQUEST_URL}/query/${glad_summary_table}?sql=${QUERIES.gladIntersectionAlerts}`
     .replace('{location}', getLocation(adm0, adm1, adm2))
     .replace('{polyname}', 'admin');
   return request.get(url, 3600, 'gladRequest');
@@ -48,9 +45,7 @@ export const fetchGladIntersectionAlerts = ({
   forestType,
   landCategory
 }) => {
-  const url = `${REQUEST_URL}/query/${
-    adm1 ? GLAD_ADM2_DATASET : GLAD_ADM1_DATASET
-  }?sql=${QUERIES.gladIntersectionAlerts}`
+  const url = `${REQUEST_URL}/query/${adm1 ? GLAD_ADM2_DATASET : GLAD_ADM1_DATASET}?sql=${QUERIES.gladIntersectionAlerts}`
     .replace('{location}', getLocation(adm0, adm1))
     .replace('{polyname}', getIndicator(forestType, landCategory));
   return request.get(url, 3600, 'gladRequest');
@@ -63,9 +58,7 @@ export const fetchFiresAlerts = ({ adm0, adm1, adm2, dataset }) => {
   } else if (adm1) {
     fires_summary_table = FIRES_ADM1_DATASET;
   }
-  const url = `${REQUEST_URL}/query/${fires_summary_table}?sql=${
-    QUERIES.firesIntersectionAlerts
-  }`
+  const url = `${REQUEST_URL}/query/${fires_summary_table}?sql=${QUERIES.firesIntersectionAlerts}`
     .replace('{location}', getLocation(adm0, adm1, adm2))
     .replace('{polyname}', 'admin')
     .replace('{dataset}', dataset);
@@ -73,46 +66,132 @@ export const fetchFiresAlerts = ({ adm0, adm1, adm2, dataset }) => {
 };
 
 export const fetchViirsAlerts = ({ adm0, adm1, adm2, dates }) => {
-  const url = `${REQUEST_URL}/viirs-active-fires/${!adm2 ? 'admin/' : ''}${
-    QUERIES.viirsAlerts
-  }`
+  const url = `${REQUEST_URL}/viirs-active-fires/${!adm2 ? 'admin/' : ''}${QUERIES.viirsAlerts}`
     .replace('{location}', !adm2 ? getLocationQuery(adm0, adm1, adm2) : '')
     .replace('{period}', `${dates[1]},${dates[0]}`);
   return request.get(url);
 };
 
 export const fetchFiresStats = ({ adm0, adm1, adm2, dates }) => {
-  const url = `${REQUEST_URL}/fire-alerts/summary-stats/admin/${
-    QUERIES.firesStats
-  }`
+  const url = `${REQUEST_URL}/fire-alerts/summary-stats/admin/${QUERIES.firesStats}`
     .replace('{location}', getLocationQuery(adm0, adm1, adm2))
     .replace('{period}', `${dates[1]},${dates[0]}`);
   return request.get(url);
 };
 
 // Latest Dates for Alerts
+const lastFriday = moment().day(-2).format('YYYY-MM-DD');
 
 export const fetchGLADLatest = () => {
   const url = `${REQUEST_URL}/glad-alerts/latest`;
-  return request.get(url, 3600, 'gladRequest');
+  return request
+    .get(url, 3600, 'gladRequest')
+    .catch((error) => {
+      console.log('Error in gladRequest:', error);
+      return new Promise(
+        (resolve) => resolve({
+          data: {
+            data: [
+              {
+                attributes:
+                  { date: lastFriday },
+                id: null,
+                type: 'glad-alerts'
+              }
+            ]
+          }
+        })
+      );
+    });
 };
 
 export const fetchFormaLatest = () => {
   const url = `${REQUEST_URL}/forma250gfw/latest`;
-  return request.get(url, 3600, 'formaRequest');
+  return request
+    .get(url, 3600, 'formaRequest')
+    .catch((error) => {
+      console.log('Error in formaRequest:', error);
+      return new Promise(
+        (resolve) => resolve({
+          data: {
+            data: {
+              attributes: {
+                latest: lastFriday
+              },
+              id: null,
+              type: 'forma250gfw'
+            }
+          }
+        })
+      );
+    });
 };
 
 export const fetchTerraiLatest = () => {
   const url = `${REQUEST_URL}/terrai-alerts/latest`;
-  return request.get(url, 3600, 'terraRequest');
+  return request
+    .get(url, 3600, 'terraRequest')
+    .catch((error) => {
+      console.log('Error in terraRequest:', error);
+      return new Promise(
+        (resolve) => resolve({
+          data: {
+            data: [
+              {
+                attributes:
+                  { date: lastFriday },
+                id: null,
+                type: 'terrai-alerts'
+              }
+            ]
+          }
+        })
+      );
+    });
 };
 
 export const fetchSADLatest = () => {
   const url = `${REQUEST_URL}/v2/imazon-alerts/latest`;
-  return request.get(url, 3600, 'sadRequest');
+  return request
+    .get(url, 3600, 'sadRequest')
+    .catch((error) => {
+      console.log('Error in sadRequest:', error);
+      return new Promise(
+        (resolve) => resolve({
+          data: {
+            data: [
+              {
+                attributes:
+                  { latest: `${lastFriday}T00:00:00Z` },
+                id: undefined,
+                type: 'imazon-latest'
+              }
+            ]
+          }
+        })
+      );
+    });
 };
 
 export const fetchGranChacoLatest = () => {
   const url = `${REQUEST_URL}/v2/guira-loss/latest`;
-  return request.get(url, 3600, 'granChacoRequest');
+  return request
+    .get(url, 3600, 'granChacoRequest')
+    .catch((error) => {
+      console.log('Error in granChacoRequest:', error);
+      return new Promise(
+        (resolve) => resolve({
+          data: {
+            data: [
+              {
+                attributes:
+                  { latest: `${lastFriday}T00:00:00Z` },
+                id: undefined,
+                type: 'imazon-latest'
+              }
+            ]
+          }
+        })
+      );
+    });
 };


### PR DESCRIPTION
## Overview

Firstly. Great detective work @blayhem 👏.

Catches errors in `/latest` endpoint responses and replaces with a template of the expected response object.

This object by default sets the latest date to the previous friday (`moment().day(-2)`) in the correct format... friday as this should be the last time the data was updated.

