### PR TITLE
Indonesia Header

### DIFF
--- a/app/javascript/pages/dashboards/header/header-reducers.js
+++ b/app/javascript/pages/dashboards/header/header-reducers.js
@@ -15,7 +15,7 @@ export const initialState = {
       withPlantationLoss:
         'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {loss} of natural forest',
       indoInitial:
-        'In 2010, {location} had {naturalForest} of natural forest, extending over {percentageNatForest} of its land area. In {year}, it lost {treeCoverLoss} of tree cover, equivalent to {emissionsTreeCover} of CO₂ of emissions. {primaryLoss} of this loss occurred within intact and degraded primary forests and {loss} within natural forest.',
+        'In 2010, {location} had {naturalForest} of natural forest, extending over {percentageNatForest} of its land area. In {year}, it lost {loss} of tree cover, equivalent to {emissionsTreeCover} of CO₂ of emissions. {primaryLoss} of this loss occurred within intact and degraded primary forests and {loss} within natural forest.',
       co2Emissions: ', equivalent to {emission} of CO\u2082 of emissions.',
       end: '.'
     }

--- a/app/javascript/pages/dashboards/header/header-selectors.js
+++ b/app/javascript/pages/dashboards/header/header-selectors.js
@@ -142,7 +142,7 @@ export const getSentence = createSelector(
       emission: `${emissionsWithoutPlantations}t`,
       emissionsTreeCover: `${emissions}t`,
       year: data.totalLoss.year,
-      treeCoverLoss: loss,
+      treeCoverLoss: `${loss}ha`,
       primaryLoss
     };
 


### PR DESCRIPTION
## Overview

Fixes this 👇 

<img width="774" alt="screen shot 2018-11-21 at 18 10 21" src="https://user-images.githubusercontent.com/30242314/48857249-b585a480-edb8-11e8-9769-e2fc50ef6c99.png">

Note missing 'ha' units. The calculation is also off (referencing the wrong value).

Calculation should now be 1.25Mha to match the loss in 2017 in the natural forest loss widget on the Forest Change tab.

# Testing

This number (..._it lost 1.30M of tree cover..._):

<img width="376" alt="screen shot 2018-11-21 at 18 13 35" src="https://user-images.githubusercontent.com/30242314/48857500-51afab80-edb9-11e8-91fc-3574b502089c.png">

...should match this number (_Natural forest 1.25Mha_):

<img width="771" alt="screen shot 2018-11-21 at 18 13 44" src="https://user-images.githubusercontent.com/30242314/48857510-56745f80-edb9-11e8-9538-2595fa0d978f.png">

for Indonesia, Brazil, Malaysia.





