### PR TITLE
Fix header keys for Indonesia

### DIFF
--- a/app/javascript/pages/dashboards/header/header-reducers.js
+++ b/app/javascript/pages/dashboards/header/header-reducers.js
@@ -15,7 +15,7 @@ export const initialState = {
       withPlantationLoss:
         'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {loss} of natural forest',
       indoInitial:
-        'In 2010, {location} had {naturalForest} of natural forest, extending over {percentageNatForest} of its land area. In {year}, it lost {loss} of tree cover, equivalent to {emissionsTreeCover} of CO₂ of emissions. {primaryLoss} of this loss occurred within intact and degraded primary forests and {loss} within natural forest.',
+        'In 2010, {location} had {naturalForest} of natural forest, extending over {percentageNatForest} of its land area. In {year}, it lost {loss} of tree cover, equivalent to {emissionsTreeCover} of CO₂ of emissions. {primaryLoss} of this loss occurred within intact and degraded primary forests and {naturalLoss} within natural forest.',
       co2Emissions: ', equivalent to {emission} of CO\u2082 of emissions.',
       end: '.'
     }

--- a/app/javascript/pages/dashboards/header/header-selectors.js
+++ b/app/javascript/pages/dashboards/header/header-selectors.js
@@ -138,12 +138,13 @@ export const getSentence = createSelector(
       location: location || 'the world',
       percentage: `${percentageCover}%`,
       percentageNatForest: `${percentageNatForest}%`,
-      loss: `${lossWithOutPlantations}ha`,
+      naturalLoss: `${lossWithOutPlantations}ha`,
+      loss: `${loss}ha`,
       emission: `${emissionsWithoutPlantations}t`,
       emissionsTreeCover: `${emissions}t`,
       year: data.totalLoss.year,
       treeCoverLoss: `${loss}ha`,
-      primaryLoss
+      primaryLoss: `${primaryLoss}ha`
     };
 
     let sentence = sentences.default;


### PR DESCRIPTION
## Overview

Puts naturalLoss, loss and primaryLoss keys in correct positions.

- loss should be equal to Loss widgets 2017 column
- primaryLoss should be equal to Loss widgets 2017 column with Primary forest selected
- naturalLoss should be equal to 2017 column of natural forest loss widget