### PR TITLE
Fix/search coords not centering

### DIFF
--- a/app/javascript/components/map-v2/component.jsx
+++ b/app/javascript/components/map-v2/component.jsx
@@ -135,7 +135,7 @@ class MapComponent extends PureComponent {
                         : {}
                     }
                     events={{
-                      move: handleMapMove
+                      moveend: handleMapMove
                     }}
                   >
                     {map => (

--- a/app/javascript/components/widgets/widgets/forest-change/fao-deforest/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/fao-deforest/selectors.js
@@ -61,7 +61,7 @@ export const parseSentence = createSelector(
       globalHuman
     } = sentences;
     const topFao = data.fao.filter(d => d.year === settings.period);
-    const { deforest, humdef } = topFao[0];
+    const { deforest, humdef } = topFao[0] || {};
     const totalDeforest = sumBy(data.rank, 'deforest');
     const rate = currentLabel === 'global' ? totalDeforest : deforest;
 

--- a/app/javascript/pages/map/components/menu/components/sections/search/components/coords/component.jsx
+++ b/app/javascript/pages/map/components/menu/components/sections/search/components/coords/component.jsx
@@ -43,13 +43,13 @@ class UTMCoords extends PureComponent {
     const lat = this.convertDMSToDD(
       parseInt(latDeg, 10),
       parseInt(latMin, 10),
-      parseInt(latSec, 10),
+      parseFloat(latSec),
       latCard
     );
     const lng = this.convertDMSToDD(
       parseInt(lngDeg, 10),
       parseInt(lngMin, 10),
-      parseInt(lngSec, 10),
+      parseFloat(lngSec),
       lngCard
     );
     if (validateLatLng(lat, lng)) {

--- a/app/javascript/pages/map/components/menu/components/sections/search/components/decimal-degrees/component.jsx
+++ b/app/javascript/pages/map/components/menu/components/sections/search/components/decimal-degrees/component.jsx
@@ -24,7 +24,7 @@ class DecimalDegreeSearch extends PureComponent {
     const { lat, lng } = this.state;
     const { setMapSettings } = this.props;
     setMapSettings({
-      center: { lat: parseInt(lat, 10), lng: parseInt(lng, 10) }
+      center: { lat: parseFloat(lat), lng: parseFloat(lng) }
     });
   };
 


### PR DESCRIPTION
## Overview

In the Search section of the map menu, when entering coordinates or decimal degrees and submitting the map was updating the center position of the map during the movement to the new desired location. This was causing the center values to be incorrect, and also requiring the user to continue submitting until they reached the correct location. See the pitoval task to access the videos: https://www.pivotaltracker.com/story/show/162083518.

Solution: use the leaflet event `moveend` instead of `move` to prevent updating the center early. Additionally floats were being parsed into floats (due to my own incompetence). Now float are floating correctly. 

## Testing

- go to map search
- enter coordinates (41°24'12.2"N 2°10'26.5"E) or decimal degrees (30.211, -16.3213) and submit.
- check that the bottom right component with lat long matches your search after a single submit.

