### PR TITLE
Update plantationsloss calc

### DIFF
--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-plantations/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-plantations/selectors.js
@@ -39,7 +39,7 @@ export const parseData = createSelector(
             ...d,
             outsideAreaLoss: totalLossForYear.area - summedPlatationsLoss,
             areaLoss: summedPlatationsLoss || 0,
-            totalLoss: totalLossForYear || 0,
+            totalLoss: totalLossForYear.area || 0,
             outsideCo2Loss:
               totalLossByYear[d.year][0].emissions - summedPlatationsEmissions,
             co2Loss: summedPlatationsEmissions || 0
@@ -104,7 +104,6 @@ export const parseSentence = createSelector(
       plantationsLoss > outsideLoss
         ? 100 * plantationsLoss / totalLoss
         : 100 * outsideLoss / totalLoss;
-
     const params = {
       location: locationName,
       startYear,


### PR DESCRIPTION
## Overview

There was one missing piece from the last update, was returning NaN in the plantations loss widget for 2017.

Now fixed, should look like this (with shown natural forest numbers matching):

<img width="784" alt="screen shot 2018-11-30 at 15 23 38" src="https://user-images.githubusercontent.com/30242314/49295244-9fad6900-f4b5-11e8-8c86-a486cee0810e.png">

<img width="751" alt="screen shot 2018-11-30 at 15 23 47" src="https://user-images.githubusercontent.com/30242314/49295245-9fad6900-f4b5-11e8-9283-45b658832bc3.png">

<img width="744" alt="screen shot 2018-11-30 at 15 34 27" src="https://user-images.githubusercontent.com/30242314/49295247-a045ff80-f4b5-11e8-8ef0-a3dd1924aa3b.png">

