### PR TITLE
Catch no plantations case in header

### DIFF
--- a/app/javascript/pages/dashboards/header/header-actions.js
+++ b/app/javascript/pages/dashboards/header/header-actions.js
@@ -50,19 +50,23 @@ export const getHeaderData = createThunkAction(
 
             // sum over different bound1 within year
             const summedPlantationsLoss =
-              latestPlantationLoss.length && latestPlantationLoss[0].area
+              latestPlantationLoss &&
+              latestPlantationLoss.length &&
+              latestPlantationLoss[0].area
                 ? sumBy(latestPlantationLoss, 'area')
                 : 0;
             const summedPlantationsEmissions =
-              latestPlantationLoss.length && latestPlantationLoss[0].emissions
+              latestPlantationLoss &&
+              latestPlantationLoss.length &&
+              latestPlantationLoss[0].emissions
                 ? sumBy(latestPlantationLoss, 'emissions')
                 : 0;
             const summedLoss =
-              latestLoss.length && latestLoss[0].area
+              latestLoss && latestLoss.length && latestLoss[0].area
                 ? sumBy(latestLoss, 'area')
                 : 0;
             const summedEmissions =
-              latestLoss.length && latestLoss[0].emissions
+              latestLoss && latestLoss.length && latestLoss[0].emissions
                 ? sumBy(latestLoss, 'emissions')
                 : 0;
 


### PR DESCRIPTION
## Overview

USA/ESP etc were failing to return a header sentence as we were expecting non-zero plantations loss.

Now catches these instances and returns 0 not null.

