### PR TITLE
Feature/widgets simplified for other platforms

### DIFF
--- a/app/javascript/app/layouts/root/component.jsx
+++ b/app/javascript/app/layouts/root/component.jsx
@@ -29,7 +29,7 @@ const PageComponent = universal(
 
 class App extends PureComponent {
   render() {
-    const { route, loggedIn, metadata } = this.props;
+    const { route, loggedIn, metadata, isGFW } = this.props;
     const { component, embed } = route;
     const isMapPage = component === 'map';
     return (
@@ -68,17 +68,18 @@ class App extends PureComponent {
               />
             </div>
             {!embed && <MyGFWProvider />}
-            {embed && (
-              <div className="embed-footer">
-                <p>For more info</p>
-                <Button
-                  className="embed-btn"
-                  extLink={window.location.href.replace('/embed', '')}
-                >
-                  EXPLORE ON GFW
-                </Button>
-              </div>
-            )}
+            {embed &&
+              !isGFW && (
+                <div className="embed-footer">
+                  <p>For more info</p>
+                  <Button
+                    className="embed-btn"
+                    extLink={window.location.href.replace('/embed', '')}
+                  >
+                    EXPLORE ON GFW
+                  </Button>
+                </div>
+              )}
             <Meta {...metadata} />
           </div>
         )}
@@ -90,6 +91,7 @@ class App extends PureComponent {
 App.propTypes = {
   route: PropTypes.object.isRequired,
   loggedIn: PropTypes.bool,
+  isGFW: PropTypes.bool,
   metadata: PropTypes.object
 };
 

--- a/app/javascript/app/layouts/root/selectors.js
+++ b/app/javascript/app/layouts/root/selectors.js
@@ -6,13 +6,18 @@ import { buildFullLocationName } from 'utils/format';
 
 const selectLoggedIn = state => !isEmpty(state.myGfw.data) || null;
 const selectLocation = state => state.location && state.location.payload;
+const selectQuery = state => state.location && state.location.query;
 const selectedCountries = state => state.countryData.countries;
 const selectedRegions = state => state.countryData.regions;
 const selectedSubRegion = state => state.countryData.subRegions;
 const selectPageLocation = state =>
   state.location && state.location.routesMap[state.location.type];
 
-// get lists selected
+export const getIsGFW = createSelector(
+  selectQuery,
+  query => query && query.gfw
+);
+
 export const getMetadata = createSelector(
   [
     selectPageLocation,
@@ -53,5 +58,6 @@ export const getMetadata = createSelector(
 export const getPageProps = createStructuredSelector({
   loggedIn: selectLoggedIn,
   route: selectPageLocation,
-  metadata: getMetadata
+  metadata: getMetadata,
+  isGFW: getIsGFW
 });

--- a/app/javascript/styles/base.scss
+++ b/app/javascript/styles/base.scss
@@ -8,7 +8,7 @@ body {
   line-height: 1.5;
   font-size: rem(18px);
   color: $slate;
-  background: $white;
+  background: transparent;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
## Overview

TRASE are wanting to put the GFW widgets within their dashboards. We had a couple of issues with styling that needed addressing to allow this:
- remove white background (transparent)
- allow widget embed footer to be removed with the param `gfw=true`
