### PR TITLE
Fix/format the latest fetched date for forma

### DIFF
--- a/app/javascript/components/maps/components/menu/components/sections/datasets/component.jsx
+++ b/app/javascript/components/maps/components/menu/components/sections/datasets/component.jsx
@@ -76,6 +76,7 @@ class Datasets extends PureComponent {
               </div>
               {countriesWithoutData &&
                 !!countriesWithoutData.length &&
+                selectedCountries &&
                 !!selectedCountries.length && (
                   <div className="no-datasets-legend">
                     <span className="legend-dot" />

--- a/app/javascript/components/maps/map/selectors.js
+++ b/app/javascript/components/maps/map/selectors.js
@@ -209,6 +209,10 @@ export const getDatasetsWithConfig = createSelector(
             id
           } = l;
           const maxDate = latestDates[id];
+          const { latestFormat } = l.params || {};
+          const maxDateFormatted = latestFormat
+            ? moment(maxDate).format(latestFormat)
+            : maxDate;
 
           return {
             ...l,
@@ -224,7 +228,10 @@ export const getDatasetsWithConfig = createSelector(
                   endDate: maxDate
                 }),
                 ...params,
-                ...(hasParamsTimeline && {
+                ...(maxDateFormatted && {
+                  date: maxDateFormatted
+                }),
+                ...((hasParamsTimeline || hasDecodeTimeline) && {
                   ...timelineParams
                 })
               }

--- a/app/javascript/providers/datasets-provider/datasets-utils.js
+++ b/app/javascript/providers/datasets-provider/datasets-utils.js
@@ -20,6 +20,10 @@ export const reduceParams = params => {
       ...(key === 'endDate' &&
         param.url && {
           latestUrl: param.url
+        }),
+      ...(key === 'date' &&
+        param.format && {
+          latestFormat: param.format
         })
     };
     return newObj;


### PR DESCRIPTION
The FORMA tiles template requires a latest date in the YYYYMMDD format (without -). This is an exception that hasn't been taken into account when passing the dynamically fetched date to the params for the layer manager.