### PR TITLE
Fix/only show perm separator statement when present

### DIFF
--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-tsc/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-tsc/selectors.js
@@ -158,10 +158,12 @@ export const parseConfig = createSelector(
         .reverse()
     );
     const insertIndex = findIndex(tooltip, { key: 'class_5' });
-    tooltip.splice(insertIndex, 0, {
-      key: 'break',
-      label: 'Drivers of permanent deforestation:'
-    });
+    if (insertIndex > -1) {
+      tooltip.splice(insertIndex, 0, {
+        key: 'break',
+        label: 'Drivers of permanent deforestation:'
+      });
+    }
     return {
       height: 250,
       xKey: 'year',


### PR DESCRIPTION
The TSC widget is showing the "permanent drivers of deforestations" statement in the tooltip when there are not any present due to not checking for it. This fixes it.

To test go to: http://localhost:5000/dashboards/country/IRN?treeLossTsc=eyJoaWdobGlnaHRlZCI6ZmFsc2UsInRzY0RyaXZlckdyb3VwIjoiYWxsIn0%3D&widget=treeLossTsc