### PR TITLE
Fix/redirect user to profile if empty

### DIFF
--- a/app/javascript/components/modals/subscribe/components/subscription-form/styles.scss
+++ b/app/javascript/components/modals/subscribe/components/subscription-form/styles.scss
@@ -13,6 +13,18 @@ $desktop-padding: rem(50px);
     }
   }
 
+  input {
+    height: rem(40px);
+    border: solid 1px $border;
+    padding: 0 rem(10px);
+    border-radius: rem(4px);
+    font-size: rem(14px);
+
+    &:focus {
+      outline: none;
+    }
+  }
+
   .save-subscription {
     display: flex;
     justify-content: flex-end;
@@ -29,6 +41,7 @@ $desktop-padding: rem(50px);
 
     .submit-btn {
       margin-left: rem(15px);
+      max-width: rem(290px);
       position: relative;
 
       &.error {

--- a/app/javascript/providers/mygfw-provider/actions.js
+++ b/app/javascript/providers/mygfw-provider/actions.js
@@ -9,13 +9,17 @@ export const checkLogged = createThunkAction('checkLogged', () => dispatch => {
   axios
     .get(`${process.env.GFW_API}/user`, { withCredentials: true })
     .then(response => {
-      if (response.status < 400) {
+      if (response.status < 400 && response.data && !!response.data.data) {
         dispatch(
           setMyGFW({
             ...response.data.data.attributes,
             id: response.data.data.id
           })
         );
+      }
+      // if profile info incomplete redirect to profile page
+      if (response.status < 400 && response.data && !response.data.data) {
+        window.location.replace('/my_gfw');
       }
     })
     .catch(() => {


### PR DESCRIPTION
When user logs in from the map for first time or if they haven't completed their profile the API returns empty user data. This means that we display the login form again.

To remedy this we check for empty profiles and then redirect them to their profile page if necessary.

Testing:
- create a new profile and you should be redirected (or delete info from your current one)
- test logging in with incomplete user when subscribing to an analysis (you should be redirected)
- complete profile info
- test logging in with complete user (you should not be redirected)