### PR TITLE
Fix/issues with recent imagery fetches

### DIFF
--- a/app/javascript/components/maps/main-map/components/recent-imagery/recent-imagery-actions.js
+++ b/app/javascript/components/maps/main-map/components/recent-imagery/recent-imagery-actions.js
@@ -66,7 +66,7 @@ export const getRecentImageryData = createThunkAction(
         })
         .catch(error => {
           dispatch(setRecentImageryLoading(false));
-          console.info(error && error.response);
+          console.info(error);
         });
     }
   }

--- a/app/javascript/components/maps/main-map/components/recent-imagery/recent-imagery.js
+++ b/app/javascript/components/maps/main-map/components/recent-imagery/recent-imagery.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 import debounce from 'lodash/debounce';
-import { checkLocationInsideBbox } from 'utils/geoms';
 import { CancelToken } from 'axios';
 import reducerRegistry from 'app/registry';
 
@@ -48,12 +47,12 @@ class RecentImageryContainer extends PureComponent {
       active,
       dataStatus,
       activeTile,
-      bounds,
       sources,
       dates,
       settings,
       getRecentImageryData,
       getMoreTiles,
+      positionInsideTile,
       position,
       loadingMoreTiles,
       resetRecentImageryData
@@ -63,15 +62,13 @@ class RecentImageryContainer extends PureComponent {
       activeTile &&
       !!activeTile.url &&
       (!prevProps.activeTile || activeTile.url !== prevProps.activeTile.url);
-    const positionInsideTile = bounds
-      ? checkLocationInsideBbox([position.lat, position.lng], bounds)
-      : true;
 
     // get data if activated or new props
     if (
       active &&
       (active !== prevProps.active ||
-        !positionInsideTile ||
+        (!positionInsideTile &&
+          !isEqual(positionInsideTile, prevProps.positionInsideTile)) ||
         !isEqual(settings.date, prevProps.settings.date) ||
         !isEqual(settings.weeks, prevProps.settings.weeks) ||
         !isEqual(settings.bands, prevProps.settings.bands))
@@ -90,8 +87,15 @@ class RecentImageryContainer extends PureComponent {
         token: this.getDataSource.token
       });
     }
+
     // get the rest of the tiles
-    if (dataStatus && !dataStatus.haveAllData && !loadingMoreTiles && active) {
+    if (
+      dataStatus &&
+      !dataStatus.haveAllData &&
+      !loadingMoreTiles &&
+      active &&
+      activeTile
+    ) {
       getMoreTiles({
         sources,
         dataStatus,
@@ -159,7 +163,7 @@ RecentImageryContainer.propTypes = {
   active: PropTypes.bool,
   dataStatus: PropTypes.object,
   activeTile: PropTypes.object,
-  bounds: PropTypes.array,
+  positionInsideTile: PropTypes.bool,
   sources: PropTypes.array,
   dates: PropTypes.object,
   settings: PropTypes.object,

--- a/app/javascript/components/ui/datepicker/datepicker-styles.scss
+++ b/app/javascript/components/ui/datepicker/datepicker-styles.scss
@@ -12,6 +12,10 @@
     font-size: 12px;
     cursor: pointer;
     color: $slate;
+
+    &:focus {
+      outline: none;
+    }
   }
 
   .react-datepicker__day-name {


### PR DESCRIPTION
We had two bugs:
1. We were sorting the tiles after the fetch before selecting the best tile from the front of the array causing the tile url never to be found
2. When moving the location of the center tile there wasnt an infinite loop created by not checking against previous props for `positionInsideTile` property.

These have been address and some small improvements to style.