### PR TITLE
Fixes value mismatch in sentence and graph axis label, and units issu…

### DIFF
--- a/app/javascript/components/charts/composed-chart/composed-chart-component.js
+++ b/app/javascript/components/charts/composed-chart/composed-chart-component.js
@@ -26,7 +26,17 @@ class CustomComposedChart extends PureComponent {
     const maxValues = [];
     Object.keys(yKeys).forEach(key => {
       Object.keys(yKeys[key]).forEach(subKey => {
-        const maxValue = maxBy(data, subKey);
+        const maxValue =
+          yKeys[key][subKey].stackId === 1
+            ? // Total sum of values if graph is a stacked bar chart
+            {
+              [subKey]: max(
+                data.map(d =>
+                  Object.keys(yKeys[key]).reduce((acc, k) => acc + d[k], 0)
+                )
+              )
+            }
+            : maxBy(data, subKey);
         if (maxValue) {
           maxValues.push(maxValue[subKey]);
         }

--- a/app/javascript/components/widgets/widgets/climate/future-carbon-gains/selectors.js
+++ b/app/javascript/components/widgets/widgets/climate/future-carbon-gains/selectors.js
@@ -20,7 +20,7 @@ export const parseData = createSelector(
       selectedData[key].forEach(obj => {
         years[obj.year] = {
           ...years[obj.year],
-          [key]: obj.value,
+          [key]: obj.value * 1000000,
           year: obj.year
         };
       })
@@ -51,13 +51,15 @@ export const parseConfig = createSelector(
       YSF: 'Young Secondary Forest',
       MASF: 'Mid-Age Secondary Forests'
     };
+    const unit = settings.unit === 'co2Gain' ? 'tCO₂' : 'tC';
+
     tooltip = tooltip.concat(
       Object.keys(selectedData)
         .map((k, i) => ({
           key: k,
           label: labels[k] ? labels[k] : k,
           color: colors.ramp && colors.ramp[i],
-          unit: 't',
+          unit,
           unitFormat: num => formatNumber({ num, unit: '' })
         }))
         .reverse()
@@ -71,6 +73,7 @@ export const parseConfig = createSelector(
       xAxis: {
         ticksFormatter: yearTicksFormatter
       },
+      unit,
       tooltip
     };
   }
@@ -96,7 +99,7 @@ export const parseSentence = createSelector(
       sentence: initial,
       params: {
         location,
-        amount: formatNumber({ num: amount * 1000000, unit: 't' }),
+        amount: formatNumber({ num: amount, unit: 't' }),
         variable,
         maxYear: maxYear.year
       }


### PR DESCRIPTION
## Overview

Units in the graph (Y axis) and sentence are now consistent. Plus, the axis only shows the unit in the top tick.

<img width="662" alt="image" src="https://user-images.githubusercontent.com/7013170/51978908-e6a2e500-248b-11e9-9f2a-190d1fd4dc89.png">


