### PR TITLE
Fixed mixed http/https in climate indicators, now using carto

### DIFF
--- a/app/javascript/components/widgets/widgets/climate/future-carbon-gains/actions.js
+++ b/app/javascript/components/widgets/widgets/climate/future-carbon-gains/actions.js
@@ -16,16 +16,16 @@ export default ({ params }) =>
       ) => {
         const data = {
           cGain: {
-            YSF: cYSF.data && cYSF.data.values,
-            MASF: cMASF.data && cMASF.data.values,
-            Pasture: cPasture.data && cPasture.data.values,
-            Crops: cCrops.data && cCrops.data.values
+            YSF: cYSF.data && cYSF.data.rows,
+            MASF: cMASF.data && cMASF.data.rows,
+            Pasture: cPasture.data && cPasture.data.rows,
+            Crops: cCrops.data && cCrops.data.rows
           },
           co2Gain: {
-            YSF: co2YSF.data && co2YSF.data.values,
-            MASF: co2MASF.data && co2MASF.data.values,
-            Pasture: co2Pasture.data && co2Pasture.data.values,
-            Crops: co2Crops.data && co2Crops.data.values
+            YSF: co2YSF.data && co2YSF.data.rows,
+            MASF: co2MASF.data && co2MASF.data.rows,
+            Pasture: co2Pasture.data && co2Pasture.data.rows,
+            Crops: co2Crops.data && co2Crops.data.rows
           }
         };
         return data;

--- a/app/javascript/components/widgets/widgets/climate/future-carbon-gains/config.js
+++ b/app/javascript/components/widgets/widgets/climate/future-carbon-gains/config.js
@@ -6,8 +6,8 @@ export default {
   },
   categories: ['climate'],
   colors: 'climate',
-  types: ['country', 'region'],
-  admins: ['adm0', 'adm1', 'adm2'],
+  types: ['country'],
+  admins: ['adm0'],
   options: {
     units: ['co2Gain', 'cGain']
   },

--- a/app/javascript/services/climate.js
+++ b/app/javascript/services/climate.js
@@ -1,8 +1,5 @@
 import request from 'utils/request';
 
-const REQUEST_URL =
-  'http://climate.globalforestwatch.org/api/indicators/{indicator}?thresh={thresh}&iso={iso}&id_1={id}&area={area}';
-
 const INDICATORS = [
   3110, // (Carbon) Young Secondary Forest
   3111, // (Carbon) Mid-Age Secondary Forests
@@ -14,12 +11,32 @@ const INDICATORS = [
   3117 // C02 Crops
 ];
 
-export const getEmissions = ({ threshold, adm0, adm1, adm2 }) =>
+export const getEmissions = ({ threshold, adm0 }) =>
   INDICATORS.map(indicator => {
-    const url = REQUEST_URL.replace('{indicator}', indicator)
-      .replace('{thresh}', threshold || '0')
-      .replace('{iso}', adm0 ? String(adm0) : '')
-      .replace('{id}', adm1 ? String(adm1) : '')
-      .replace('{area}', adm2 ? String(adm1) : '');
-    return request.get(url);
+    const url = `${process.env.CARTO_API}/sql?q=`;
+    const query = `SELECT indicator_id,
+values.cartodb_id AS cartodb_id,
+values.iso,
+values.sub_nat_id,
+values.boundary_code,
+values.thresh,
+values.the_geom,
+values.the_geom_webmercator,
+values.country AS country_name,
+values.country AS admin0_name,
+values.year,
+CAST(values.value AS double precision) AS value,
+values.value AS text_value,
+subnat.name_1 AS sub_nat_name,
+boundaries.boundary_name${' '}
+FROM gfw_climate_country_pages_indicator_values_2017_data_20180913 AS values${' '}
+LEFT JOIN gadm28_adm1 AS subnat ON values.sub_nat_id = subnat.id_1${' '}
+AND values.iso = subnat.iso LEFT JOIN gfw_climate_country_pages_boundary_info_2017_data${' '}
+AS boundaries ON values.boundary_code = boundaries.boundary_code${' '}
+WHERE indicator_id = ${indicator} AND value IS NOT NULL AND thresh =
+${threshold || 0} AND values.iso = UPPER('${
+  adm0
+}') AND values.sub_nat_id IS NULL AND values.boundary_code = 'admin' ORDER BY year`;
+
+    return request.get(encodeURI(`${url}${query}`));
   });


### PR DESCRIPTION
## Overview

Fixed a bug related to mixed content (http resources on a https page) that made this widget to not load any data in the production website. Instead of using climate.globalforestwatch, we are using wri-carto endpoint.