### PR TITLE
Fix: Ranked gain widget parent location

### DIFF
--- a/app/javascript/components/widgets/selectors.js
+++ b/app/javascript/components/widgets/selectors.js
@@ -51,6 +51,10 @@ const locationTypes = {
     label: 'country',
     value: 'admin'
   },
+  global: {
+    label: 'global',
+    value: 'global'
+  },
   geostore: {
     label: 'your custom area',
     value: 'geostore'
@@ -148,15 +152,6 @@ export const getLocationObject = createSelector(
   (adminLevel, adms, location, parent) => {
     if (location.type !== 'country') {
       return locationTypes[location.type];
-    }
-    if (!adms || adminLevel === 'global') {
-      return {
-        parentLabel: null,
-        parentValue: null,
-        label: 'global',
-        value: 'global',
-        adminLevel
-      };
     }
 
     const locationObject = location.adm0

--- a/app/javascript/components/widgets/selectors.js
+++ b/app/javascript/components/widgets/selectors.js
@@ -149,7 +149,15 @@ export const getLocationObject = createSelector(
     if (location.type !== 'country') {
       return locationTypes[location.type];
     }
-    if (!adms) return null;
+    if (!adms || adminLevel === 'global') {
+      return {
+        parentLabel: null,
+        parentValue: null,
+        label: 'global',
+        value: 'global',
+        adminLevel
+      };
+    }
 
     const locationObject = location.adm0
       ? adms.find(a => a.value === location[adminLevel])

--- a/app/javascript/components/widgets/widgets/climate/emissions-plantations/selectors.js
+++ b/app/javascript/components/widgets/widgets/climate/emissions-plantations/selectors.js
@@ -64,7 +64,7 @@ export const parseSentence = createSelector(
       location: locationName !== 'global' ? `${locationName}'s` : locationName,
       percentage:
         plantationsPct < 0.1
-          ? '<0.1%'
+          ? '< 0.1%'
           : formatNumber({ num: plantationsPct, unit: '%' }),
       emissions: formatNumber({ num: emissions, unit: 't' }),
       startYear,

--- a/app/javascript/components/widgets/widgets/climate/emissions/selectors.js
+++ b/app/javascript/components/widgets/widgets/climate/emissions/selectors.js
@@ -116,7 +116,7 @@ export const parseSentence = createSelector(
       location_alt: `${locationName}'s`,
       percentage:
         Math.abs(emissionFraction) < 0.1
-          ? '<0.1%'
+          ? '< 0.1%'
           : `${format('.2r')(Math.abs(emissionFraction))}%`,
       value: `${format('.3s')(
         Math.abs(emissionsCount / (endYear - startYear))

--- a/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/config.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/config.js
@@ -24,9 +24,9 @@ export default {
     globalWithIndicator:
       'From 2001 to 2012, {gain} of tree cover was gained within {indicator} {location}.',
     initial:
-      'From 2001 to 2012, {location} gained {gain} of tree cover equal to {gainPercent} of global total.',
+      'From 2001 to 2012, {location} gained {gain} of tree cover equal to {gainPercent} of the {parent} total.',
     withIndicator:
-      'From 2001 to 2012, {location} gained {gain} of tree cover in {indicator} equal to {gainPercent} of global total.',
+      'From 2001 to 2012, {location} gained {gain} of tree cover in {indicator} equal to {gainPercent} of the {parent} total.',
     regionInitial:
       'From 2001 to 2012, {location} gained {gain} of tree cover {indicator} equal to {gainPercent} of all tree cover gain in {parent}.',
     regionWithIndicator:

--- a/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
@@ -158,7 +158,7 @@ export const parseSentence = createSelector(
     const gainPercent = gain ? 100 * gain / sumBy(data, 'gain') : 0;
     const areaPercent = (locationData && locationData.percentage) || 0;
 
-    const adminLevel = locationObject.adminLevel;
+    const adminLevel = locationObject.adminLevel || 'global';
 
     const params = {
       location: currentLabel === 'global' ? 'globally' : currentLabel,

--- a/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
@@ -19,9 +19,6 @@ const getTitle = state => state.config.title;
 const getLocationType = state => state.locationType || null;
 const getAllLocation = state => state.allLocation || null;
 
-const getAdminLevel = state => state.adminLevel || null;
-const getParentLocation = state => state[state.parentLevel] || null;
-
 const haveData = (data, locationObject) =>
   locationObject &&
   data &&
@@ -137,19 +134,9 @@ export const parseSentence = createSelector(
     getIndicator,
     getLocationObject,
     getLocationName,
-    getSentences,
-    getParentLocation,
-    getAdminLevel
+    getSentences
   ],
-  (
-    data,
-    indicator,
-    locationObject,
-    currentLabel,
-    sentences,
-    parent,
-    adminLevel
-  ) => {
+  (data, indicator, locationObject, currentLabel, sentences) => {
     if (
       !data ||
       !data.length ||
@@ -171,6 +158,8 @@ export const parseSentence = createSelector(
     const gainPercent = gain ? 100 * gain / sumBy(data, 'gain') : 0;
     const areaPercent = (locationData && locationData.percentage) || 0;
 
+    const adminLevel = locationObject.adminLevel;
+
     const params = {
       location: currentLabel === 'global' ? 'globally' : currentLabel,
       gain: gain < 1 ? `${format('.3r')(gain)}ha` : `${format('.3s')(gain)}ha`,
@@ -178,13 +167,13 @@ export const parseSentence = createSelector(
       percent: areaPercent >= 0.1 ? `${format('.2r')(areaPercent)}%` : '<0.1%',
       gainPercent:
         gainPercent >= 0.1 ? `${format('.2r')(gainPercent)}%` : '<0.1%',
-      parent: parent && parent.label
+      parent: locationObject && locationObject.parentLabel
     };
 
     let sentence = indicator ? withIndicator : initial;
-    if (adminLevel === 'region' || adminLevel === 'subRegion') {
+    if (adminLevel === 'adm1' || adminLevel === 'adm2') {
       sentence = indicator ? regionWithIndicator : regionInitial;
-    } else if (adminLevel === 'global' || adminLevel === 'subRegion') {
+    } else if (adminLevel === 'global' || adminLevel === 'adm2') {
       sentence = indicator ? globalWithIndicator : globalInitial;
     }
 

--- a/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
@@ -167,13 +167,13 @@ export const parseSentence = createSelector(
       percent: areaPercent >= 0.1 ? `${format('.2r')(areaPercent)}%` : '<0.1%',
       gainPercent:
         gainPercent >= 0.1 ? `${format('.2r')(gainPercent)}%` : '<0.1%',
-      parent: locationObject && locationObject.parentLabel
+      parent: locationObject.parentLabel || null
     };
 
     let sentence = indicator ? withIndicator : initial;
     if (adminLevel === 'adm1' || adminLevel === 'adm2') {
       sentence = indicator ? regionWithIndicator : regionInitial;
-    } else if (adminLevel === 'global' || adminLevel === 'adm2') {
+    } else if (adminLevel === 'global') {
       sentence = indicator ? globalWithIndicator : globalInitial;
     }
 

--- a/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
@@ -164,9 +164,9 @@ export const parseSentence = createSelector(
       location: currentLabel === 'global' ? 'globally' : currentLabel,
       gain: gain < 1 ? `${format('.3r')(gain)}ha` : `${format('.3s')(gain)}ha`,
       indicator: (indicator && indicator.label.toLowerCase()) || 'region-wide',
-      percent: areaPercent >= 0.1 ? `${format('.2r')(areaPercent)}%` : '<0.1%',
+      percent: areaPercent >= 0.1 ? `${format('.2r')(areaPercent)}%` : '< 0.1%',
       gainPercent:
-        gainPercent >= 0.1 ? `${format('.2r')(gainPercent)}%` : '<0.1%',
+        gainPercent >= 0.1 ? `${format('.2r')(gainPercent)}%` : '< 0.1%',
       parent: locationObject.parentLabel || null
     };
 

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
@@ -168,9 +168,9 @@ export const parseSentence = createSelector(
           ? `${format('.3r')(lossArea)}ha`
           : `${format('.3s')(lossArea)}ha`,
       localPercent:
-        areaPercent >= 0.1 ? `${format('.2r')(areaPercent)}%` : '<0.1%',
+        areaPercent >= 0.1 ? `${format('.2r')(areaPercent)}%` : '< 0.1%',
       globalPercent:
-        lossPercent >= 0.1 ? `${format('.2r')(lossPercent)}%` : '<0.1%',
+        lossPercent >= 0.1 ? `${format('.2r')(lossPercent)}%` : '< 0.1%',
       extentYear: settings.extentYear
     };
 

--- a/app/javascript/components/widgets/widgets/land-cover/fao-cover/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/fao-cover/selectors.js
@@ -78,7 +78,7 @@ export const parseSentence = createSelector(
           ? `${format('.3r')(extent)}ha`
           : `${format('.3s')(extent)}ha`,
       primaryPercent:
-        primaryPercent >= 0.1 ? `${format('.2r')(primaryPercent)}%` : '<0.1%'
+        primaryPercent >= 0.1 ? `${format('.2r')(primaryPercent)}%` : '< 0.1%'
     };
     let sentence = forest_primary > 0 ? initial : noPrimary;
     if (locationName === 'global') {

--- a/app/javascript/components/widgets/widgets/land-cover/intact-tree-cover/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/intact-tree-cover/selectors.js
@@ -75,7 +75,9 @@ export const parseSentence = createSelector(
       location: locationName !== 'global' ? `${locationName}'s` : locationName,
       indicator: indicatorLabel,
       percentage:
-        intactPercentage < 0.1 ? '<0.1%' : `${format('.2r')(intactPercentage)}%`
+        intactPercentage < 0.1
+          ? '< 0.1%'
+          : `${format('.2r')(intactPercentage)}%`
     };
 
     let sentence =

--- a/app/javascript/components/widgets/widgets/land-cover/primary-forest/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/primary-forest/selectors.js
@@ -74,7 +74,7 @@ export const parseSentence = createSelector(
       indicator: indicatorLabel,
       percentage:
         primaryPercentage < 0.1
-          ? '<0.1%'
+          ? '< 0.1%'
           : `${format('.2r')(primaryPercentage)}%`,
       extentYear: settings.extentYear
     };

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
@@ -126,11 +126,11 @@ export const parseSentence = createSelector(
 
     const topRegionPercent =
       topRegion.percentage < 0.1
-        ? '<0.1%'
+        ? '< 0.1%'
         : `${format('.2r')(topRegion.percentage)}%`;
     const aveRegionPercent =
       avgExtentPercentage < 0.1
-        ? '<0.1%'
+        ? '< 0.1%'
         : `${format('.2r')(avgExtentPercentage)}%`;
 
     const params = {

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-plantations/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-plantations/selectors.js
@@ -62,7 +62,7 @@ export const parseSentence = createSelector(
           : `${format('.3s')(otherExtent)}ha`,
       count: data.length - top.length,
       topType: `${top[0].label}${endsWith(top[0].label, 's') ? '' : 's'}`,
-      percent: areaPerc >= 0.1 ? `${format('.2r')(areaPerc)}%` : '<0.1%'
+      percent: areaPerc >= 0.1 ? `${format('.2r')(areaPerc)}%` : '< 0.1%'
     };
     const sentence =
       settings.type === 'bound1'

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/selectors.js
@@ -112,9 +112,9 @@ export const parseSentence = createSelector(
           : `${format('.3s')(extent)}ha`,
       indicator: indicator && indicator.label.toLowerCase(),
       landPercentage:
-        landPercent >= 0.1 ? `${format('.2r')(landPercent)}%` : '<0.1%',
+        landPercent >= 0.1 ? `${format('.2r')(landPercent)}%` : '< 0.1%',
       globalPercentage:
-        globalPercent >= 0.1 ? `${format('.2r')(globalPercent)}%` : '<0.1%'
+        globalPercent >= 0.1 ? `${format('.2r')(globalPercent)}%` : '< 0.1%'
     };
 
     let sentence = indicator ? withInd : initial;

--- a/app/javascript/components/widgets/widgets/land-use/economic-impact/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-use/economic-impact/selectors.js
@@ -172,7 +172,7 @@ export const parseSentence = createSelector(
       percentage:
         selectedFAO[0].net_perc >= 0.1
           ? `${format('2r')(selectedFAO[0].net_perc)}%`
-          : '<0.1%',
+          : '< 0.1%',
       year: settings.year
     };
 

--- a/app/javascript/components/widgets/widgets/land-use/forestry-employment/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-use/forestry-employment/selectors.js
@@ -79,7 +79,7 @@ export const parseSentence = createSelector(
     const params = {
       location: `${locationObject && locationObject && locationObject.label}'s`,
       value: `${employees ? format('.3s')(employees) : 'no'}`,
-      percent: percentage >= 0.1 ? `${format('.2r')(percentage)}%` : '<0.1%',
+      percent: percentage >= 0.1 ? `${format('.2r')(percentage)}%` : '< 0.1%',
       year
     };
 


### PR DESCRIPTION
## Overview

The ranked gain widget should have access the parent locations (e.g. Acre's parent is Brazil, Brazils is Global etc)

This update the 'getLocationsObject' function to include parent information as well as teh admin level of the selected location.

<img width="377" alt="screen shot 2019-02-20 at 11 53 58" src="https://user-images.githubusercontent.com/30242314/53090821-c73e2b80-3510-11e9-980f-c9f5bddc764f.png">

<img width="366" alt="screen shot 2019-02-20 at 11 54 59" src="https://user-images.githubusercontent.com/30242314/53091123-67945000-3511-11e9-8287-789058b2fc6e.png">


