### PR TITLE
Removes KBA, TCL etc from ranked glad

### DIFF
--- a/app/javascript/components/widgets/widgets/forest-change/glad-ranked/config.js
+++ b/app/javascript/components/widgets/widgets/forest-change/glad-ranked/config.js
@@ -6,7 +6,7 @@ export default {
   admins: ['adm0', 'adm1'],
   options: {
     forestTypes: true,
-    landCategories: true,
+    landCategories: ['mining', 'wdpa', 'landmark'],
     thresholds: true,
     units: ['%', 'ha'],
     extentYears: true,


### PR DESCRIPTION
## Overview

Simply removes the Land category options that are not present in the data since KBA, TCL, AZE are no longer processed for glad.