### PR TITLE
typo fix for degrees

### DIFF
--- a/app/javascript/components/maps/components/menu/components/sections/search/component.jsx
+++ b/app/javascript/components/maps/components/menu/components/sections/search/component.jsx
@@ -33,7 +33,7 @@ class MapMenuSearch extends PureComponent {
                 value: 'coords'
               },
               {
-                label: 'decimal degress',
+                label: 'decimal degrees',
                 value: 'decimals'
               },
               {


### PR DESCRIPTION
The label for "decimal degrees" option was "decimal degress"; fixed

## Overview

Brief description of what this PR does, and why it is needed.

## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

