### PR TITLE
Feature/allow staging datasets

### DIFF
--- a/app/javascript/providers/datasets-provider/datasets-decode-config.js
+++ b/app/javascript/providers/datasets-provider/datasets-decode-config.js
@@ -363,6 +363,7 @@ export default {
   '78747ea1-34a9-4aa7-b099-bdb8948200f4': decodes.treeCover,
   'c05c32fd-289c-4b20-8d73-dc2458234e04': decodes.treeCover,
   'c3075c5a-5567-4b09-bc0d-96ed1673f8b6': decodes.treeCoverLoss,
+  '0d35db15-9c05-4dbb-9879-ceded4f7951d': decodes.treeCoverLoss,
   'fd05bc2c-6ade-408c-862e-7318557dd4fc': decodes.treeLossByDriver,
   'dd5df87f-39c2-4aeb-a462-3ef969b20b66': decodes.GLADs,
   '9a370f5a-6631-44e3-a955-7f3884c27d91': decodes.GLADs,

--- a/app/javascript/services/datasets.js
+++ b/app/javascript/services/datasets.js
@@ -1,11 +1,13 @@
 import request from 'utils/request';
 
 const REQUEST_URL = `${process.env.RESOURCE_WATCH_API}`;
+const featureEnv = process.env.FEATURE_ENV;
 
 export const getDatasetsProvider = () =>
   request.get(
     `${
       REQUEST_URL
-    }/dataset?application=gfw&includes=metadata,vocabulary,layer&page[size]=9999&hash=${process
-      .env.API_CACHE || new Date()}`
+    }/dataset?application=gfw&includes=metadata,vocabulary,layer&page[size]=9999&env=production${
+      featureEnv ? `,${featureEnv}` : ''
+    }&hash=${process.env.API_CACHE || new Date()}`
   );


### PR DESCRIPTION
When fetching datasets we need to pass `env=${FEATURE_ENV}` to be able to see those datasets in the app.