### PR TITLE
Fix: increase scroll to speed for sgf about tab

### DIFF
--- a/app/javascript/components/scroll-to/scroll-to.js
+++ b/app/javascript/components/scroll-to/scroll-to.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 class ScrollTo extends PureComponent {
   // eslint-disable-line react/prefer-stateless-function
   componentDidMount() {
-    setTimeout(this.handleScroll, 150);
+    setTimeout(this.handleScroll, this.props.delay);
   }
 
   handleFadeOut = el => {
@@ -37,7 +37,12 @@ class ScrollTo extends PureComponent {
 }
 
 ScrollTo.propTypes = {
-  target: PropTypes.object
+  target: PropTypes.object,
+  delay: PropTypes.number
+};
+
+ScrollTo.defaultProps = {
+  delay: 150
 };
 
 export default ScrollTo;

--- a/app/javascript/pages/sgf/section-about/section-about-component.jsx
+++ b/app/javascript/pages/sgf/section-about/section-about-component.jsx
@@ -153,7 +153,7 @@ class SectionAbout extends PureComponent {
             </div>
           </div>
         </section>
-        {anchor && <ScrollTo target={anchor} />}
+        {anchor && <ScrollTo target={anchor} delay={500} />}
       </div>
     );
   }


### PR DESCRIPTION
Anchor links in SGF tab weren't working on page load. Increased to 500 delay and allowed delay props in component.