### PR TITLE
Update loss widgets text

### DIFF
--- a/app/javascript/components/widgets/widgets/forest-change/fao-deforest/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/fao-deforest/selectors.js
@@ -11,7 +11,6 @@ const getSettings = state => state.settings || null;
 const getPeriod = state => state.settings.period || null;
 const getSentences = state => state.config && state.config.sentences;
 const getTitle = state => state.config.title;
-const getLocationType = state => state.locationType || null;
 
 export const parseData = createSelector(
   [getData, getLocation, getColors],
@@ -88,10 +87,10 @@ export const parseSentence = createSelector(
 );
 
 export const parseTitle = createSelector(
-  [getTitle, getLocationType],
-  (title, type) => {
+  [getTitle, getLocationName],
+  (title, name) => {
     let selectedTitle = title.initial;
-    if (type === 'global') {
+    if (name === 'global') {
       selectedTitle = title.global;
     }
     return selectedTitle;

--- a/app/javascript/components/widgets/widgets/forest-change/fao-reforest/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/fao-reforest/selectors.js
@@ -11,7 +11,6 @@ const getLocationName = state => state.locationName || null;
 const getPeriod = state => state.settings.period || null;
 const getSentences = state => state.config && state.config.sentences;
 const getTitle = state => state.config.title;
-const getLocationType = state => state.locationType || null;
 const getAllLocation = state => state.allLocation || null;
 
 export const getSortedData = createSelector([getData], data => {
@@ -101,10 +100,10 @@ export const parseSentence = createSelector(
 );
 
 export const parseTitle = createSelector(
-  [getTitle, getLocationType],
-  (title, type) => {
+  [getTitle, getLocationName],
+  (title, name) => {
     let selectedTitle = title.initial;
-    if (type === 'global') {
+    if (name === 'global') {
       selectedTitle = title.global;
     }
     return selectedTitle;

--- a/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
@@ -16,7 +16,6 @@ const getLocationObject = state => state.locationObject || null;
 const getLocationName = state => state.locationName || null;
 const getSentences = state => state.config.sentences || null;
 const getTitle = state => state.config.title;
-const getLocationType = state => state.locationType || null;
 const getAllLocation = state => state.allLocation || null;
 
 const haveData = (data, locationObject) =>
@@ -186,10 +185,10 @@ export const parseSentence = createSelector(
 );
 
 export const parseTitle = createSelector(
-  [getTitle, getLocationType],
-  (title, type) => {
+  [getTitle, getLocationName],
+  (title, name) => {
     let selectedTitle = title.initial;
-    if (type === 'global') {
+    if (name === 'global') {
       selectedTitle = title.global;
     }
     return selectedTitle;

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/config.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/config.js
@@ -3,9 +3,9 @@ export default {
   title: 'Annual Global Tree cover loss',
   sentence: {
     initial:
-      'From {startYear} and {endYear}, there was a total of {loss} of tree cover loss {location}, equivalent to a {percent} decrease since {extentYear} and {emissions} of CO\u2082 emissions.',
+      'From {startYear} to {endYear}, there was a total of {loss} of tree cover loss {location}, equivalent to a {percent} decrease in tree cover since {extentYear} and {emissions} of CO\u2082 emissions.',
     withInd:
-      'From {startYear} and {endYear}, there was a total of {loss} of tree cover loss {location} within {indicator}, equivalent to a {percent} decrease since {extentYear} and {emissions} of CO\u2082 emissions.'
+      'From {startYear} to {endYear}, there was a total of {loss} of tree cover loss {location} within {indicator}, equivalent to a {percent} decrease in tree cover since {extentYear} and {emissions} of CO\u2082 emissions.'
   },
   types: ['global'],
   admins: ['global'],

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
@@ -20,7 +20,7 @@ const getQuery = state => state.query || null;
 const getLocationObject = state => state.locationObject || null;
 const getSentences = state => state.config && state.config.sentence;
 const getTitle = state => state.config.title;
-const getLocationType = state => state.type;
+const getLocationName = state => state.locationName || null;
 
 export const getSummedByYearsData = createSelector(
   [getData, getSettings],
@@ -182,10 +182,10 @@ export const parseSentence = createSelector(
 );
 
 export const parseTitle = createSelector(
-  [getTitle, getLocationType],
-  (title, type) => {
+  [getTitle, getLocationName],
+  (title, name) => {
     let selectedTitle = title.default;
-    if (type === 'global') {
+    if (name === 'global') {
       selectedTitle = title.global;
     }
     return selectedTitle;

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-tsc/config.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-tsc/config.js
@@ -22,10 +22,10 @@ export default {
   },
   sentences: {
     initial:
-      'In {location} from {startYear} to {endYear}, {permPercent} of tree cover loss occurred in areas where the dominant drivers of loss resulted in {permanent deforestation}.',
+      'In {location} from {startYear} to {endYear}, {permPercent} of tree cover loss occurred in areas where the dominant drivers of loss resulted in {deforestation}.',
     noLoss:
-      'In {location} from {startYear} to {endYear}, <b>no</b> tree cover loss occurred in areas where the dominant drivers of loss resulted in {permanent deforestation}.',
+      'In {location} from {startYear} to {endYear}, <b>no</b> tree cover loss occurred in areas where the dominant drivers of loss resulted in {deforestation}.',
     globalInitial:
-      '{location} from {startYear} to {endYear}, {permPercent} of tree cover loss occurred in areas where the dominant drivers of loss resulted in {permanent deforestation}.'
+      '{location} from {startYear} to {endYear}, {permPercent} of tree cover loss occurred in areas where the dominant drivers of loss resulted in {deforestation}.'
   }
 };

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-tsc/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-tsc/selectors.js
@@ -213,7 +213,7 @@ export const parseSentence = createSelector(
           ? '< 0.1%'
           : `${format('.2r')(permPercent)}%`,
       component: {
-        key: 'permanent deforestation',
+        key: 'deforestation',
         tooltip:
           'The drivers of permanent deforestation are urbanization and commodity-driven deforestation.'
       }

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-tsc/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-tsc/selectors.js
@@ -18,7 +18,6 @@ const getLocationName = state => state.locationName || null;
 const getColors = state => state.colors || null;
 const getSentences = state => state.config && state.config.sentences;
 const getTitle = state => state.config.title;
-const getLocationType = state => state.locationType || null;
 
 export const getPermCats = createSelector([], () =>
   tscLossCategories.filter(x => x.permanent).map(el => el.value.toString())
@@ -227,10 +226,10 @@ export const parseSentence = createSelector(
 );
 
 export const parseTitle = createSelector(
-  [getTitle, getLocationType],
-  (title, type) => {
+  [getTitle, getLocationName],
+  (title, name) => {
     let selectedTitle = title.initial;
-    if (type === 'global') {
+    if (name === 'global') {
       selectedTitle = title.global;
     }
     return selectedTitle;

--- a/app/javascript/components/widgets/widgets/land-cover/fao-cover/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/fao-cover/selectors.js
@@ -8,7 +8,6 @@ const getLocationName = state => state.locationName || null;
 const getColors = state => state.colors || null;
 const getSentences = state => state.config && state.config.sentences;
 const getTitle = state => state.config.title;
-const getLocationType = state => state.locationType || null;
 
 // get lists selected
 export const parseData = createSelector(
@@ -92,10 +91,10 @@ export const parseSentence = createSelector(
 );
 
 export const parseTitle = createSelector(
-  [getTitle, getLocationType],
-  (title, type) => {
+  [getTitle, getLocationName],
+  (title, name) => {
     let selectedTitle = title.initial;
-    if (type === 'global') {
+    if (name === 'global') {
       selectedTitle = title.global;
     }
     return selectedTitle;

--- a/app/javascript/components/widgets/widgets/land-cover/intact-tree-cover/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/intact-tree-cover/selectors.js
@@ -9,7 +9,6 @@ const getIndicator = state => state.indicator || null;
 const getColors = state => state.colors;
 const getSentences = state => state.config && state.config.sentences;
 const getTitle = state => state.config.title;
-const getLocationType = state => state.locationType || null;
 
 // get lists selected
 export const parseData = createSelector(
@@ -97,10 +96,10 @@ export const parseSentence = createSelector(
 );
 
 export const parseTitle = createSelector(
-  [getTitle, getLocationType],
-  (title, type) => {
+  [getTitle, getLocationName],
+  (title, name) => {
     let selectedTitle = title.initial;
-    if (type === 'global') {
+    if (name === 'global') {
       selectedTitle = title.global;
     }
     return selectedTitle;

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
@@ -18,7 +18,6 @@ const getLocationName = state => state.locationName || null;
 const getColors = state => state.colors || null;
 const getSentences = state => state.config && state.config.sentences;
 const getTitle = state => state.config.title;
-const getLocationType = state => state.locationType || null;
 
 export const parseList = createSelector(
   [getData, getSettings, getLocation, getLocationsMeta, getColors],
@@ -173,10 +172,10 @@ export const parseSentence = createSelector(
 );
 
 export const parseTitle = createSelector(
-  [getTitle, getLocationType],
-  (title, type) => {
+  [getTitle, getLocationName],
+  (title, name) => {
     let selectedTitle = title.initial;
-    if (type === 'global') {
+    if (name === 'global') {
       selectedTitle = title.global;
     }
     return selectedTitle;

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover/selectors.js
@@ -10,14 +10,13 @@ const getWhitelist = state => state.whitelists && state.whitelists.adm0;
 const getColors = state => state.colors;
 const getSentence = state => state.config.sentence;
 const getTitle = state => state.config.title;
-const getLocationType = state => state.type;
 const getLocationName = state => state.locationName;
 
 export const isoHasPlantations = createSelector(
-  [getWhitelist, getLocationType],
-  (whitelist, type) => {
+  [getWhitelist, getLocationName],
+  (whitelist, name) => {
     const hasPlantations =
-      (type !== 'global' && isEmpty(whitelist)) ||
+      (name !== 'global' && isEmpty(whitelist)) ||
       (whitelist && whitelist.includes('plantations'));
     return hasPlantations;
   }
@@ -68,10 +67,10 @@ export const parseData = createSelector(
 );
 
 export const parseTitle = createSelector(
-  [getTitle, getLocationType, getWhitelist],
-  (title, type, whitelist) => {
+  [getTitle, getLocationName, getWhitelist],
+  (title, name, whitelist) => {
     let selectedTitle = title.default;
-    if (type === 'global') {
+    if (name === 'global') {
       selectedTitle = title.global;
     } else if (
       whitelist &&


### PR DESCRIPTION
## Overview

1. Loss TSC widget: removes 'permanent deforestation'
2. Loss Global widget sentence fix
3. Refactors title logic to use getLocationName not getLocationType (depreciated). Global titles not all begin with `Global`