### PR TITLE
Adds parent location check in header sentences

### DIFF
--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/config.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/config.js
@@ -1,6 +1,6 @@
 export default {
   widget: 'treeLossGlobal',
-  title: 'Annual Global Tree cover loss',
+  title: 'Global Annual Tree cover loss',
   sentence: {
     initial:
       'From {startYear} to {endYear}, there was a total of {loss} of tree cover loss {location}, equivalent to a {percent} decrease in tree cover since {extentYear} and {emissions} of CO\u2082 emissions.',

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover/config.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover/config.js
@@ -4,7 +4,7 @@ export default {
   // title for header
   title: {
     default: 'Tree cover in {location}',
-    global: 'Global tree cover',
+    global: 'Global forest cover',
     withPlantations: 'Forest cover in {location}'
   },
   // sentences for header

--- a/app/javascript/pages/dashboards/header/header-reducers.js
+++ b/app/javascript/pages/dashboards/header/header-reducers.js
@@ -14,8 +14,10 @@ export const initialState = {
         'In 2010, {location} had {extent} of tree cover, extending over {percentage} of its land area. In {year}, it lost {loss} of tree cover.',
       withPlantationLoss:
         'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {naturalLoss} of natural forest',
-      indoInitial:
-        'In 2010, {location} had {naturalForest} of natural forest, extending over {percentageNatForest} of its land area. In {year}, it lost {loss} of tree cover, equivalent to {emissionsTreeCover} of CO₂ of emissions. {primaryLoss} of this loss occurred within intact and degraded primary forests and {naturalLoss} within natural forest.',
+      countrySpecific: {
+        IDN:
+          'In 2010, {location} had {naturalForest} of natural forest, extending over {percentageNatForest} of its land area. In {year}, it lost {loss} of tree cover, equivalent to {emissionsTreeCover} of CO₂ of emissions. {primaryLoss} of this loss occurred within primary forests and {naturalLoss} within natural forest.'
+      },
       co2Emissions: ', equivalent to {emission} of CO\u2082 of emissions.',
       end: '.'
     }


### PR DESCRIPTION
## Overview

All daughter locations within indonesia now have the modified sentence which references intact forest and co2 emissions.

<img width="751" alt="Screen Shot 2019-03-28 at 11 09 28" src="https://user-images.githubusercontent.com/30242314/55149178-fcf6b580-5149-11e9-8920-1628d471d815.png">

<img width="770" alt="Screen Shot 2019-03-28 at 11 08 31" src="https://user-images.githubusercontent.com/30242314/55149134-dfc1e700-5149-11e9-951e-f0705aabf91e.png">

Extends this behaviour to any country-specific header sentence - in the future we can now add the ISO  code as a key in the header-config and it will automatically select it if it exists.
