### PR TITLE
Fixes broken IDN Tree Cover metadata

### DIFF
--- a/app/javascript/components/widgets/components/widget/components/widget-header/selectors.js
+++ b/app/javascript/components/widgets/components/widget/components/widget-header/selectors.js
@@ -17,7 +17,7 @@ export const selectWidgetMetaKey = (state, { config, widget, whitelist }) =>
   (widget === 'treeCover' &&
   whitelist.length &&
   whitelist.includes('plantations')
-    ? 'widget_natural_vs _planted'
+    ? 'widget_natural_vs_planted'
     : config.metaKey);
 
 export const getParsedTitle = createSelector(


### PR DESCRIPTION
## Overview

Ensures info button forms correct request to `https://production-api.globalforestwatch.org/v1/gfw-metadata/widget_natural_vs_planted`

<img width="436" alt="Screen Shot 2019-03-29 at 12 56 05" src="https://user-images.githubusercontent.com/30242314/55231172-208d2f00-5222-11e9-997c-1bde644b5ca6.png">
