### PR TITLE
force SSL on all deployed production environments

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,7 @@ Gfw::Application.configure do
   config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = ENV['FEATURE_ENV'] == 'production' ? true : false
+  config.force_ssl = true
 
   # Set to :debug to see everything in the log.
   config.log_level = :debug


### PR DESCRIPTION
Now we have SSL for staging and preproduction we can force SSL on the production env config.