### PR TITLE
Hotfix/prevent widget endyear overflow

### DIFF
--- a/app/javascript/components/maps/components/analysis/styles.scss
+++ b/app/javascript/components/maps/components/analysis/styles.scss
@@ -71,6 +71,7 @@
     font-size: rem(14px);
     font-weight: 500;
     height: rem(30px);
+    width: 100%;
 
     &:first-child {
       margin-right: rem(5px);

--- a/app/javascript/components/maps/components/basemaps/styles.scss
+++ b/app/javascript/components/maps/components/basemaps/styles.scss
@@ -129,6 +129,7 @@ $top-section-height: 125px;
       align-items: center;
       height: rem(10px);
       font-size: rem(10px);
+      cursor: pointer;
 
       .arrow-icon {
         right: 0;

--- a/app/javascript/components/maps/map/selectors.js
+++ b/app/javascript/components/maps/map/selectors.js
@@ -437,17 +437,25 @@ export const getWidgetsWithLayerParams = createSelector(
         (params && params.endDate) || (decodeParams && decodeParams.endDate);
       const endYear = endDate && parseInt(moment(endDate).format('YYYY'), 10);
 
+      // fix for 2018 data not being ready. please remove once active
+      const newSettings = {
+        ...params,
+        ...decodeParams,
+        ...(startYear && {
+          startYear
+        }),
+        ...(endYear && {
+          endYear
+        })
+      };
+
       return {
         ...w,
         settings: {
           ...w.settings,
-          ...params,
-          ...decodeParams,
-          ...(startYear && {
-            startYear
-          }),
-          ...(endYear && {
-            endYear
+          ...newSettings,
+          ...(newSettings.endYear > w.settings.endYear && {
+            endYear: w.settings.endYear
           })
         }
       };


### PR DESCRIPTION
Adds a hack to stop the endYear settings property of and widget being exceeded by the maps timeline. This prevents the TCL loss widgets sentence not matching with the maximum of the data.