### PR TITLE
Feature: change default dataset for Fire Alerts widget to VIIRS instead of MODIS

### DIFF
--- a/app/javascript/components/widgets/widgets/forest-change/fires-alerts/settings.js
+++ b/app/javascript/components/widgets/widgets/forest-change/fires-alerts/settings.js
@@ -1,7 +1,7 @@
 export default {
   period: 'week',
   weeks: 13,
-  dataset: 'MODIS',
+  dataset: 'VIIRS',
   layerStartDate: null,
   layerEndDate: null
 };


### PR DESCRIPTION
## Overview

Changed the fires widget to show VIIRS dataset by default, so when the user clicks analysis for regions on the map it will relate to the data layer (i.e. it will show VIIRS on the widget and the layer).