### PR TITLE
Fix: recent imagery infinite fetching thumbs

### DIFF
--- a/app/javascript/components/maps/main-map/components/recent-imagery/components/recent-imagery-settings/recent-imagery-settings-component.js
+++ b/app/javascript/components/maps/main-map/components/recent-imagery/components/recent-imagery-settings/recent-imagery-settings-component.js
@@ -157,6 +157,7 @@ class RecentImagerySettings extends PureComponent {
                 </div>
                 <div className="thumbnail-grid">
                   {tiles &&
+                    !error &&
                     !!tiles.length &&
                     tiles.map((tile, i) => (
                       <RecentImageryThumbnail

--- a/app/javascript/components/maps/main-map/components/recent-imagery/components/recent-imagery-settings/recent-imagery-settings-component.js
+++ b/app/javascript/components/maps/main-map/components/recent-imagery/components/recent-imagery-settings/recent-imagery-settings-component.js
@@ -147,7 +147,7 @@ class RecentImagerySettings extends PureComponent {
                     onChange={option => {
                       resetRecentImageryData();
                       setRecentImagerySettings({
-                        bands: option,
+                        bands: option === '0' ? 0 : option,
                         selected: null,
                         selectedIndex: 0
                       });

--- a/app/javascript/components/maps/main-map/components/recent-imagery/components/recent-imagery-settings/recent-imagery-settings-component.js
+++ b/app/javascript/components/maps/main-map/components/recent-imagery/components/recent-imagery-settings/recent-imagery-settings-component.js
@@ -42,6 +42,7 @@ class RecentImagerySettings extends PureComponent {
       settings: { date, weeks, bands },
       setRecentImagerySettings,
       setRecentImageryLoading,
+      resetRecentImageryData,
       setModalMetaSettings,
       onClickClose,
       error
@@ -145,6 +146,7 @@ class RecentImagerySettings extends PureComponent {
                     value={bands}
                     options={BANDS}
                     onChange={option => {
+                      resetRecentImageryData();
                       setRecentImagerySettings({
                         bands: option,
                         selected: null,
@@ -216,6 +218,7 @@ RecentImagerySettings.propTypes = {
   setRecentImagerySettings: PropTypes.func,
   setRecentImageryLoading: PropTypes.func,
   setModalMetaSettings: PropTypes.func,
+  resetRecentImageryData: PropTypes.func,
   loading: PropTypes.bool,
   moreTilesLoading: PropTypes.bool,
   onClickClose: PropTypes.func,

--- a/app/javascript/components/maps/main-map/components/recent-imagery/components/recent-imagery-settings/recent-imagery-settings-component.js
+++ b/app/javascript/components/maps/main-map/components/recent-imagery/components/recent-imagery-settings/recent-imagery-settings-component.js
@@ -38,7 +38,6 @@ class RecentImagerySettings extends PureComponent {
       activeTile,
       tiles,
       loading,
-      moreTilesLoading,
       settings: { date, weeks, bands },
       setRecentImagerySettings,
       setRecentImageryLoading,
@@ -204,7 +203,9 @@ class RecentImagerySettings extends PureComponent {
                 message="We can't find additional images for the selection"
               />
             )}
-          {loading && !moreTilesLoading && <Loader className="placeholder" />}
+          {loading &&
+            !error &&
+            (!tiles || !tiles.length) && <Loader className="placeholder" />}
         </div>
       </div>
     );
@@ -220,7 +221,6 @@ RecentImagerySettings.propTypes = {
   setModalMetaSettings: PropTypes.func,
   resetRecentImageryData: PropTypes.func,
   loading: PropTypes.bool,
-  moreTilesLoading: PropTypes.bool,
   onClickClose: PropTypes.func,
   error: PropTypes.bool
 };

--- a/app/javascript/components/maps/main-map/components/recent-imagery/components/recent-imagery-settings/recent-imagery-settings.js
+++ b/app/javascript/components/maps/main-map/components/recent-imagery/components/recent-imagery-settings/recent-imagery-settings.js
@@ -4,7 +4,8 @@ import * as mapActions from 'components/maps/map/actions';
 import { getRecentImageryProps } from 'components/maps/main-map/components/recent-imagery/recent-imagery-selectors';
 import {
   setRecentImagerySettings,
-  setRecentImageryLoading
+  setRecentImageryLoading,
+  resetRecentImageryData
 } from 'components/maps/main-map/components/recent-imagery/recent-imagery-actions';
 import { setModalMetaSettings } from 'components/modals/meta/meta-actions';
 
@@ -14,7 +15,8 @@ const actions = {
   ...mapActions,
   setRecentImagerySettings,
   setRecentImageryLoading,
-  setModalMetaSettings
+  setModalMetaSettings,
+  resetRecentImageryData
 };
 
 export default connect(getRecentImageryProps, actions)(Component);

--- a/app/javascript/components/maps/main-map/components/recent-imagery/recent-imagery-actions.js
+++ b/app/javascript/components/maps/main-map/components/recent-imagery/recent-imagery-actions.js
@@ -78,11 +78,14 @@ export const getMoreTiles = createThunkAction(
   'getMoreTiles',
   params => (dispatch, getState) => {
     const { recentImagery } = getState();
-    if (recentImagery && !recentImagery.loadingMoreTiles) {
+    if (
+      recentImagery &&
+      !recentImagery.loadingMoreTiles &&
+      !recentImagery.loading
+    ) {
       dispatch(
         setRecentImageryLoadingMoreTiles({
-          loadingMoreTiles: true,
-          error: false
+          loadingMoreTiles: true
         })
       );
       const { sources, dataStatus, bands } = params;
@@ -129,8 +132,7 @@ export const getMoreTiles = createThunkAction(
               );
               dispatch(
                 setRecentImageryLoadingMoreTiles({
-                  loadingMoreTiles: false,
-                  error: false
+                  loadingMoreTiles: false
                 })
               );
             }
@@ -146,8 +148,7 @@ export const getMoreTiles = createThunkAction(
           );
           dispatch(
             setRecentImageryLoadingMoreTiles({
-              loadingMoreTiles: false,
-              error: true
+              loadingMoreTiles: false
             })
           );
         });

--- a/app/javascript/components/maps/main-map/components/recent-imagery/recent-imagery-selectors.js
+++ b/app/javascript/components/maps/main-map/components/recent-imagery/recent-imagery-selectors.js
@@ -10,7 +10,7 @@ import { initialState } from './recent-imagery-reducers';
 const getData = state => state.recentImagery && state.recentImagery.data;
 export const getRecentImageryLoading = state =>
   state.recentImagery && state.recentImagery.loading;
-export const getMoreTilesLoading = state =>
+export const getLoadingMoreTiles = state =>
   state.recentImagery && state.recentImagery.loadingMoreTiles;
 const getError = state => state.recentImagery && state.recentImagery.error;
 const getLocation = state => state.location && state.location.query;
@@ -55,14 +55,6 @@ export const getActiveDatasetsFromState = createSelector(
   getMapSettings,
   settings => settings.datasets
 );
-
-// export const getActive = createSelector(
-//   [getActiveDatasetsFromState, getActive],
-//   (datasets, active) => {
-//     if (isEmpty(datasets)) return null;
-//     return active && !!datasets.find(d => d.isRecentImagery);
-//   }
-// );
 
 export const getFilteredTiles = createSelector(
   [getData, getRecentImagerySettings],
@@ -148,7 +140,7 @@ export const getRecentImageryDataset = createSelector(
 export const getRecentImageryProps = createStructuredSelector({
   // settings
   loading: getRecentImageryLoading,
-  moreTilesLoading: getMoreTilesLoading,
+  loadingMoreTiles: getLoadingMoreTiles,
   error: getError,
   active: getActive,
   dates: getDates,

--- a/app/javascript/services/recent-imagery.js
+++ b/app/javascript/services/recent-imagery.js
@@ -15,18 +15,18 @@ export const getRecentTiles = ({ lat, lng, start, end, bands, token }) => {
     .replace('{lng}', lng)
     .replace('{start}', start)
     .replace('{end}', end)
-    .replace('{bands}', !bands || bands === '0' ? '' : bands);
+    .replace('{bands}', !bands ? '' : bands);
   return axios.get(url, { cancelToken: token });
 };
 
 export const getTiles = ({ sources, bands }) =>
   axios.post(`${REQUEST_URL}${QUERIES.tiles}`, {
     source_data: sources,
-    bands: !bands || bands === '0' ? '' : bands
+    bands: !bands ? '' : bands
   });
 
 export const getThumbs = ({ sources, bands }) =>
   axios.post(`${REQUEST_URL}${QUERIES.thumbs}`, {
     source_data: sources,
-    bands: !bands || bands === '0' ? '' : bands
+    bands: !bands ? '' : bands
   });

--- a/app/javascript/services/recent-imagery.js
+++ b/app/javascript/services/recent-imagery.js
@@ -15,18 +15,18 @@ export const getRecentTiles = ({ lat, lng, start, end, bands, token }) => {
     .replace('{lng}', lng)
     .replace('{start}', start)
     .replace('{end}', end)
-    .replace('{bands}', bands || '');
+    .replace('{bands}', !bands || bands === '0' ? '' : bands);
   return axios.get(url, { cancelToken: token });
 };
 
 export const getTiles = ({ sources, bands }) =>
   axios.post(`${REQUEST_URL}${QUERIES.tiles}`, {
     source_data: sources,
-    bands
+    bands: !bands || bands === '0' ? '' : bands
   });
 
 export const getThumbs = ({ sources, bands }) =>
   axios.post(`${REQUEST_URL}${QUERIES.thumbs}`, {
     source_data: sources,
-    bands
+    bands: !bands || bands === '0' ? '' : bands
   });


### PR DESCRIPTION
## Overview

This PR's objective is to fix several bugs related to recent imagery. Sometimes the fetch fails and both the error message and the previous tiles appeared, which is now fixed.

TODO: fix endless fetch loop that happens sometimes when switching from Vegetation health to Natural color, clear previous tiles.