### PR TITLE
Added custom class to avoid body scroll when header menu is open

### DIFF
--- a/app/javascript/components/header/components/nav-alt/component.jsx
+++ b/app/javascript/components/header/components/nav-alt/component.jsx
@@ -40,6 +40,15 @@ class NavAlt extends PureComponent {
     };
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    const { showMore } = this.state;
+    if (prevState.showMore && !showMore) {
+      document.body.classList.remove('Header__no-scroll');
+    } else if (!prevState.showMore && showMore) {
+      document.body.classList.add('Header__no-scroll');
+    }
+  }
+
   handleLangSelect = lang => {
     localStorage.setItem('txlive:selectedlang', `"${lang}"`);
     window.Transifex.live.translateTo(lang);

--- a/app/javascript/components/header/components/nav-alt/styles.scss
+++ b/app/javascript/components/header/components/nav-alt/styles.scss
@@ -1,5 +1,9 @@
 @import '~styles/settings.scss';
 
+.Header__no-scroll {
+  overflow: hidden;
+}
+
 .c-nav-alt {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## Overview

This PR addresses a ~~bug~~ feature related to Firefox in Windows where the menu opened on mobile view creating 2 scroll bars that pushed the menu content to the left. We added a class to the body that is applied when the menu opens, then removed when it's closed. This class controls the overflow.