### PR TITLE
move locationLevelToStr to utils, fixed TSC for geostores and high zoom levels

### DIFF
--- a/app/javascript/components/analysis/components/show-analysis/selectors.js
+++ b/app/javascript/components/analysis/components/show-analysis/selectors.js
@@ -3,7 +3,11 @@ import moment from 'moment';
 import flatMap from 'lodash/flatMap';
 import intersection from 'lodash/intersection';
 
-import { buildLocationName, buildFullLocationName } from 'utils/format';
+import {
+  buildLocationName,
+  buildFullLocationName,
+  locationLevelToStr
+} from 'utils/format';
 
 import {
   getActiveLayers,
@@ -67,6 +71,7 @@ export const getDataFromLayers = createSelector(
     const { type } = location;
     const routeType = type === 'country' ? 'admin' : type;
     const { areaHa } = geostore;
+    const admLevel = locationLevelToStr(location);
 
     return [
       {
@@ -84,7 +89,8 @@ export const getDataFromLayers = createSelector(
             !l.isBoundary &&
             !l.isRecentImagery &&
             l.analysisConfig &&
-            !widgetLayers.includes(l.id)
+            !widgetLayers.includes(l.id) &&
+            (!l.admLevels || l.admLevels.includes(admLevel))
         )
         .map(l => {
           let analysisConfig = l.analysisConfig.find(a => a.type === routeType);

--- a/app/javascript/components/analysis/selectors.js
+++ b/app/javascript/components/analysis/selectors.js
@@ -6,6 +6,7 @@ import flatMap from 'lodash/flatMap';
 
 import { getAllLayers, getActiveDatasets } from 'components/map/selectors';
 import { parseWidgetsWithOptions } from 'components/widgets/selectors';
+import { locationLevelToStr } from 'utils/format';
 
 import { initialState } from './reducers';
 
@@ -105,12 +106,15 @@ export const getLayerEndpoints = createSelector(
     const routeType = type === 'country' ? 'admin' : type;
     const lossLayer = layers.find(l => l.metadata === 'tree_cover_loss');
     const hasWidgetLayers = widgetLayers && !!widgetLayers.length;
+
+    const admLevel = locationLevelToStr(location);
     const endpoints = compact(
       layers
         .filter(
           l =>
             l.analysisConfig &&
-            (!hasWidgetLayers || !widgetLayers.includes(l.id))
+            (!hasWidgetLayers || !widgetLayers.includes(l.id)) &&
+            (!l.admLevels || l.admLevels.includes(admLevel))
         )
         .map(l => {
           const analysisConfig =

--- a/app/javascript/components/widgets/selectors.js
+++ b/app/javascript/components/widgets/selectors.js
@@ -6,6 +6,7 @@ import lowerCase from 'lodash/lowerCase';
 
 import tropicalIsos from 'data/tropical-isos.json';
 import colors from 'data/colors.json';
+import { locationLevelToStr } from 'utils/format';
 import allOptions from './options';
 import allWidgets from './manifest';
 
@@ -78,13 +79,9 @@ export const getOptions = createSelector([], () => {
   return optionsMeta;
 });
 
-export const getAdminLevel = createSelector([selectLocation], location => {
-  const { type, adm0, adm1, adm2 } = location;
-  if (adm2) return 'adm2';
-  if (adm1) return 'adm1';
-  if (adm0) return 'adm0';
-  return type || 'global';
-});
+export const getAdminLevel = createSelector([selectLocation], location =>
+  locationLevelToStr(location)
+);
 
 export const getActiveWhitelist = createSelector(
   [selectWhitelists, getAdminLevel],

--- a/app/javascript/utils/format.js
+++ b/app/javascript/utils/format.js
@@ -99,3 +99,11 @@ export const buildLocationName = (
 
 export const buildLocationFromNames = (name_0, name_1, name_2) =>
   `${name_2 ? `${name_2}, ` : ''}${name_1 ? `${name_1}, ` : ''}${name_0}`;
+
+export const locationLevelToStr = location => {
+  const { type, adm0, adm1, adm2 } = location;
+  if (adm2) return 'adm2';
+  else if (adm1) return 'adm1';
+  else if (adm0 && type === 'country') return 'adm0';
+  return type || 'global';
+};


### PR DESCRIPTION
## Overview

This PR hides TSC widget in `adm1` and `adm2` level analysis, also moving `locationLevelToStr` method to utils, as it's being used in different files.