### PR TITLE
Fix/widget css grid overflow issue

### DIFF
--- a/app/javascript/components/widgets/components/widget/styles.scss
+++ b/app/javascript/components/widgets/components/widget/styles.scss
@@ -6,11 +6,10 @@
   height: auto;
   border: solid 1px rgba($medium-grey, 0.2);
   border-radius: 4px;
-  min-height: rem(460px);
   display: flex;
   flex-direction: column;
   padding: rem(20px) rem(15px);
-  justify-content: flex-start;
+  justify-content: space-between;
 
   @media screen and (min-width: $screen-m) {
     padding: rem(25px) rem(20px);
@@ -31,7 +30,7 @@
 
   .container {
     position: relative;
-    height: auto;
+    height: 100%;
     min-height: rem(300px);
     margin-bottom: rem(10px);
 
@@ -58,7 +57,6 @@
 
   &.simple {
     border: 0;
-    min-height: rem(200px);
     padding: 0;
     border-radius: 0;
 

--- a/app/javascript/components/widgets/styles.scss
+++ b/app/javascript/components/widgets/styles.scss
@@ -9,33 +9,16 @@
   padding: rem(20px) $mobile-gutter rem(30px) $mobile-gutter;
   min-width: 100%;
 
-  @supports not (display: grid) {
-    > div {
-      width: 100%;
-      margin-bottom: rem(30px);
-
-      @media screen and (min-width: $screen-l) {
-        width: calc(50% - 15px);
-        margin-bottom: rem(30px);
-
-        &.large {
-          width: 100%;
-        }
-      }
-    }
-  }
-
-  @supports (display: grid) {
-    display: grid;
-    grid-template-columns: 1fr;
-    grid-gap: 30px;
-    grid-auto-flow: dense;
+  > div {
+    width: 100%;
+    margin-bottom: rem(30px);
 
     @media screen and (min-width: $screen-l) {
-      grid-template-columns: 1fr 1fr;
+      width: calc(50% - 15px);
+      margin-bottom: rem(30px);
 
-      .large {
-        grid-column-end: span 2;
+      &.large {
+        width: 100%;
       }
     }
   }

--- a/app/javascript/pages/dashboards/styles.scss
+++ b/app/javascript/pages/dashboards/styles.scss
@@ -7,15 +7,6 @@ $right-panel-width: calc((#{$max-width} * 0.3) + ((100vw - #{$max-width}) / 2));
   border-bottom: solid 1px $border;
   display: flex;
 
-  @supports (display: grid) {
-    display: grid;
-    grid-template-columns: 100%;
-
-    @media screen and (min-width: $screen-m) {
-      grid-template-columns: $left-panel-width $right-panel-width;
-    }
-  }
-
   .content-panel {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
CSS grid in Chrome is causing an overflow with the latest version. This remove CSS grid from the widgets and always uses flex, alongside some fixes for the footer position of the widgets.