### PR TITLE
Feature/dynamic sentence translation

### DIFF
--- a/app.json
+++ b/app.json
@@ -158,6 +158,9 @@
     "SPARKPOST_SMTP_USERNAME": {
       "required": true
     },
+    "TRANSIFEX_RESOURCE_API_TOKEN": {
+      "required": true
+    },
     "TRASE_API": {
       "required": true
     }

--- a/app/javascript/components/ui/dynamic-sentence/dynamic-sentence-component.jsx
+++ b/app/javascript/components/ui/dynamic-sentence/dynamic-sentence-component.jsx
@@ -28,13 +28,18 @@ class WidgetDynamicSentence extends PureComponent {
                 formattedSentence &&
                 formattedSentence.replace(
                   `{${p}}`,
-                  `<b style="color: ${param.color};">${param.value}</b>`
+                  `<b class="notranslate" style="color: ${param.color};">${
+                    param.value
+                  }</b>`
                 );
             }
           } else {
             formattedSentence =
               formattedSentence &&
-              formattedSentence.replace(`{${p}}`, `<b>${param}</b>`);
+              formattedSentence.replace(
+                `{${p}}`,
+                `<b class="notranslate">${param}</b>`
+              );
           }
         }
       });

--- a/app/views/shared/_transifex.html.erb
+++ b/app/views/shared/_transifex.html.erb
@@ -1,2 +1,2 @@
-<script type="text/javascript">window.liveSettings={api_key:"9eda410a7db74687ba40771c56abd357", detectlang: true};</script>
+<script type="text/javascript">window.liveSettings={api_key:"<%= ENV['TRANSIFEX_RESOURCE_API_TOKEN'] %>", detectlang: true};</script>
 <script type="text/javascript" src="//cdn.transifex.com/live.js"></script>


### PR DESCRIPTION
## Overview

Add `notranslate` class to the dynamic sentence component so that transifex ignores the variables and allows the translation of the widget sentences.

## Testing

You need access to transifex. Go to `0.0.0.0:5000?transifex` and login. Then inspect the widget sentences using the transifex live interface.

