### PR TITLE
Fixed empty values that crashed the settings menu

### DIFF
--- a/app/javascript/components/basemaps/component.jsx
+++ b/app/javascript/components/basemaps/component.jsx
@@ -286,7 +286,8 @@ class Basemaps extends React.PureComponent {
                   this.setState({ planetTooltipOpen: !planetTooltipOpen });
                 }}
               >
-                {planetBasemapSelected && planetBasemapSelected.label}
+                {(planetBasemapSelected && planetBasemapSelected.label) ||
+                  'Select...'}
                 <Icon icon={arrowIcon} className="arrow-icon" />
               </span>
             </Tooltip>

--- a/app/javascript/components/basemaps/component.jsx
+++ b/app/javascript/components/basemaps/component.jsx
@@ -223,51 +223,58 @@ class Basemaps extends React.PureComponent {
                       });
                     }}
                   />
-                  <div className="date-selectors">
-                    <Dropdown
-                      className="year-selector"
-                      label="Year"
-                      theme="theme-dropdown-native"
-                      value={planetYearSelected}
-                      options={planetYears}
-                      onChange={selected => {
-                        const selectedYear = planetYears.find(
-                          f => f.value === parseInt(selected, 10)
-                        );
-                        selectBasemap({
-                          value: 'planet',
-                          interval:
-                            (selectedYear && selectedYear.interval) || null,
-                          period: (selectedYear && selectedYear.period) || null,
-                          planetYear: parseInt(selected, 10),
-                          url: (selectedYear && selectedYear.url) || ''
-                        });
-                      }}
-                      native
-                    />
-                    <Dropdown
-                      className="period-selector"
-                      label="Period"
-                      theme="theme-dropdown-native"
-                      value={planetPeriodSelected}
-                      options={planetPeriods}
-                      onChange={selected => {
-                        const selectedPeriod = planetPeriods.find(
-                          f => f.value === selected
-                        );
-                        selectBasemap({
-                          value: 'planet',
-                          period: selected,
-                          interval:
-                            (selectedPeriod && selectedPeriod.interval) || '',
-                          planetYear:
-                            (selectedPeriod && selectedPeriod.year) || '',
-                          url: (selectedPeriod && selectedPeriod.url) || ''
-                        });
-                      }}
-                      native
-                    />
-                  </div>
+                  {planetYears && planetPeriods ? (
+                    <div className="date-selectors">
+                      <Dropdown
+                        className="year-selector"
+                        label="Year"
+                        theme="theme-dropdown-native"
+                        value={planetYearSelected}
+                        options={planetYears}
+                        onChange={selected => {
+                          const selectedYear = planetYears.find(
+                            f => f.value === parseInt(selected, 10)
+                          );
+                          selectBasemap({
+                            value: 'planet',
+                            interval:
+                              (selectedYear && selectedYear.interval) || null,
+                            period:
+                              (selectedYear && selectedYear.period) || null,
+                            planetYear: parseInt(selected, 10),
+                            url: (selectedYear && selectedYear.url) || ''
+                          });
+                        }}
+                        native
+                      />
+                      <Dropdown
+                        className="period-selector"
+                        label="Period"
+                        theme="theme-dropdown-native"
+                        value={planetPeriodSelected}
+                        options={planetPeriods}
+                        onChange={selected => {
+                          const selectedPeriod = planetPeriods.find(
+                            f => f.value === selected
+                          );
+                          selectBasemap({
+                            value: 'planet',
+                            period: selected,
+                            interval:
+                              (selectedPeriod && selectedPeriod.interval) || '',
+                            planetYear:
+                              (selectedPeriod && selectedPeriod.year) || '',
+                            url: (selectedPeriod && selectedPeriod.url) || ''
+                          });
+                        }}
+                        native
+                      />
+                    </div>
+                  ) : (
+                    <div className="date-selectors">
+                      <p>There was an error retrieving the data.</p>
+                    </div>
+                  )}
                 </div>
               }
               trigger="click"

--- a/app/javascript/components/basemaps/selectors.js
+++ b/app/javascript/components/basemaps/selectors.js
@@ -79,12 +79,16 @@ export const selectPlanetBasemapsIntervalOptions = createSelector(
   [getPlanetBasemapsByInvertal],
   planetBasemaps => {
     if (isEmpty(planetBasemaps)) return intervalOptions;
-    return intervalOptions.map(f => ({
-      ...f,
-      year: planetBasemaps[f.value][0].year,
-      url: planetBasemaps[f.value][0].url,
-      period: planetBasemaps[f.value][0].period
-    }));
+    return intervalOptions.map(
+      f =>
+        (planetBasemaps[f.value][0] && {
+          ...f,
+          year: planetBasemaps[f.value][0].year,
+          url: planetBasemaps[f.value][0].url,
+          period: planetBasemaps[f.value][0].period
+        }) ||
+        intervalOptions.find(interval => interval.value === f.value)
+    );
   }
 );
 

--- a/app/javascript/components/basemaps/styles.scss
+++ b/app/javascript/components/basemaps/styles.scss
@@ -306,5 +306,9 @@ $top-section-height: 125px;
         width: 100%;
       }
     }
+
+    p {
+      max-width: 160px;
+    }
   }
 }


### PR DESCRIPTION
## Overview

When retrieving planet basemap data, the default selected value caused a conflict with the empty data retrieved, causing the basemap settings menu to crash. Added a couple of checks to avoid this.

![image](https://user-images.githubusercontent.com/7013170/60872665-6734f100-a235-11e9-8cbd-293bf4d46eae.png)

