### PR TITLE
Fix/widget list links

### DIFF
--- a/app/javascript/components/map/selectors.js
+++ b/app/javascript/components/map/selectors.js
@@ -349,12 +349,12 @@ export const getActiveLayersWithDates = createSelector(
             ...(startDate && {
               startYear: moment(startDate).year(),
               startMonth: moment(startDate).month(),
-              startDay: moment(startDate).month()
+              startDay: moment(startDate).dayOfYear()
             }),
             ...(endDate && {
               endYear: moment(endDate).year(),
               endMonth: moment(endDate).month(),
-              endDay: moment(endDate).month()
+              endDay: moment(endDate).dayOfYear()
             }),
             ...getDayRange(decodeParams)
           }

--- a/app/javascript/components/widgets/widgets/forest-change/fao-deforest/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/fao-deforest/selectors.js
@@ -41,7 +41,13 @@ export const parseData = createSelector(
       path: {
         type,
         payload: { type: 'country', adm0: d.iso },
-        query
+        query: {
+          ...query,
+          map: {
+            ...(query && query.map),
+            canBound: true
+          }
+        }
       },
       value: d.deforest
     }));

--- a/app/javascript/components/widgets/widgets/forest-change/fao-reforest/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/fao-reforest/selectors.js
@@ -52,7 +52,13 @@ export const parseData = createSelector(
           type: 'country',
           adm0: d.iso
         },
-        query
+        query: {
+          ...query,
+          map: {
+            ...(query && query.map),
+            canBound: true
+          }
+        }
       },
       value: d.rate
     }));

--- a/app/javascript/components/widgets/widgets/forest-change/glad-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/glad-ranked/selectors.js
@@ -80,13 +80,19 @@ export const parseList = createSelector(
             payload: {
               ...payload,
               ...(payload.adm1 && {
-                adm2: k
+                adm2: parseInt(k, 10)
               }),
               ...(!payload.adm1 && {
-                adm1: k
+                adm1: parseInt(k, 10)
               })
             },
-            query
+            query: {
+              ...query,
+              map: {
+                ...(query && query.map),
+                canBound: true
+              }
+            }
           }
         };
       });

--- a/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/selectors.js
@@ -47,7 +47,13 @@ export const getSortedData = createSelector(
                 adm1: d.id
               })
             },
-            query
+            query: {
+              ...query,
+              map: {
+                ...(query && query.map),
+                canBound: true
+              }
+            }
           },
           color: colors.main
         });

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/selectors.js
@@ -54,7 +54,13 @@ export const mapData = createSelector(
               adm1: d.id
             })
           },
-          query
+          query: {
+            ...query,
+            map: {
+              ...(query && query.map),
+              canBound: true
+            }
+          }
         }
       };
     });
@@ -110,8 +116,11 @@ export const parseSentence = createSelector(
       percentileLoss / totalLoss < 0.5 &&
       percentileLength !== 10
     ) {
-      percentileLoss += sortedData[percentileLength].loss;
-      percentileLength += 1;
+      const percentile = sortedData[percentileLength];
+      if (percentile) {
+        percentileLoss += percentile.loss;
+        percentileLength += 1;
+      }
     }
 
     const topLoss = percentileLoss / totalLoss * 100 || 0;

--- a/app/javascript/components/widgets/widgets/land-cover/ranked-plantations/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/ranked-plantations/selectors.js
@@ -76,7 +76,13 @@ export const parseData = createSelector(
               adm1: regionId
             })
           },
-          query
+          query: {
+            ...query,
+            map: {
+              ...(query && query.map),
+              canBound: true
+            }
+          }
         },
         extLink: embed
       };

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/selectors.js
@@ -4,13 +4,11 @@ import findIndex from 'lodash/findIndex';
 import { sortByKey } from 'utils/data';
 import { format } from 'd3-format';
 import sumBy from 'lodash/sumBy';
-import { getAdminPath } from 'components/widgets/utils/strings';
 
 // get list data
 const getData = state => state.data || null;
 const getSettings = state => state.settings || null;
-const getLocation = state => state.location || null;
-const getQuery = state => state.query || null;
+const getLocation = state => state.allLocation || null;
 const getLocationData = state => state.locationData || null;
 const getColors = state => state.colors || null;
 const getIndicator = state => state.indicator || null;
@@ -41,10 +39,9 @@ export const parseData = createSelector(
     getLocation,
     getLocationObject,
     getLocationData,
-    getColors,
-    getQuery
+    getColors
   ],
-  (data, settings, location, locationObject, meta, colors, query) => {
+  (data, settings, location, locationObject, meta, colors) => {
     if (!data || !data.length || !locationObject || !meta) return null;
     const locationIndex = findIndex(
       data,
@@ -61,6 +58,7 @@ export const parseData = createSelector(
       trimEnd = data.length;
     }
     const dataTrimmed = data.slice(trimStart, trimEnd);
+    const { query, payload, type } = location;
     return dataTrimmed.map(d => {
       const locationData = meta && meta.find(l => d.id === l.value);
 
@@ -68,7 +66,20 @@ export const parseData = createSelector(
         ...d,
         label: (locationData && locationData.label) || '',
         color: colors.main,
-        path: getAdminPath({ ...location, query, id: d.id }),
+        path: {
+          type,
+          payload: {
+            ...payload,
+            adm0: locationData && locationData.value
+          },
+          query: {
+            ...query,
+            map: {
+              ...(query && query.map),
+              canBound: true
+            }
+          }
+        },
         value: settings.unit === 'ha' ? d.extent : d.percentage
       };
     });


### PR DESCRIPTION
Fixes issues with ranked list widgets links not passing the payload for redux first router correctly. In some cases numbers were being passes as strings. Now the links work and fit bounds correctly on the map.

Also fixes an old issues with the timeline params for the decoded layers on the map.

To test check all widgets with links in their lists.