### PR TITLE
Fix/planet basemap backwards compatibility

### DIFF
--- a/app.json
+++ b/app.json
@@ -131,6 +131,9 @@
     "NPM_CONFIG_PRODUCTION": {
       "required": true
     },
+    "PLANET_API_KEY": {
+      "required": true
+    },
     "RAILS_ENV": {
       "required": true
     },

--- a/app/javascript/components/basemaps/component.jsx
+++ b/app/javascript/components/basemaps/component.jsx
@@ -155,10 +155,10 @@ class Basemaps extends React.PureComponent {
       planetPeriodSelected
     } = this.props;
     const { planetTooltipOpen } = this.state;
-    const { url, interval, year, period } = planetBasemapSelected || {};
+    const { name, interval, year, period } = planetBasemapSelected || {};
     const basemap = {
       value: 'planet',
-      url,
+      name,
       interval,
       planetYear: year,
       period
@@ -219,7 +219,7 @@ class Basemaps extends React.PureComponent {
                           (selectedInvertal && selectedInvertal.period) || null,
                         planetYear:
                           (selectedInvertal && selectedInvertal.year) || null,
-                        url: (selectedInvertal && selectedInvertal.url) || ''
+                        name: (selectedInvertal && selectedInvertal.name) || ''
                       });
                     }}
                   />
@@ -242,7 +242,7 @@ class Basemaps extends React.PureComponent {
                             period:
                               (selectedYear && selectedYear.period) || null,
                             planetYear: parseInt(selected, 10),
-                            url: (selectedYear && selectedYear.url) || ''
+                            name: (selectedYear && selectedYear.name) || ''
                           });
                         }}
                         native
@@ -264,7 +264,7 @@ class Basemaps extends React.PureComponent {
                               (selectedPeriod && selectedPeriod.interval) || '',
                             planetYear:
                               (selectedPeriod && selectedPeriod.year) || '',
-                            url: (selectedPeriod && selectedPeriod.url) || ''
+                            name: (selectedPeriod && selectedPeriod.name) || ''
                           });
                         }}
                         native

--- a/app/javascript/components/basemaps/selectors.js
+++ b/app/javascript/components/basemaps/selectors.js
@@ -51,7 +51,7 @@ export const getPlanetBasemaps = createSelector(
         return {
           label: `${year}/${period}`,
           interval: p.interval,
-          url: p._links.tiles,
+          name: p.name,
           year,
           period
         };
@@ -84,7 +84,7 @@ export const selectPlanetBasemapsIntervalOptions = createSelector(
         (planetBasemaps[f.value][0] && {
           ...f,
           year: planetBasemaps[f.value][0].year,
-          url: planetBasemaps[f.value][0].url,
+          name: planetBasemaps[f.value][0].name,
           period: planetBasemaps[f.value][0].period
         }) ||
         intervalOptions.find(interval => interval.value === f.value)
@@ -114,7 +114,7 @@ export const getPlanetBasemapSelected = createSelector(
     if (isEmpty(planetBasemaps)) return null;
     if (basemap.value !== 'planet') return planetBasemaps[0];
 
-    return planetBasemaps.find(p => p.url === basemap.url);
+    return planetBasemaps.find(p => p.name === basemap.name);
   }
 );
 
@@ -127,7 +127,7 @@ export const getPlanetYears = createSelector(
     return Object.keys(groupByYears).map(y => ({
       label: y,
       value: parseInt(y, 10),
-      url: groupByYears[y] && groupByYears[y][0].url,
+      name: groupByYears[y] && groupByYears[y][0].name,
       interval: groupByYears[y] && groupByYears[y][0].interval,
       period: groupByYears[y] && groupByYears[y][0].period
     }));

--- a/app/javascript/components/map/basemaps.js
+++ b/app/javascript/components/map/basemaps.js
@@ -48,7 +48,7 @@ export default {
     image: satelliteImage,
     mapStyle:
       'mapbox://styles/resourcewatch/cjww89e5j08o91cmjsbrd47qt?fresh=true',
-    url: `https://tiles.planet.com/basemaps/v1/planet-tiles/global_{frequency}_{period}_mosaic/gmap/{z}/{x}/{y}.png?api_key=${
+    url: `https://tiles.planet.com/basemaps/v1/planet-tiles/{name}/gmap/{z}/{x}/{y}.png?api_key=${
       process.env.PLANET_API_KEY
     }`
   }


### PR DESCRIPTION
Fix to remove the use or URL when dispatching action to change the planet basemap and replacing it with the `name` prop from the source data and following the same replacement method in the selectors as LANDSAT `year` prop. This is to solve the issue of API changes (which exist in the URL received from planet) so that older links are backwards compatible with updates.