### PR TITLE
Fix/widget improvements

### DIFF
--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/config.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/config.js
@@ -10,7 +10,7 @@ export default {
   types: ['global'],
   admins: ['global'],
   options: {
-    forestTypes: ['ifl'],
+    forestTypes: ['ifl', 'primary_forest'],
     landCategories: ['wdpa'],
     extentYears: true,
     thresholds: true,

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/selectors.js
@@ -1,10 +1,10 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
+import sum from 'lodash/sum';
 import groupBy from 'lodash/groupBy';
 import { format } from 'd3-format';
 import moment from 'moment';
-import {} from 'utils/calculations';
 import { sortByKey, getColorPalette } from 'utils/data';
 import { yearTicksFormatter } from 'components/widgets/utils/data';
 
@@ -73,6 +73,7 @@ export const parseData = createSelector(
   [getFilteredData, getTopIsos],
   (data, isos) => {
     if (isEmpty(data)) return null;
+
     const allCountries = Object.keys(groupBy(data, 'iso'));
     const topData = data.filter(d => isos.indexOf(d.iso) > -1);
     let otherData = [];
@@ -90,7 +91,8 @@ export const parseData = createSelector(
 
       return {
         year: y,
-        ...datakeys
+        ...datakeys,
+        total: sum(Object.values(datakeys))
       };
     });
   }
@@ -114,6 +116,12 @@ export const parseConfig = createSelector(
     let tooltip = [
       {
         key: 'year'
+      },
+      {
+        key: 'total',
+        label: 'Total',
+        unit: 'ha',
+        unitFormat: value => format('.3s')(value)
       }
     ];
     tooltip = tooltip.concat(

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss/config.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss/config.js
@@ -30,9 +30,9 @@ export default {
   },
   sentence: {
     initial:
-      'From {startYear} to {endYear}, {location} lost {loss} of tree cover, equivalent to a {percent} decrease since {extentYear}',
+      'From {startYear} to {endYear}, {location} lost {loss} of tree cover, equivalent to a {percent} decrease in tree cover since {extentYear}',
     withIndicator:
-      'From {startYear} to {endYear}, {location} lost {loss} of tree cover in {indicator}, equivalent to a {percent} decrease since {extentYear}',
+      'From {startYear} to {endYear}, {location} lost {loss} of tree cover in {indicator}, equivalent to a {percent} decrease in tree cover since {extentYear}',
     noLoss:
       'From {startYear} to {endYear}, {location} lost {loss} of tree cover',
     noLossWithIndicator:

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover/config.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover/config.js
@@ -4,7 +4,7 @@ export default {
   // title for header
   title: {
     default: 'Tree cover in {location}',
-    global: 'Global forest cover',
+    global: 'Global tree cover',
     withPlantations: 'Forest cover in {location}'
   },
   // sentences for header

--- a/app/javascript/components/widgets/widgets/land-cover/us-land-cover/settings.js
+++ b/app/javascript/components/widgets/widgets/land-cover/us-land-cover/settings.js
@@ -1,7 +1,4 @@
 export default {
-  threshold: 10,
-  pageSize: 5,
-  page: 0,
   startYear: 2001,
   endYear: 2016,
   variable: 'changes_only',


### PR DESCRIPTION
## Overview

Adds following fixes for widgets:
- removes the 10% canopy density statement from footer for NCLD cover widget
- adds total values to tooltip for the global loss widget
- makes tree loss sentence clearer
- add primary forests to global tree loss widget