### PR TITLE
Fix link to preview image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 dynamic online forest monitoring and alert system that empowers people
 everywhere to better manage forests. This repository contains the GFW web app.
 
-![Global forest watch map](app/assets/images/map-page.png?raw=true "Title")
+![Global forest watch map](app/assets/images/preview.png?raw=true "Title")
 
 # Developing
 


### PR DESCRIPTION
## Overview

Hi team, I was looking at your project on https://explore.ovio.org and noticed that your preview image had a broken link.
I simply updated the link to target https://github.com/Vizzuality/gfw/blob/master/app/assets/images/preview.png.
Hope that works!