### PR TITLE
Feature/relative percentage widgets

### DIFF
--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/config.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/config.js
@@ -2,7 +2,7 @@ export default {
   widget: 'treeLossRanked',
   title: {
     default: 'Tree cover loss in {location} compared to other areas',
-    global: 'Global Tree cover loss'
+    global: 'Countries with the highest tree cover loss'
   },
   categories: ['forest-change'],
   types: ['global', 'country'],
@@ -36,9 +36,9 @@ export default {
     globalWithIndicator:
       'From {startYear} to {endYear}, {topLocationLabel} within {indicator} had the highest relative tree cover loss in the world, eqivalent to a loss of {topLocationLoss}, which represents {topLocationPerc} of the tree cover in the year {extentYear}.',
     initial:
-      'From {startYear} to {endYear}, {location} lost {loss} of tree cover, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of the global total.',
+      'From {startYear} to {endYear}, {location} lost {loss} of relative tree cover, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of the global total.',
     withIndicator:
-      'From {startYear} to {endYear}, {location} lost {loss} of tree cover in {indicator}, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of the global total.',
-    noLoss: 'There was no tree cover loss identified in {location}.'
+      'From {startYear} to {endYear}, {location} lost {loss} of tree relative cover in {indicator}, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of the global total.',
+    noLoss: 'There was no relative tree cover loss identified in {location}.'
   }
 };

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/config.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/config.js
@@ -32,9 +32,9 @@ export default {
   },
   sentence: {
     globalInitial:
-      'From {startYear} to {endYear}, {loss} of tree cover was lost {location}, equivalent to a {localPercent} decrease since {extentYear}.',
+      'From {startYear} to {endYear}, {topLocationLabel} had the highest relative tree cover loss in the world, eqivalent to a loss of {topLocationLoss}, which represents {topLocationPerc} of the tree cover in the year {extentYear}.',
     globalWithIndicator:
-      'From {startYear} to {endYear}, {loss} of tree cover was lost {location}, within {indicator} equivalent to a {localPercent} decrease since {extentYear}',
+      'From {startYear} to {endYear}, {topLocationLabel} within {indicator} had the highest relative tree cover loss in the world, eqivalent to a loss of {topLocationLoss}, which represents {topLocationPerc} of the tree cover in the year {extentYear}.',
     initial:
       'From {startYear} to {endYear}, {location} lost {loss} of tree cover, equivalent to a {localPercent} decrease since {extentYear} and {globalPercent} of the global total.',
     withIndicator:

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
@@ -138,8 +138,15 @@ export const parseData = createSelector(
 );
 
 export const parseSentence = createSelector(
-  [sortData, getSettings, getIndicator, getLocationObject, getSentences],
-  (data, settings, indicator, locationObject, sentences) => {
+  [
+    sortData,
+    getSettings,
+    getIndicator,
+    getLocationObject,
+    getSentences,
+    getLocationsMeta
+  ],
+  (data, settings, indicator, locationObject, sentences, meta) => {
     if (!data || !data.length || !locationObject) return null;
     const { startYear, endYear } = settings;
     const {
@@ -169,8 +176,19 @@ export const parseSentence = createSelector(
       sentence = !indicator ? globalInitial : globalWithIndicator;
     }
     if (loss === 0) sentence = noLoss;
+
+    const topRegionData = data[0];
+    const topRegion =
+      meta && topRegionData && meta.find(m => m.value === topRegionData.id);
+
     const params = {
       indicator: indicatorName,
+      topLocationLabel: topRegion && topRegion.label,
+      topLocationPerc:
+        topRegionData &&
+        formatNumber({ num: topRegionData.percentage, unit: '%' }),
+      topLocationLoss:
+        topRegionData && formatNumber({ num: topRegionData.loss, unit: 'ha' }),
       location:
         locationObject.label === 'global'
           ? 'globally'


### PR DESCRIPTION
## Overview

Updates the loss ranked widget `treeLossRanked` title for global sentences for all levels. At global level the widget now describes to top country and compares to others:

Title
> Countries with the highest tree cover loss

Sentence
> From {startYear} to {endYear}, {topLocationLabel} had the highest relative tree cover loss in the world, eqivalent to a loss of {topLocationLoss}, which represents {topLocationPerc} of the tree cover in the year {extentYear}.

And add changes `tree cover loss` to `relative tree cover loss` at the admin levels.