### PR TITLE
Fixed lower caps for Key Biodiversity Areas indicator

### DIFF
--- a/app/javascript/components/widgets/components/widget/components/widget-footer/selectors.js
+++ b/app/javascript/components/widgets/components/widget/components/widget-footer/selectors.js
@@ -61,7 +61,10 @@ export const getStatements = createSelector(
         ? translateText(
           '*{indicator} are available in {datasetsCount} countries only',
           {
-            indicator: indicator.label.toLowerCase(),
+            indicator:
+                indicator.label === 'Key Biodiversity Areas'
+                  ? indicator.label
+                  : indicator.label.toLowerCase(),
             datasetsCount: datasets[indicator.value]
           }
         )

--- a/app/javascript/components/widgets/components/widget/components/widget-footer/selectors.js
+++ b/app/javascript/components/widgets/components/widget/components/widget-footer/selectors.js
@@ -61,10 +61,7 @@ export const getStatements = createSelector(
         ? translateText(
           '*{indicator} are available in {datasetsCount} countries only',
           {
-            indicator:
-                indicator.label === 'Key Biodiversity Areas'
-                  ? indicator.label
-                  : indicator.label.toLowerCase(),
+            indicator: indicator.label,
             datasetsCount: datasets[indicator.value]
           }
         )

--- a/app/javascript/components/widgets/components/widget/selectors.js
+++ b/app/javascript/components/widgets/components/widget/selectors.js
@@ -194,6 +194,9 @@ export const getIndicator = createSelector(
       label = forestType.label;
       value = forestType.value;
     }
+    if (label !== 'Key Biodiversity Areas') {
+      label = label.toLowerCase();
+    }
 
     return {
       label,

--- a/app/javascript/components/widgets/widgets/climate/emissions-deforestation/selectors.js
+++ b/app/javascript/components/widgets/widgets/climate/emissions-deforestation/selectors.js
@@ -75,17 +75,9 @@ export const parseSentence = createSelector(
       unit === 'biomassLoss' ? 'aboveground biomass' : 'CO\u2082';
     let indicatorText = '';
     if (indicator && indicator.value === 'mining') {
-      indicatorText = ` ${
-        indicator.label === 'Key Biodiversity Areas'
-          ? indicator.label
-          : indicator.label.toLowerCase()
-      } regions`;
+      indicatorText = ` ${indicator.label} regions`;
     } else if (indicator) {
-      indicatorText = ` ${
-        indicator.label === 'Key Biodiversity Areas'
-          ? indicator.label
-          : indicator.label.toLowerCase()
-      }`;
+      indicatorText = ` ${indicator.label}`;
     }
 
     const params = {

--- a/app/javascript/components/widgets/widgets/climate/emissions-deforestation/selectors.js
+++ b/app/javascript/components/widgets/widgets/climate/emissions-deforestation/selectors.js
@@ -75,9 +75,17 @@ export const parseSentence = createSelector(
       unit === 'biomassLoss' ? 'aboveground biomass' : 'CO\u2082';
     let indicatorText = '';
     if (indicator && indicator.value === 'mining') {
-      indicatorText = ` ${indicator.label.toLowerCase()} regions`;
+      indicatorText = ` ${
+        indicator.label === 'Key Biodiversity Areas'
+          ? indicator.label
+          : indicator.label.toLowerCase()
+      } regions`;
     } else if (indicator) {
-      indicatorText = ` ${indicator.label.toLowerCase()}`;
+      indicatorText = ` ${
+        indicator.label === 'Key Biodiversity Areas'
+          ? indicator.label
+          : indicator.label.toLowerCase()
+      }`;
     }
 
     const params = {

--- a/app/javascript/components/widgets/widgets/forest-change/fires-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/fires-ranked/selectors.js
@@ -122,7 +122,15 @@ export const parseSentence = createSelector(
       topRegionCount: format(',')(topRegionCount),
       topRegionPerc: `${format('.2r')(topRegionPerc)}%`,
       location: locationName,
-      indicator: `${indicator ? `${indicator.label.toLowerCase()}` : ''}`
+      indicator: `${
+        indicator
+          ? `${
+            indicator.label === 'Key Biodiversity Areas'
+              ? indicator.label
+              : indicator.label.toLowerCase()
+          }`
+          : ''
+      }`
     };
     const sentence = indicator ? withInd : initial;
     return { sentence, params };

--- a/app/javascript/components/widgets/widgets/forest-change/fires-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/fires-ranked/selectors.js
@@ -122,15 +122,7 @@ export const parseSentence = createSelector(
       topRegionCount: format(',')(topRegionCount),
       topRegionPerc: `${format('.2r')(topRegionPerc)}%`,
       location: locationName,
-      indicator: `${
-        indicator
-          ? `${
-            indicator.label === 'Key Biodiversity Areas'
-              ? indicator.label
-              : indicator.label.toLowerCase()
-          }`
-          : ''
-      }`
+      indicator: `${indicator ? `${indicator.label}` : ''}`
     };
     const sentence = indicator ? withInd : initial;
     return { sentence, params };

--- a/app/javascript/components/widgets/widgets/forest-change/glad-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/glad-ranked/selectors.js
@@ -146,7 +146,15 @@ export const parseSentence = createSelector(
           ? `${percentileLength} region`
           : `${percentileLength} regions`,
       location: locationName,
-      indicator: `${indicator ? `${indicator.label.toLowerCase()}` : ''}`
+      indicator: `${
+        indicator
+          ? `${
+            indicator.label === 'Key Biodiversity Areas'
+              ? indicator.label
+              : indicator.label.toLowerCase()
+          }`
+          : ''
+      }`
     };
     const sentence = indicator ? withInd : initial;
     return { sentence, params };

--- a/app/javascript/components/widgets/widgets/forest-change/glad-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/glad-ranked/selectors.js
@@ -146,15 +146,7 @@ export const parseSentence = createSelector(
           ? `${percentileLength} region`
           : `${percentileLength} regions`,
       location: locationName,
-      indicator: `${
-        indicator
-          ? `${
-            indicator.label === 'Key Biodiversity Areas'
-              ? indicator.label
-              : indicator.label.toLowerCase()
-          }`
-          : ''
-      }`
+      indicator: `${indicator ? `${indicator.label}` : ''}`
     };
     const sentence = indicator ? withInd : initial;
     return { sentence, params };

--- a/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
@@ -167,12 +167,7 @@ export const parseSentence = createSelector(
     const params = {
       location: currentLabel === 'global' ? 'globally' : currentLabel,
       gain: formatNumber({ num: gain, unit: 'ha' }),
-      indicator:
-        (indicator &&
-          (indicator.label === 'Key Biodiversity Areas'
-            ? indicator.label
-            : indicator.label.toLowerCase())) ||
-        'region-wide',
+      indicator: (indicator && indicator.label) || 'region-wide',
       percent: formatNumber({ num: areaPercent, unit: '%' }),
       gainPercent: formatNumber({ num: gainPercent, unit: '%' }),
       parent: locationObject.parentLabel || null

--- a/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-cover-gain/selectors.js
@@ -167,7 +167,12 @@ export const parseSentence = createSelector(
     const params = {
       location: currentLabel === 'global' ? 'globally' : currentLabel,
       gain: formatNumber({ num: gain, unit: 'ha' }),
-      indicator: (indicator && indicator.label.toLowerCase()) || 'region-wide',
+      indicator:
+        (indicator &&
+          (indicator.label === 'Key Biodiversity Areas'
+            ? indicator.label
+            : indicator.label.toLowerCase())) ||
+        'region-wide',
       percent: formatNumber({ num: areaPercent, unit: '%' }),
       gainPercent: formatNumber({ num: gainPercent, unit: '%' }),
       parent: locationObject.parentLabel || null

--- a/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/selectors.js
@@ -113,7 +113,11 @@ export const parseSentence = createSelector(
     const aveFormat = avgGain < 1 ? '.3r' : '.3s';
 
     const params = {
-      indicator: indicator && indicator.label.toLowerCase(),
+      indicator:
+        indicator &&
+        (indicator.label === 'Key Biodiversity Areas'
+          ? indicator.label
+          : indicator.label.toLowerCase()),
       location: locationName,
       topGain: `${format('.2r')(topGain)}%`,
       percentileLength: percentileLength || '0',

--- a/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-gain-located/selectors.js
@@ -113,11 +113,7 @@ export const parseSentence = createSelector(
     const aveFormat = avgGain < 1 ? '.3r' : '.3s';
 
     const params = {
-      indicator:
-        indicator &&
-        (indicator.label === 'Key Biodiversity Areas'
-          ? indicator.label
-          : indicator.label.toLowerCase()),
+      indicator: indicator && indicator.label,
       location: locationName,
       topGain: `${format('.2r')(topGain)}%`,
       percentileLength: percentileLength || '0',

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/selectors.js
@@ -176,7 +176,11 @@ export const parseSentence = createSelector(
     const sentence = indicator ? withInd : initial;
 
     const params = {
-      indicator: indicator && indicator.label.toLowerCase(),
+      indicator:
+        indicator &&
+        (indicator.label === 'Key Biodiversity Areas'
+          ? indicator.label
+          : indicator.label.toLowerCase()),
       location: locationName === 'global' ? 'globally' : locationName,
       startYear,
       endYear,

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-global/selectors.js
@@ -176,11 +176,7 @@ export const parseSentence = createSelector(
     const sentence = indicator ? withInd : initial;
 
     const params = {
-      indicator:
-        indicator &&
-        (indicator.label === 'Key Biodiversity Areas'
-          ? indicator.label
-          : indicator.label.toLowerCase()),
+      indicator: indicator && indicator.label,
       location: locationName === 'global' ? 'globally' : locationName,
       startYear,
       endYear,

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/selectors.js
@@ -137,7 +137,11 @@ export const parseSentence = createSelector(
     }
 
     const params = {
-      indicator: indicator && indicator.label.toLowerCase(),
+      indicator:
+        indicator &&
+        (indicator.label === 'Key Biodiversity Areas'
+          ? indicator.label
+          : indicator.label.toLowerCase()),
       location: locationName,
       startYear,
       endYear,

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-located/selectors.js
@@ -137,11 +137,7 @@ export const parseSentence = createSelector(
     }
 
     const params = {
-      indicator:
-        indicator &&
-        (indicator.label === 'Key Biodiversity Areas'
-          ? indicator.label
-          : indicator.label.toLowerCase()),
+      indicator: indicator && indicator.label,
       location: locationName,
       startYear,
       endYear,

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
@@ -170,7 +170,11 @@ export const parseSentence = createSelector(
     const lossPercent = loss && locationData ? 100 * loss / globalLoss : 0;
     const indicatorName = !indicator
       ? 'region-wide'
-      : `${indicator.label.toLowerCase()}`;
+      : `${
+        indicator.label === 'Key Biodiversity Areas'
+          ? indicator.label
+          : indicator.label.toLowerCase()
+      }`;
     let sentence = !indicator ? initial : withIndicator;
     if (locationObject.label === 'global') {
       sentence = !indicator ? globalInitial : globalWithIndicator;

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss-ranked/selectors.js
@@ -168,13 +168,7 @@ export const parseSentence = createSelector(
         ? 100 * globalLoss / globalExtent
         : (locationData && format('.1f')(locationData.percentage)) || 0;
     const lossPercent = loss && locationData ? 100 * loss / globalLoss : 0;
-    const indicatorName = !indicator
-      ? 'region-wide'
-      : `${
-        indicator.label === 'Key Biodiversity Areas'
-          ? indicator.label
-          : indicator.label.toLowerCase()
-      }`;
+    const indicatorName = !indicator ? 'region-wide' : `${indicator.label}`;
     let sentence = !indicator ? initial : withIndicator;
     if (locationObject.label === 'global') {
       sentence = !indicator ? globalInitial : globalWithIndicator;

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss/selectors.js
@@ -123,11 +123,7 @@ export const parseSentence = createSelector(
     sentence = `${sentence}.`;
 
     const params = {
-      indicator:
-        indicator &&
-        (indicator.label === 'Key Biodiversity Areas'
-          ? indicator.label
-          : indicator.label.toLowerCase()),
+      indicator: indicator && indicator.label,
       location: locationName,
       startYear,
       endYear,

--- a/app/javascript/components/widgets/widgets/forest-change/tree-loss/selectors.js
+++ b/app/javascript/components/widgets/widgets/forest-change/tree-loss/selectors.js
@@ -123,7 +123,11 @@ export const parseSentence = createSelector(
     sentence = `${sentence}.`;
 
     const params = {
-      indicator: indicator && indicator.label.toLowerCase(),
+      indicator:
+        indicator &&
+        (indicator.label === 'Key Biodiversity Areas'
+          ? indicator.label
+          : indicator.label.toLowerCase()),
       location: locationName,
       startYear,
       endYear,

--- a/app/javascript/components/widgets/widgets/land-cover/intact-tree-cover/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/intact-tree-cover/selectors.js
@@ -56,8 +56,13 @@ export const parseSentence = createSelector(
       .reduce((sum, d) => sum + d);
     const intactData = parsedData.find(d => d.label === 'Intact Forest').value;
     const intactPercentage = intactData && intactData / totalExtent * 100;
-    const indicatorLabel =
-      indicator && indicator.label ? indicator.label.toLowerCase() : null;
+    let indicatorLabel;
+    if (indicator && indicator.label) {
+      indicatorLabel =
+        indicator.label === 'Key Biodiversity Areas'
+          ? indicator.label
+          : indicator.label.toLowerCase();
+    } else indicatorLabel = null;
 
     const params = {
       location: locationName !== 'global' ? `${locationName}'s` : locationName,

--- a/app/javascript/components/widgets/widgets/land-cover/intact-tree-cover/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/intact-tree-cover/selectors.js
@@ -56,13 +56,8 @@ export const parseSentence = createSelector(
       .reduce((sum, d) => sum + d);
     const intactData = parsedData.find(d => d.label === 'Intact Forest').value;
     const intactPercentage = intactData && intactData / totalExtent * 100;
-    let indicatorLabel;
-    if (indicator && indicator.label) {
-      indicatorLabel =
-        indicator.label === 'Key Biodiversity Areas'
-          ? indicator.label
-          : indicator.label.toLowerCase();
-    } else indicatorLabel = null;
+    const indicatorLabel =
+      indicator && indicator.label ? indicator.label : null;
 
     const params = {
       location: locationName !== 'global' ? `${locationName}'s` : locationName,

--- a/app/javascript/components/widgets/widgets/land-cover/primary-forest/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/primary-forest/selectors.js
@@ -53,14 +53,8 @@ export const parseSentence = createSelector(
     const primaryData = parsedData.find(d => d.label === 'Primary Forest')
       .value;
     const primaryPercentage = primaryData && primaryData / totalExtent * 100;
-
-    let indicatorLabel;
-    if (indicator && indicator.label) {
-      indicatorLabel =
-        indicator.label === 'Key Biodiversity Areas'
-          ? indicator.label
-          : indicator.label.toLowerCase();
-    } else indicatorLabel = null;
+    const indicatorLabel =
+      indicator && indicator.label ? indicator.label : null;
 
     const params = {
       location: `${locationName}'s`,

--- a/app/javascript/components/widgets/widgets/land-cover/primary-forest/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/primary-forest/selectors.js
@@ -54,8 +54,13 @@ export const parseSentence = createSelector(
       .value;
     const primaryPercentage = primaryData && primaryData / totalExtent * 100;
 
-    const indicatorLabel =
-      indicator && indicator.label ? indicator.label.toLowerCase() : null;
+    let indicatorLabel;
+    if (indicator && indicator.label) {
+      indicatorLabel =
+        indicator.label === 'Key Biodiversity Areas'
+          ? indicator.label
+          : indicator.label.toLowerCase();
+    } else indicatorLabel = null;
 
     const params = {
       location: `${locationName}'s`,

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
@@ -149,11 +149,7 @@ export const parseSentence = createSelector(
     const params = {
       location: locationName === 'global' ? 'Globally' : locationName,
       region: topRegion.label,
-      indicator:
-        indicator &&
-        (indicator.label === 'Key Biodiversity Areas'
-          ? indicator.label
-          : indicator.label.toLowerCase()),
+      indicator: indicator && indicator.label,
       percentage: topExtent ? `${format('.2r')(topExtent)}%` : '0%',
       year: settings.extentYear,
       value: settings.unit === '%' ? topRegionPercent : topRegionExtent,

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-located/selectors.js
@@ -149,7 +149,11 @@ export const parseSentence = createSelector(
     const params = {
       location: locationName === 'global' ? 'Globally' : locationName,
       region: topRegion.label,
-      indicator: indicator && indicator.label.toLowerCase(),
+      indicator:
+        indicator &&
+        (indicator.label === 'Key Biodiversity Areas'
+          ? indicator.label
+          : indicator.label.toLowerCase()),
       percentage: topExtent ? `${format('.2r')(topExtent)}%` : '0%',
       year: settings.extentYear,
       value: settings.unit === '%' ? topRegionPercent : topRegionExtent,

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/selectors.js
@@ -121,11 +121,7 @@ export const parseSentence = createSelector(
         extent < 1
           ? `${format('.3r')(extent)}ha`
           : `${format('.3s')(extent)}ha`,
-      indicator:
-        indicator &&
-        (indicator.label === 'Key Biodiversity Areas'
-          ? indicator.label
-          : indicator.label.toLowerCase()),
+      indicator: indicator && indicator.label,
       landPercentage:
         landPercent >= 0.1 ? `${format('.2r')(landPercent)}%` : '< 0.1%',
       globalPercentage:

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover-ranked/selectors.js
@@ -121,7 +121,11 @@ export const parseSentence = createSelector(
         extent < 1
           ? `${format('.3r')(extent)}ha`
           : `${format('.3s')(extent)}ha`,
-      indicator: indicator && indicator.label.toLowerCase(),
+      indicator:
+        indicator &&
+        (indicator.label === 'Key Biodiversity Areas'
+          ? indicator.label
+          : indicator.label.toLowerCase()),
       landPercentage:
         landPercent >= 0.1 ? `${format('.2r')(landPercent)}%` : '< 0.1%',
       globalPercentage:

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover/selectors.js
@@ -109,7 +109,11 @@ export const parseSentence = createSelector(
     const params = {
       year: settings.extentYear,
       location: locationName || 'global',
-      indicator: indicator && indicator.label.toLowerCase(),
+      indicator:
+        indicator &&
+        (indicator.label === 'Key Biodiversity Areas'
+          ? indicator.label
+          : indicator.label.toLowerCase()),
       percentage:
         percentCover >= 0.1 ? `${format('.2r')(percentCover)}%` : '< 0.1%',
       value:

--- a/app/javascript/components/widgets/widgets/land-cover/tree-cover/selectors.js
+++ b/app/javascript/components/widgets/widgets/land-cover/tree-cover/selectors.js
@@ -109,11 +109,7 @@ export const parseSentence = createSelector(
     const params = {
       year: settings.extentYear,
       location: locationName || 'global',
-      indicator:
-        indicator &&
-        (indicator.label === 'Key Biodiversity Areas'
-          ? indicator.label
-          : indicator.label.toLowerCase()),
+      indicator: indicator && indicator.label,
       percentage:
         percentCover >= 0.1 ? `${format('.2r')(percentCover)}%` : '< 0.1%',
       value:


### PR DESCRIPTION
## Overview

Related [thread](https://basecamp.com/3063126/projects/10727890/todos/404782334).

This PR fixes the capitalization of Key Biodiversity Areas in the dashboard widgets. However, because it's the only indicator that is kept with the original capitalization (see thread), I had to add a lot of "special cases" in the widget configs, and there's probably a better way of doing this.