### PR TITLE
[Fix, not urgent] Fixed downloads for GLAD and VIIRS alerts on the map legend

### DIFF
--- a/app/javascript/components/analysis/components/show-analysis/selectors.js
+++ b/app/javascript/components/analysis/components/show-analysis/selectors.js
@@ -17,13 +17,8 @@ const selectData = state => state.analysis && state.analysis.data;
 const selectError = state => state.analysis && state.analysis.error;
 
 export const getDataFromLayers = createSelector(
-  [getActiveLayers, selectData, selectLocation, getWidgetLayers],
-  (
-    layers,
-    data,
-    location
-    // , widgetLayers
-  ) => {
+  [getActiveLayers, selectData, selectLocation],
+  (layers, data, location) => {
     if (!layers || !layers.length) return null;
 
     const { type } = location;
@@ -36,7 +31,6 @@ export const getDataFromLayers = createSelector(
           !l.isBoundary &&
           !l.isRecentImagery &&
           l.analysisConfig &&
-          // (!widgetLayers || !widgetLayers.includes(l.id)) &&
           (!l.admLevels || l.admLevels.includes(admLevel))
       )
       .map(l => {

--- a/app/javascript/components/analysis/components/show-analysis/selectors.js
+++ b/app/javascript/components/analysis/components/show-analysis/selectors.js
@@ -17,8 +17,8 @@ const selectData = state => state.analysis && state.analysis.data;
 const selectError = state => state.analysis && state.analysis.error;
 
 export const getDataFromLayers = createSelector(
-  [getActiveLayers, selectData, selectLocation],
-  (layers, data, location) => {
+  [getActiveLayers, selectData, selectLocation, getWidgetLayers],
+  (layers, data, location, widgetLayers) => {
     if (!layers || !layers.length) return null;
 
     const { type } = location;
@@ -31,6 +31,7 @@ export const getDataFromLayers = createSelector(
           !l.isBoundary &&
           !l.isRecentImagery &&
           l.analysisConfig &&
+          (!widgetLayers || !widgetLayers.includes(l.id)) &&
           (!l.admLevels || l.admLevels.includes(admLevel))
       )
       .map(l => {

--- a/app/javascript/components/analysis/components/show-analysis/selectors.js
+++ b/app/javascript/components/analysis/components/show-analysis/selectors.js
@@ -18,7 +18,12 @@ const selectError = state => state.analysis && state.analysis.error;
 
 export const getDataFromLayers = createSelector(
   [getActiveLayers, selectData, selectLocation, getWidgetLayers],
-  (layers, data, location, widgetLayers) => {
+  (
+    layers,
+    data,
+    location
+    // , widgetLayers
+  ) => {
     if (!layers || !layers.length) return null;
 
     const { type } = location;
@@ -31,7 +36,7 @@ export const getDataFromLayers = createSelector(
           !l.isBoundary &&
           !l.isRecentImagery &&
           l.analysisConfig &&
-          (!widgetLayers || !widgetLayers.includes(l.id)) &&
+          // (!widgetLayers || !widgetLayers.includes(l.id)) &&
           (!l.admLevels || l.admLevels.includes(admLevel))
       )
       .map(l => {
@@ -85,6 +90,7 @@ export const getCountryDownloadLink = createSelector(
 export const getDownloadLinks = createSelector(
   [getDataFromLayers, getCountryDownloadLink],
   (data, countryUrl) => {
+    // dataset-related download links
     const layerLinks =
       data &&
       data.filter(d => d.downloadUrls && d.value).map(d => {
@@ -112,6 +118,7 @@ export const getDownloadLinks = createSelector(
         };
       });
 
+    // admin-related download links
     return countryUrl
       ? [
         {

--- a/app/javascript/components/analysis/selectors.js
+++ b/app/javascript/components/analysis/selectors.js
@@ -101,18 +101,13 @@ export const getWidgetLayers = createSelector(
 );
 
 export const getLayerEndpoints = createSelector(
-  [getAllLayers, getDataLocation, getWidgetLayers],
-  (
-    layers,
-    location
-    // , widgetLayers
-  ) => {
+  [getAllLayers, getDataLocation],
+  (layers, location) => {
     if (!layers || !layers.length) return null;
 
     const { type, adm2 } = location;
     const routeType = type === 'country' ? 'admin' : type;
     const lossLayer = layers.find(l => l.metadata === 'tree_cover_loss');
-    // const hasWidgetLayers = widgetLayers && !!widgetLayers.length;
 
     const admLevel = locationLevelToStr(location);
     const endpoints = compact(
@@ -121,7 +116,6 @@ export const getLayerEndpoints = createSelector(
           l =>
             l.analysisConfig &&
             !l.analysisDisabled &&
-            // (!hasWidgetLayers || !widgetLayers.includes(l.id)) &&
             (!l.admLevels || l.admLevels.includes(admLevel))
         )
         .map(l => {

--- a/app/javascript/components/analysis/selectors.js
+++ b/app/javascript/components/analysis/selectors.js
@@ -102,13 +102,17 @@ export const getWidgetLayers = createSelector(
 
 export const getLayerEndpoints = createSelector(
   [getAllLayers, getDataLocation, getWidgetLayers],
-  (layers, location, widgetLayers) => {
+  (
+    layers,
+    location
+    // , widgetLayers
+  ) => {
     if (!layers || !layers.length) return null;
 
     const { type, adm2 } = location;
     const routeType = type === 'country' ? 'admin' : type;
     const lossLayer = layers.find(l => l.metadata === 'tree_cover_loss');
-    const hasWidgetLayers = widgetLayers && !!widgetLayers.length;
+    // const hasWidgetLayers = widgetLayers && !!widgetLayers.length;
 
     const admLevel = locationLevelToStr(location);
     const endpoints = compact(
@@ -117,7 +121,7 @@ export const getLayerEndpoints = createSelector(
           l =>
             l.analysisConfig &&
             !l.analysisDisabled &&
-            (!hasWidgetLayers || !widgetLayers.includes(l.id)) &&
+            // (!hasWidgetLayers || !widgetLayers.includes(l.id)) &&
             (!l.admLevels || l.admLevels.includes(admLevel))
         )
         .map(l => {

--- a/app/javascript/components/analysis/selectors.js
+++ b/app/javascript/components/analysis/selectors.js
@@ -101,13 +101,14 @@ export const getWidgetLayers = createSelector(
 );
 
 export const getLayerEndpoints = createSelector(
-  [getAllLayers, getDataLocation],
-  (layers, location) => {
+  [getAllLayers, getDataLocation, getWidgetLayers],
+  (layers, location, widgetLayers) => {
     if (!layers || !layers.length) return null;
 
     const { type, adm2 } = location;
     const routeType = type === 'country' ? 'admin' : type;
     const lossLayer = layers.find(l => l.metadata === 'tree_cover_loss');
+    const hasWidgetLayers = widgetLayers && !!widgetLayers.length;
 
     const admLevel = locationLevelToStr(location);
     const endpoints = compact(
@@ -116,6 +117,7 @@ export const getLayerEndpoints = createSelector(
           l =>
             l.analysisConfig &&
             !l.analysisDisabled &&
+            (!hasWidgetLayers || !widgetLayers.includes(l.id)) &&
             (!l.admLevels || l.admLevels.includes(admLevel))
         )
         .map(l => {

--- a/app/javascript/components/widget/components/widget-header/component.jsx
+++ b/app/javascript/components/widget/components/widget-header/component.jsx
@@ -54,8 +54,7 @@ class WidgetHeader extends PureComponent {
     } = this.props;
 
     const showSettingsBtn = !embed && !simple && !isEmpty(settingsConfig);
-    const showDownloadBtn =
-      !embed && !simple && getDataURL && status !== 'pending';
+    const showDownloadBtn = !embed && getDataURL && status !== 'pending';
     const showMapBtn = !embed && !simple && datasets;
     const showSeparator = showSettingsBtn || showMapBtn;
 

--- a/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
+++ b/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
@@ -6,6 +6,7 @@ import snakeCase from 'lodash/snakeCase';
 import JSZipUtils from 'jszip-utils';
 import moment from 'moment';
 import { saveAs } from 'file-saver';
+import cx from 'classnames';
 
 import Button from 'components/ui/button';
 import Icon from 'components/ui/icon';
@@ -24,7 +25,8 @@ class WidgetDownloadButton extends PureComponent {
     childData: PropTypes.object,
     location: PropTypes.object,
     adminLevel: PropTypes.string,
-    metaKey: PropTypes.string
+    metaKey: PropTypes.string,
+    simple: PropTypes.bool
   };
 
   generateZipFromURL = () => {
@@ -175,8 +177,12 @@ class WidgetDownloadButton extends PureComponent {
   render() {
     return (
       <Button
-        className="c-widget-download-button"
-        theme="theme-button-small square"
+        className={cx('c-widget-download-button', {
+          'small-download-button': this.props.simple
+        })}
+        theme={cx('theme-button-small square', {
+          'theme-button-grey-filled theme-button-xsmall': this.props.simple
+        })}
         onClick={this.generateZipFromURL}
         tooltip={{ text: 'Download the data' }}
       >

--- a/app/javascript/components/widget/components/widget-header/components/widget-download-button/styles.scss
+++ b/app/javascript/components/widget/components/widget-header/components/widget-download-button/styles.scss
@@ -5,4 +5,12 @@
     width: rem(10px);
     height: rem(10px);
   }
+
+  &,
+  .small-download-button {
+    .download-icon {
+      width: rem(8px);
+      height: rem(8px);
+    }
+  }
 }


### PR DESCRIPTION
## Overview

Updated the widget header component to show the download button _also_ for widgets in the map legend so everybody can download data for the widgets directly from there. This allows downloads for GLAD and VIIRS datasets from the map, and more.