### PR TITLE
Fix reset password for MyGFW

### DIFF
--- a/app/javascript/components/forms/login/actions.js
+++ b/app/javascript/components/forms/login/actions.js
@@ -34,11 +34,9 @@ export const registerUser = createThunkAction('sendRegisterUser', data => () =>
 
 export const resetUserPassword = createThunkAction(
   'sendResetPassword',
-  ({ data, success }) => () =>
+  data => () =>
     resetPassword(data)
-      .then(() => {
-        success();
-      })
+      .then(() => {})
       .catch(error => {
         const { errors } = error.response.data;
 


### PR DESCRIPTION
## Overview

This PR fixes resetting password for MyGFW.
It sends the email to the API and the rest is handled there.
The issue was that the `resetUserPassword` was sending an empty string (incorrect destructuring issue)

## Testing

- Go to My GFW tab
- Click Forgot Password
- Put your email
- Hit OK
- Check that you got the email or check in the Network tab that you're sending the **Request Payload**
![image](https://user-images.githubusercontent.com/6136899/75353188-d9307800-58a2-11ea-8229-c599fc4c95f7.png)
