### PR TITLE
extend endyear to 2018 data for tcl by driver

### DIFF
--- a/app/javascript/components/widgets/forest-change/tree-loss-tsc/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss-tsc/index.js
@@ -105,10 +105,10 @@ export default {
           ...data,
           settings: {
             startYear,
-            endYear: 2015
+            endYear: 2018
           },
           options: {
-            years: range.filter(y => y.value <= 2015)
+            years: range.filter(y => y.value <= 2018)
           }
         };
       })


### PR DESCRIPTION
## Overview

Extension of the endyear for the TCL by driver dashboard to 2018 using the new table id (table id on staging d833af84-c790-4bbc-b081-6d27cb08c18d/ and table id on production 7610bcaf-4f3c-473e-8fa1-4625c92f14b4). 

<img width="793" alt="Screenshot 2020-03-04 at 16 57 41" src="https://user-images.githubusercontent.com/49622839/75897780-65a9e000-5e39-11ea-965a-60f2191c98f6.png">


