### PR TITLE
Feature/idn tcl primary forest

### DIFF
--- a/app/javascript/components/widgets/forest-change/tree-loss/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss/index.js
@@ -163,6 +163,10 @@ export default {
         return {
           ...data,
           settings: {
+            forestType:
+              params && params.adm0 && params.adm0 === 'IDN'
+                ? 'primary_forest'
+                : null,
             startYear,
             endYear
           },


### PR DESCRIPTION
## Overview

![image](https://user-images.githubusercontent.com/7013170/76234576-2eb53f00-622a-11ea-91cb-bdc2681870ba.png)

Makes default "Forest Type" setting equal "Primary Forests", but only in Indonesia.

## How to test:

Go to `/dashboards/country/IDN` and check `TREE COVER LOSS IN INDONESIA` widget in Summary.