### PR TITLE
Fix/extlinks absolute path

### DIFF
--- a/app/javascript/components/ui/button/button-component.jsx
+++ b/app/javascript/components/ui/button/button-component.jsx
@@ -59,7 +59,7 @@ const Button = props => {
           { disabled },
           { '--active': active }
         )}
-        href={extLink}
+        href={`//${extLink}`}
         target={target || '_blank'}
         rel="noopener"
         onClick={handleClick}

--- a/app/javascript/components/ui/button/button-component.jsx
+++ b/app/javascript/components/ui/button/button-component.jsx
@@ -50,6 +50,9 @@ const Button = props => {
   const isDeviceTouch = isTouch();
   let button = null;
   if (extLink) {
+    const pattern = /^((http|https):\/\/)/;
+    const url = !pattern.test(extLink) ? `http://${extLink}` : extLink;
+
     button = (
       <a
         className={cx(
@@ -59,7 +62,7 @@ const Button = props => {
           { disabled },
           { '--active': active }
         )}
-        href={`//${extLink}`}
+        href={url}
         target={target || '_blank'}
         rel="noopener"
         onClick={handleClick}


### PR DESCRIPTION
## Overview

External link buttons now use a forced absolute path. This fixes an issue with `href`s using `www.something`, which caused the link to be `globalforestwatch.org/www.something`. This is an issue in the metadata (info) modal in the PTW layer (GLADs).

Reference: https://tools.ietf.org/html/rfc3986#section-4.2

or https://stackoverflow.com/questions/43803778/href-without-https-prefix