### PR TITLE
Fix custom shape downloads for glads in the map widgets

### DIFF
--- a/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
+++ b/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
@@ -15,9 +15,13 @@ import downloadIcon from 'assets/icons/download.svg';
 
 import './styles.scss';
 
+const { GFW_API } = process.env;
+const GLAD_ALERTS_WIDGET = 'gladAlerts';
+
 class WidgetDownloadButton extends PureComponent {
   static propTypes = {
     getDataURL: PropTypes.func,
+    gladAlertsDownloadUrls: PropTypes.obj,
     settings: PropTypes.object,
     title: PropTypes.string,
     parentData: PropTypes.object,
@@ -26,7 +30,8 @@ class WidgetDownloadButton extends PureComponent {
     location: PropTypes.object,
     adminLevel: PropTypes.string,
     metaKey: PropTypes.string,
-    simple: PropTypes.bool
+    simple: PropTypes.bool,
+    widget: PropTypes.string
   };
 
   generateZipFromURL = () => {
@@ -174,7 +179,36 @@ class WidgetDownloadButton extends PureComponent {
     });
   };
 
+  isGladAlertsWidget = () => {
+    const { widget } = this.props;
+    return widget === GLAD_ALERTS_WIDGET;
+  };
+
+  isCustomShape = () => {
+    const { location } = this.props;
+    return location && location.type === 'geostore';
+  };
+
+  onClickDownloadBtn = () => {
+    const { gladAlertsDownloadUrls } = this.props;
+
+    const isGladAlertsWidget = this.isGladAlertsWidget();
+    const isCustomShape = this.isCustomShape();
+
+    if (isGladAlertsWidget && isCustomShape) {
+      const csvFile = `${GFW_API}/${gladAlertsDownloadUrls.csv}`;
+      saveAs(csvFile, 'download.csv');
+    }
+
+    this.generateZipFromURL();
+  };
+
   render() {
+    const tooltipText =
+      this.isGladAlertsWidget() && this.isCustomShape()
+        ? 'Download the data. Please add .csv to the file if extension is missing.'
+        : 'Download the data.';
+
     return (
       <Button
         className={cx('c-widget-download-button', {
@@ -183,8 +217,8 @@ class WidgetDownloadButton extends PureComponent {
         theme={cx('theme-button-small square', {
           'theme-button-grey-filled theme-button-xsmall': this.props.simple
         })}
-        onClick={this.generateZipFromURL}
-        tooltip={{ text: 'Download the data' }}
+        onClick={this.onClickDownloadBtn}
+        tooltip={{ text: tooltipText }}
       >
         <Icon icon={downloadIcon} className="download-icon" />
       </Button>

--- a/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
+++ b/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
@@ -192,10 +192,7 @@ class WidgetDownloadButton extends PureComponent {
   onClickDownloadBtn = () => {
     const { gladAlertsDownloadUrls } = this.props;
 
-    const isGladAlertsWidget = this.isGladAlertsWidget();
-    const isCustomShape = this.isCustomShape();
-
-    if (isGladAlertsWidget && isCustomShape) {
+    if (this.isGladAlertsWidget() && this.isCustomShape()) {
       const csvFile = `${GFW_API}/${gladAlertsDownloadUrls.csv}`;
       saveAs(csvFile, 'download.csv');
     }

--- a/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
+++ b/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
@@ -193,11 +193,11 @@ class WidgetDownloadButton extends PureComponent {
     const { gladAlertsDownloadUrls } = this.props;
 
     if (this.isGladAlertsWidget() && this.isCustomShape()) {
-      const csvFile = `${GFW_API}/${gladAlertsDownloadUrls.csv}`;
-      saveAs(csvFile, 'download.csv');
+      const csvFile = `${GFW_API}${gladAlertsDownloadUrls.csv}`;
+      saveAs(csvFile, 'download');
+    } else {
+      this.generateZipFromURL();
     }
-
-    this.generateZipFromURL();
   };
 
   render() {

--- a/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
+++ b/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
@@ -206,7 +206,7 @@ class WidgetDownloadButton extends PureComponent {
   render() {
     const tooltipText =
       this.isGladAlertsWidget() && this.isCustomShape()
-        ? 'Download the data. Please add .csv to the file if extension is missing.'
+        ? 'Download the data. Please add .csv to the filename if extension is missing.'
         : 'Download the data.';
 
     return (

--- a/app/javascript/components/widget/components/widget-header/components/widget-download-button/index.js
+++ b/app/javascript/components/widget/components/widget-header/components/widget-download-button/index.js
@@ -1,3 +1,6 @@
+import { connect } from 'react-redux';
 import Component from './component';
 
-export default Component;
+import mapStateToProps from './selectors';
+
+export default connect(mapStateToProps, null)(Component);

--- a/app/javascript/components/widget/components/widget-header/components/widget-download-button/selectors.js
+++ b/app/javascript/components/widget/components/widget-header/components/widget-download-button/selectors.js
@@ -1,0 +1,11 @@
+import { createStructuredSelector } from 'reselect';
+
+const getGladAlertsDownloadUrls = state =>
+  state.widgets &&
+  state.widgets.data &&
+  state.widgets.data.gladAlerts &&
+  state.widgets.data.gladAlerts.downloadUrls;
+
+export default createStructuredSelector({
+  gladAlertsDownloadUrls: getGladAlertsDownloadUrls
+});

--- a/app/javascript/components/widgets/forest-change/glad-alerts/index.js
+++ b/app/javascript/components/widgets/forest-change/glad-alerts/index.js
@@ -98,6 +98,7 @@ export default {
         spread((alertsResponse, latestResponse) => {
           const alerts = alertsResponse.data.data.attributes.value;
           const latestDate = latestResponse.attributes.updatedAt;
+          const downloadUrls = alertsResponse.data.data.attributes.downloadUrls;
 
           return {
             alerts:
@@ -107,7 +108,8 @@ export default {
                 alerts: d.count
               })),
             latest: latestDate,
-            settings: { latestDate }
+            settings: { latestDate },
+            downloadUrls
           };
         })
       );

--- a/app/javascript/components/widgets/forest-change/glad-alerts/selectors.js
+++ b/app/javascript/components/widgets/forest-change/glad-alerts/selectors.js
@@ -15,7 +15,6 @@ import {
 
 // get list data
 const selectAlerts = state => state.data && state.data.alerts;
-const selectDownloadUrls = state => state.data && state.data.downloadUrls;
 const selectLatestDates = state => state.data && state.data.latest;
 const selectColors = state => state.colors;
 const selectInteraction = state => state.settings.interaction;
@@ -213,6 +212,5 @@ export const parseSentence = createSelector(
 export default createStructuredSelector({
   data: parseData,
   config: parseConfig,
-  sentence: parseSentence,
-  gladAlertsDownloadUrls: selectDownloadUrls
+  sentence: parseSentence
 });

--- a/app/javascript/components/widgets/forest-change/glad-alerts/selectors.js
+++ b/app/javascript/components/widgets/forest-change/glad-alerts/selectors.js
@@ -15,6 +15,7 @@ import {
 
 // get list data
 const selectAlerts = state => state.data && state.data.alerts;
+const selectDownloadUrls = state => state.data && state.data.downloadUrls;
 const selectLatestDates = state => state.data && state.data.latest;
 const selectColors = state => state.colors;
 const selectInteraction = state => state.settings.interaction;
@@ -212,5 +213,6 @@ export const parseSentence = createSelector(
 export default createStructuredSelector({
   data: parseData,
   config: parseConfig,
-  sentence: parseSentence
+  sentence: parseSentence,
+  gladAlertsDownloadUrls: selectDownloadUrls
 });


### PR DESCRIPTION
## Overview

This PR adds a fix for the custom shape downloads for glad alerts widgets on the map.
It uses `downloadUrls.csv` property from /glad-alerts API request result to download the file:

![image](https://user-images.githubusercontent.com/6136899/76303752-23a9ef80-62ba-11ea-9524-b27fc43388a4.png)

The `Content-type` (coming from the BE)  of the `downloadUrls.csv` url is incorrect so as a workaround we change the tooltip text for the user to know to add an extension to the filename.

## Demo

![image](https://user-images.githubusercontent.com/6136899/76304167-cf533f80-62ba-11ea-90bb-bfe9c0424d30.png)

## Testing

- Go to the map
- Activate `Deforestation alerts (GLAD)` layer
- Go to `Analysis` tab
- Choose the option to draw a shape
- Draw a shape in Brazil for example
- Click on the download icon to download the csv data
- Notice that for other types of analysis (not custom shapes) the download files are different (zip) as it uses a different logic.

![image](https://user-images.githubusercontent.com/6136899/76304387-37098a80-62bb-11ea-840b-3bd74f267cb2.png)