### PR TITLE
Dashboard - use precomputed links for saved areas to populate widgets

### DIFF
--- a/app/javascript/components/widgets/forest-change/fires/index.js
+++ b/app/javascript/components/widgets/forest-change/fires/index.js
@@ -15,7 +15,7 @@ export default {
     summary: 7,
     forestChange: 11
   },
-  visible: ['dashboard', 'analysis'],
+  visible: ['analysis'],
   chartType: 'listLegend',
   sentences: {
     initial: '{count} active fires detected in {location} in the last 7 days.'

--- a/app/javascript/components/widgets/forest-change/glad-alerts/index.js
+++ b/app/javascript/components/widgets/forest-change/glad-alerts/index.js
@@ -5,6 +5,8 @@ import tropicalIsos from 'data/tropical-isos.json';
 import { fetchAnalysisEndpoint } from 'services/analysis';
 import { fetchGladAlerts, fetchGLADLatest } from 'services/analysis-cached';
 
+import { shouldQueryPrecomputedTables } from 'components/widgets/utils/helpers';
+
 import getWidgetProps from './selectors';
 
 export default {
@@ -79,58 +81,55 @@ export default {
     weeks: 13
   },
   getData: params => {
-    if (
-      params.status === 'pending' ||
-      !['global', 'country'].includes(params.type)
-    ) {
-      return all([
-        fetchAnalysisEndpoint({
-          ...params,
-          params,
-          name: 'glad-alerts',
-          slug: 'glad-alerts',
-          version: 'v1',
-          aggregate: true,
-          aggregateBy: 'week'
-        }),
-        fetchGLADLatest(params)
-      ]).then(
-        spread((alertsResponse, latestResponse) => {
-          const alerts = alertsResponse.data.data.attributes.value;
-          const latestDate = latestResponse.attributes.updatedAt;
-          const downloadUrls = alertsResponse.data.data.attributes.downloadUrls;
+    if (shouldQueryPrecomputedTables(params)) {
+      return all([fetchGladAlerts(params), fetchGLADLatest(params)]).then(
+        spread((alerts, latest) => {
+          const gladsData = alerts && alerts.data.data;
+          let data = {};
+          if (gladsData && latest) {
+            const latestDate =
+              latest && latest.attributes && latest.attributes.updatedAt;
 
-          return {
-            alerts:
-              alerts &&
-              alerts.map(d => ({
-                ...d,
-                alerts: d.count
-              })),
-            latest: latestDate,
-            settings: { latestDate },
-            downloadUrls
-          };
+            data = {
+              alerts: gladsData,
+              latest: latestDate,
+              settings: { latestDate }
+            };
+          }
+
+          return data;
         })
       );
     }
 
-    return all([fetchGladAlerts(params), fetchGLADLatest(params)]).then(
-      spread((alerts, latest) => {
-        const gladsData = alerts && alerts.data.data;
-        let data = {};
-        if (gladsData && latest) {
-          const latestDate =
-            latest && latest.attributes && latest.attributes.updatedAt;
+    return all([
+      fetchAnalysisEndpoint({
+        ...params,
+        params,
+        name: 'glad-alerts',
+        slug: 'glad-alerts',
+        version: 'v1',
+        aggregate: true,
+        aggregateBy: 'week'
+      }),
+      fetchGLADLatest(params)
+    ]).then(
+      spread((alertsResponse, latestResponse) => {
+        const alerts = alertsResponse.data.data.attributes.value;
+        const latestDate = latestResponse.attributes.updatedAt;
+        const downloadUrls = alertsResponse.data.data.attributes.downloadUrls;
 
-          data = {
-            alerts: gladsData,
-            latest: latestDate,
-            settings: { latestDate }
-          };
-        }
-
-        return data;
+        return {
+          alerts:
+            alerts &&
+            alerts.map(d => ({
+              ...d,
+              alerts: d.count
+            })),
+          latest: latestDate,
+          settings: { latestDate },
+          downloadUrls
+        };
       })
     );
   },

--- a/app/javascript/components/widgets/forest-change/glads/index.js
+++ b/app/javascript/components/widgets/forest-change/glads/index.js
@@ -17,7 +17,7 @@ export default {
     summary: 8,
     forestChange: 12
   },
-  visible: ['dashboard', 'analysis'],
+  visible: ['analysis'],
   chartType: 'composedChart',
   sentence:
     '{count} deforestation alerts detected in {location} in the last 7 days, compared to a weekly average of {weeklyMean} in the last year.',

--- a/app/javascript/components/widgets/land-cover/tree-cover/index.js
+++ b/app/javascript/components/widgets/land-cover/tree-cover/index.js
@@ -1,30 +1,32 @@
 import { all, spread } from 'axios';
 import { getExtent } from 'services/analysis-cached';
 import { fetchAnalysisEndpoint } from 'services/analysis';
+
+import { shouldQueryPrecomputedTables } from 'components/widgets/utils/helpers';
+
 import getWidgetProps from './selectors';
 
-export const getDataAPI = params =>
-  fetchAnalysisEndpoint({
-    ...params,
-    name: 'umd',
-    params,
-    slug: 'umd-loss-gain',
-    version: 'v1',
-    aggregate: false
-  }).then(response => {
-    const { data } = (response && response.data) || {};
-    const totalArea = data && data.attributes.areaHa;
-    const exentKey =
+export const getDataAPI = params => fetchAnalysisEndpoint({
+  ...params,
+  name: 'umd',
+  params,
+  slug: 'umd-loss-gain',
+  version: 'v1',
+  aggregate: false
+}).then(response => {
+  const { data } = (response && response.data) || {};
+  const totalArea = data && data.attributes.areaHa;
+  const exentKey =
       params.extentYear === 2010 ? 'treeExtent2010' : 'treeExtent';
-    const totalCover = data && data.attributes[exentKey];
+  const totalCover = data && data.attributes[exentKey];
 
-    return {
-      totalArea,
-      totalCover,
-      cover: totalCover,
-      plantations: 0
-    };
-  });
+  return {
+    totalArea,
+    totalCover,
+    cover: totalCover,
+    plantations: 0
+  };
+});
 
 export default {
   widget: 'treeCover',
@@ -104,57 +106,54 @@ export default {
     extentYear: 2000
   },
   getData: params => {
-    if (
-      params.status === 'pending' ||
-      !['global', 'country'].includes(params.type)
-    ) {
-      return getDataAPI(params);
+    if (shouldQueryPrecomputedTables(params)) {
+      return all([
+        getExtent(params),
+        getExtent({ ...params, forestType: '', landCategory: '' }),
+        getExtent({ ...params, forestType: 'plantations' })
+      ]).then(
+        spread((response, adminResponse, plantationsResponse) => {
+          const extent = response.data && response.data.data;
+          const adminExtent = adminResponse.data && adminResponse.data.data;
+          let totalArea = 0;
+          let totalCover = 0;
+          let cover = 0;
+          let plantations = 0;
+          let data = {};
+          if (extent && extent.length) {
+            totalArea = adminExtent[0].total_area;
+            cover = extent[0].extent;
+            totalCover = adminExtent[0].extent;
+            data = {
+              totalArea,
+              totalCover,
+              cover,
+              plantations
+            };
+          }
+          if (params.forestType || params.landCategory) {
+            return data;
+          }
+          // if plantations get more data
+          const plantationsData =
+            plantationsResponse.data && plantationsResponse.data.data;
+          plantations =
+            plantationsData && plantationsData.length
+              ? plantationsData[0].extent
+              : 0;
+          if (extent && extent.length) {
+            data = {
+              ...data,
+              plantations
+            };
+          }
+
+          return data;
+        })
+      );
     }
 
-    return all([
-      getExtent(params),
-      getExtent({ ...params, forestType: '', landCategory: '' }),
-      getExtent({ ...params, forestType: 'plantations' })
-    ]).then(
-      spread((response, adminResponse, plantationsResponse) => {
-        const extent = response.data && response.data.data;
-        const adminExtent = adminResponse.data && adminResponse.data.data;
-        let totalArea = 0;
-        let totalCover = 0;
-        let cover = 0;
-        let plantations = 0;
-        let data = {};
-        if (extent && extent.length) {
-          totalArea = adminExtent[0].total_area;
-          cover = extent[0].extent;
-          totalCover = adminExtent[0].extent;
-          data = {
-            totalArea,
-            totalCover,
-            cover,
-            plantations
-          };
-        }
-        if (params.forestType || params.landCategory) {
-          return data;
-        }
-        // if plantations get more data
-        const plantationsData =
-          plantationsResponse.data && plantationsResponse.data.data;
-        plantations =
-          plantationsData && plantationsData.length
-            ? plantationsData[0].extent
-            : 0;
-        if (extent && extent.length) {
-          data = {
-            ...data,
-            plantations
-          };
-        }
-
-        return data;
-      })
-    );
+    return getDataAPI(params);
   },
   getDataURL: params => {
     const urlArr =

--- a/app/javascript/components/widgets/utils/helpers.js
+++ b/app/javascript/components/widgets/utils/helpers.js
@@ -1,0 +1,8 @@
+const isAreaComputed = status => status === 'saved';
+const isGlobalArea = type => type === 'global';
+const isCountryArea = type => type === 'country';
+
+export const shouldQueryPrecomputedTables = params =>
+  isAreaComputed(params.status) ||
+  isGlobalArea(params.type) ||
+  isCountryArea(params.type);

--- a/app/javascript/services/analysis.js
+++ b/app/javascript/services/analysis.js
@@ -85,14 +85,13 @@ const reduceAnalysisResponse = response => {
   return {};
 };
 
-export const fetchAnalysisEndpoint = ({ type, ...rest }) =>
-  apiRequest.get(
-    `${buildAnalysisUrl({
-      urlTemplate: getUrlTemplate(type),
-      type,
-      ...rest
-    })}`
-  );
+export const fetchAnalysisEndpoint = ({ type, ...rest }) => apiRequest.get(
+  `${buildAnalysisUrl({
+    urlTemplate: getUrlTemplate(type),
+    type,
+    ...rest
+  })}`
+);
 
 export const fetchUmdLossGain = ({
   endpoints,


### PR DESCRIPTION
## Overview

This PR adds a decision tree that if the area is saved, the data for the widgets should be fetched from the precomputed tables endpoints or else it would be fetched from the custom endpoints (`umd-loss-gain`, `glad-alerts`, `viirs-active-fires`)
Effectively, the decision tree impacts these widgets on the dashboard:
- Loss, Gain, Extent and Glad alerts

Additionally, Fires widget and Glad last 7 days widget are disabled on the dashboards

## Testing

- Go to My GFW
- Choose one of the saved custom shapes

![image](https://user-images.githubusercontent.com/6136899/77569563-4ba47000-6ec2-11ea-895f-c35325874a17.png)

- You will be redirected to the dashboard and can check there what endpoints are hit (filter by `?sql=`). If the area was saved correctly, the widgets should be populated with data from the precomputed tables.

