### PR TITLE
Hotfix/aoi data issues

### DIFF
--- a/app/javascript/components/widgets/climate/emissions-deforestation/index.js
+++ b/app/javascript/components/widgets/climate/emissions-deforestation/index.js
@@ -9,45 +9,46 @@ import { shouldQueryPrecomputedTables } from 'components/widgets/utils/helpers';
 
 import getWidgetProps from './selectors';
 
-const getDataFromAPI = params => fetchAnalysisEndpoint({
-  ...params,
-  name: 'Umd',
-  params,
-  slug: ['wdpa', 'use', 'geostore'].includes(params.type)
-    ? 'biomass-loss'
-    : 'umd-loss-gain',
-  version: ['wdpa', 'use', 'geostore'].includes(params.type) ? 'v1' : 'v3',
-  aggregate: false
-}).then(response => {
-  const { attributes: data } =
+const getDataFromAPI = params =>
+  fetchAnalysisEndpoint({
+    ...params,
+    name: 'Umd',
+    params,
+    slug: ['wdpa', 'use', 'geostore'].includes(params.type)
+      ? 'biomass-loss'
+      : 'umd-loss-gain',
+    version: ['wdpa', 'use', 'geostore'].includes(params.type) ? 'v1' : 'v3',
+    aggregate: false
+  }).then(response => {
+    const { attributes: data } =
       (response && response.data && response.data.data) || {};
-  let loss = [];
+    let loss = [];
 
-  if (['wdpa', 'use', 'geostore'].includes(params.type)) {
-    const biomassData = data.biomassLossByYear;
-    const emissionsData = data.co2LossByYear;
-    loss = Object.keys(biomassData).map(l => ({
-      year: parseInt(l, 10),
-      emissions: emissionsData[l],
-      biomassLoss: biomassData[l]
-    }));
-  } else {
-    loss = data.years;
-  }
-
-  const { startYear, endYear, range } = getYearsRange(loss);
-
-  return {
-    loss,
-    settings: {
-      startYear,
-      endYear
-    },
-    options: {
-      years: range
+    if (['wdpa', 'use', 'geostore'].includes(params.type)) {
+      const biomassData = data.biomassLossByYear;
+      const emissionsData = data.co2LossByYear;
+      loss = Object.keys(biomassData).map(l => ({
+        year: parseInt(l, 10),
+        emissions: emissionsData[l],
+        biomassLoss: biomassData[l]
+      }));
+    } else {
+      loss = data.years;
     }
-  };
-});
+
+    const { startYear, endYear, range } = getYearsRange(loss);
+
+    return {
+      loss,
+      settings: {
+        startYear,
+        endYear
+      },
+      options: {
+        years: range
+      }
+    };
+  });
 
 export default {
   widget: 'emissionsDeforestation',
@@ -103,7 +104,7 @@ export default {
     climate: 2
   },
   sentences:
-    'Between {startYear} and {endYear}, a total of {value} of {type} ({annualAvg} per year) was released into the atmosphere as a result of tree cover loss in {location}.',
+    'Between {startYear} and {endYear}, a total of {value} of {type} was released into the atmosphere as a result of tree cover loss in {location}. This is equivalent to {annualAvg} per year.',
   settings: {
     unit: 'co2LossByYear',
     threshold: 30,

--- a/app/javascript/components/widgets/forest-change/tree-cover-gain-simple/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-cover-gain-simple/index.js
@@ -15,19 +15,14 @@ export default {
   metaKey: 'widget_tree_cover_gain',
   settingsConfig: [
     {
-      key: 'extentYear',
-      label: 'extent year',
-      type: 'switch'
-    },
-    {
       key: 'threshold',
       label: 'canopy density',
       type: 'mini-select',
       metaKey: 'widget_canopy_density'
     }
   ],
-  pendingKeys: ['threshold', 'extentYear'],
-  refetchKeys: ['threshold', 'extentYear'],
+  pendingKeys: ['threshold'],
+  refetchKeys: ['threshold'],
   datasets: [
     {
       dataset: 'fdc8dc1b-2728-4a79-b23f-b09485052b8d',
@@ -82,7 +77,7 @@ export default {
       const gain = data && data.attributes.gain;
       const extent =
         data &&
-        data.attributes[`treeExtent${params.extentYear === 2010 ? 2010 : ''}`];
+        data.attributes[`treeExtent${params.extentYear === 2000 ? 2000 : ''}`];
 
       return {
         gain,

--- a/app/javascript/components/widgets/forest-change/tree-cover-gain/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-cover-gain/index.js
@@ -28,9 +28,15 @@ export default {
       type: 'select',
       placeholder: 'All categories',
       clearable: true
+    },
+    {
+      key: 'threshold',
+      label: 'canopy density',
+      type: 'mini-select',
+      metaKey: 'widget_canopy_density'
     }
   ],
-  refetchKeys: ['forestType', 'landCategory'],
+  refetchKeys: ['forestType', 'landCategory', 'threshold'],
   chartType: 'rankedList',
   colors: 'gain',
   metaKey: 'widget_tree_cover_gain',

--- a/app/javascript/providers/whitelists-provider/index.js
+++ b/app/javascript/providers/whitelists-provider/index.js
@@ -23,7 +23,7 @@ class WhitelistProvider extends PureComponent {
 
   componentDidMount() {
     const { location: { type, adm0, adm1, adm2 } } = this.props;
-    if (adm0 && type === 'country') {
+    if (adm0) {
       this.handleFetchWhitelist({ type, adm0, adm1, adm2 });
     }
   }
@@ -32,9 +32,8 @@ class WhitelistProvider extends PureComponent {
     const { location, setWhitelist } = this.props;
     const { type, adm0, adm1, adm2 } = location;
     const hasLocationChanged = !isEqual(location, prevProps.location);
-    const isCountry = type === 'country';
 
-    if (adm0 && hasLocationChanged && isCountry) {
+    if (adm0 && hasLocationChanged) {
       this.handleFetchWhitelist({ type, adm0, adm1, adm2 });
     }
 

--- a/app/javascript/services/analysis-cached.js
+++ b/app/javascript/services/analysis-cached.js
@@ -41,7 +41,7 @@ const SQL_QUERIES = {
   lossTsc:
     'SELECT tcs_driver__type, treecover_loss__year, SUM(treecover_loss__ha) AS treecover_loss__ha, SUM(aboveground_biomass_loss__Mg) as aboveground_biomass_loss__Mg, SUM(aboveground_co2_emissions__Mg) AS aboveground_co2_emissions__Mg FROM data {WHERE} AND treecover_loss__year > 0 GROUP BY tcs_driver__type, treecover_loss__year',
   lossGrouped:
-    'SELECT treecover_loss__year, SUM(aboveground_biomass_loss__Mg) as aboveground_biomass_loss__Mg, SUM(aboveground_co2_emissions__Mg) AS aboveground_co2_emissions__Mg, SUM(treecover_loss__ha) AS treecover_loss__ha FROM data {WHERE} treecover_loss__year > 0 GROUP BY treecover_loss__year, {location} ORDER BY treecover_loss__year, {location}',
+    'SELECT treecover_loss__year, SUM(aboveground_biomass_loss__Mg) as aboveground_biomass_loss__Mg, SUM(aboveground_co2_emissions__Mg) AS aboveground_co2_emissions__Mg, SUM(treecover_loss__ha) AS treecover_loss__ha FROM data {WHERE} AND treecover_loss__year > 0 GROUP BY treecover_loss__year, {location} ORDER BY treecover_loss__year, {location}',
   extent:
     'SELECT SUM(treecover_extent_{extentYear}__ha) as treecover_extent_{extentYear}__ha, SUM(area__ha) as area__ha FROM data {WHERE}',
   extentGrouped:

--- a/app/javascript/services/analysis-cached.js
+++ b/app/javascript/services/analysis-cached.js
@@ -37,11 +37,11 @@ const {
 
 const SQL_QUERIES = {
   loss:
-    'SELECT treecover_loss__year, SUM(aboveground_biomass_loss__Mg) as aboveground_biomass_loss__Mg, SUM(aboveground_co2_emissions__Mg) AS aboveground_co2_emissions__Mg, SUM(treecover_loss__ha) AS treecover_loss__ha FROM data {WHERE} GROUP BY treecover_loss__year ORDER BY treecover_loss__year',
+    'SELECT treecover_loss__year, SUM(aboveground_biomass_loss__Mg) as aboveground_biomass_loss__Mg, SUM(aboveground_co2_emissions__Mg) AS aboveground_co2_emissions__Mg, SUM(treecover_loss__ha) AS treecover_loss__ha FROM data {WHERE} AND treecover_loss__year > 0 GROUP BY treecover_loss__year ORDER BY treecover_loss__year',
   lossTsc:
-    'SELECT tcs_driver__type, treecover_loss__year, SUM(treecover_loss__ha) AS treecover_loss__ha, SUM(aboveground_biomass_loss__Mg) as aboveground_biomass_loss__Mg, SUM(aboveground_co2_emissions__Mg) AS aboveground_co2_emissions__Mg FROM data {WHERE} GROUP BY tcs_driver__type, treecover_loss__year',
+    'SELECT tcs_driver__type, treecover_loss__year, SUM(treecover_loss__ha) AS treecover_loss__ha, SUM(aboveground_biomass_loss__Mg) as aboveground_biomass_loss__Mg, SUM(aboveground_co2_emissions__Mg) AS aboveground_co2_emissions__Mg FROM data {WHERE} AND treecover_loss__year > 0 GROUP BY tcs_driver__type, treecover_loss__year',
   lossGrouped:
-    'SELECT treecover_loss__year, SUM(aboveground_biomass_loss__Mg) as aboveground_biomass_loss__Mg, SUM(aboveground_co2_emissions__Mg) AS aboveground_co2_emissions__Mg, SUM(treecover_loss__ha) AS treecover_loss__ha FROM data {WHERE} GROUP BY treecover_loss__year, {location} ORDER BY treecover_loss__year, {location}',
+    'SELECT treecover_loss__year, SUM(aboveground_biomass_loss__Mg) as aboveground_biomass_loss__Mg, SUM(aboveground_co2_emissions__Mg) AS aboveground_co2_emissions__Mg, SUM(treecover_loss__ha) AS treecover_loss__ha FROM data {WHERE} treecover_loss__year > 0 GROUP BY treecover_loss__year, {location} ORDER BY treecover_loss__year, {location}',
   extent:
     'SELECT SUM(treecover_extent_{extentYear}__ha) as treecover_extent_{extentYear}__ha, SUM(area__ha) as area__ha FROM data {WHERE}',
   extentGrouped:
@@ -488,7 +488,7 @@ export const getGain = ({
       url: url.replace('query', 'download')
     };
   }
-  
+
   return apiRequest.get(url).then(response => ({
     ...response,
     data: {


### PR DESCRIPTION
## Overview

Fixes issue where the loss year widget could surface the year 0 in settings. Unfortunately Hansen data doesn't go back to the Roman Empire.

Loss widget - filters invalid years (namely, `treecover_loss_year = 0`) in sql
Gain - remove the 2010 extent year option from settings

## Testing

- Please double check me that this doesn't break Admin dashboard widgets!

