### PR TITLE
Fix AOI cards for l mv3

### DIFF
--- a/app/javascript/components/map-geostore/component.jsx
+++ b/app/javascript/components/map-geostore/component.jsx
@@ -261,7 +261,7 @@ class MapGeostore extends Component {
                   type="raster"
                   source={{
                     type: 'raster',
-                    url: basemap.url
+                    tiles: [basemap.url]
                   }}
                   zIndex={100}
                 />

--- a/app/javascript/components/map-geostore/component.jsx
+++ b/app/javascript/components/map-geostore/component.jsx
@@ -258,7 +258,9 @@ class MapGeostore extends Component {
                   key={basemap.url}
                   id={basemap.url}
                   name="Basemap"
+                  type="raster"
                   source={{
+                    type: 'raster',
                     url: basemap.url
                   }}
                   zIndex={100}

--- a/app/javascript/components/map/selectors.js
+++ b/app/javascript/components/map/selectors.js
@@ -449,6 +449,7 @@ export const getInteractiveLayerIds = createSelector(
     const interactiveLayers = layers.filter(
       l =>
         !isEmpty(l.interactionConfig) &&
+        l.layerConfig &&
         l.layerConfig.render &&
         l.layerConfig.render.layers
     );


### PR DESCRIPTION
This PR attempts to fix any issues that came up from merging Layer Manager v3 changes with the AOIs.
* It adds a guard for checking if `layerConfig` exists
* It fixes the AOI cards small map previews by adding a `type` prop to `<Layer />` component and adjusting the specification for aoi cards basemaps (`tiles` instead of `url`)

**Testing** 

Go to My GFW profile and go through the AOIs workflow.