### PR TITLE
Removed TSC from aois and GLAD week from map

### DIFF
--- a/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
+++ b/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
@@ -21,7 +21,7 @@ const GLAD_ALERTS_WIDGET = 'gladAlerts';
 class WidgetDownloadButton extends PureComponent {
   static propTypes = {
     getDataURL: PropTypes.func,
-    gladAlertsDownloadUrls: PropTypes.obj,
+    gladAlertsDownloadUrls: PropTypes.object,
     settings: PropTypes.object,
     title: PropTypes.string,
     parentData: PropTypes.object,

--- a/app/javascript/components/widgets/forest-change/glads/index.js
+++ b/app/javascript/components/widgets/forest-change/glads/index.js
@@ -20,12 +20,14 @@ export default {
   title: 'Deforestation alerts for the last week in {location}',
   categories: ['forest-change', 'summary'],
   admins: ['adm0', 'adm1', 'adm2'],
+  types: [],
   type: 'loss',
   colors: 'loss',
   sortOrder: {
     summary: 8,
     forestChange: 12
   },
+  visible: ['analysis'],
   chartType: 'composedChart',
   sentence:
     '{count} deforestation alerts detected in {location} in the last 7 days, compared to a weekly average of {weeklyMean} in the last year.',

--- a/app/javascript/components/widgets/forest-change/glads/index.js
+++ b/app/javascript/components/widgets/forest-change/glads/index.js
@@ -20,14 +20,12 @@ export default {
   title: 'Deforestation alerts for the last week in {location}',
   categories: ['forest-change', 'summary'],
   admins: ['adm0', 'adm1', 'adm2'],
-  types: [],
   type: 'loss',
   colors: 'loss',
   sortOrder: {
     summary: 8,
     forestChange: 12
   },
-  visible: ['analysis'],
   chartType: 'composedChart',
   sentence:
     '{count} deforestation alerts detected in {location} in the last 7 days, compared to a weekly average of {weeklyMean} in the last year.',

--- a/app/javascript/components/widgets/forest-change/glads/index.js
+++ b/app/javascript/components/widgets/forest-change/glads/index.js
@@ -20,7 +20,7 @@ export default {
   title: 'Deforestation alerts for the last week in {location}',
   categories: ['forest-change', 'summary'],
   admins: ['adm0', 'adm1', 'adm2'],
-  types: ['geostore', 'wdpa', 'use'],
+  types: [],
   type: 'loss',
   colors: 'loss',
   sortOrder: {

--- a/app/javascript/components/widgets/forest-change/tree-loss-tsc/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss-tsc/index.js
@@ -57,8 +57,8 @@ export default {
     },
     // loss tsc
     {
-      dataset: '89755b9f-df05-4e22-a9bc-05217c8eafc8',
-      layers: ['fd05bc2c-6ade-408c-862e-7318557dd4fc']
+      dataset: 'f23a1803-ba17-4fe3-a1ad-39abfbfb56c6',
+      layers: ['04774cb7-912c-4612-bbd8-ba982d532c88']
     }
   ],
   metaKey: 'widget_tsc_drivers',

--- a/app/javascript/components/widgets/forest-change/tree-loss-tsc/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss-tsc/index.js
@@ -2,10 +2,14 @@ import { all, spread } from 'axios';
 import moment from 'moment';
 import { getYearsRange } from 'components/widgets/utils/data';
 
-import { POLITICAL_BOUNDARIES_DATASET } from 'data/layers-datasets';
+import {
+  POLITICAL_BOUNDARIES_DATASET,
+  FOREST_LOSS_BY_DRIVER_DATASET
+} from 'data/layers-datasets';
 import {
   DISPUTED_POLITICAL_BOUNDARIES,
-  POLITICAL_BOUNDARIES
+  POLITICAL_BOUNDARIES,
+  TREE_COVER_LOSS_BY_DOMINANT_DRIVER
 } from 'data/layers';
 
 import treeLoss from 'components/widgets/forest-change/tree-loss';
@@ -57,8 +61,8 @@ export default {
     },
     // loss tsc
     {
-      dataset: 'f23a1803-ba17-4fe3-a1ad-39abfbfb56c6',
-      layers: ['04774cb7-912c-4612-bbd8-ba982d532c88']
+      dataset: FOREST_LOSS_BY_DRIVER_DATASET,
+      layers: [TREE_COVER_LOSS_BY_DOMINANT_DRIVER]
     }
   ],
   metaKey: 'widget_tsc_drivers',

--- a/app/javascript/components/widgets/forest-change/tree-loss-tsc/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss-tsc/index.js
@@ -20,7 +20,7 @@ export default {
     initial: 'Annual tree cover loss by dominant driver in {location}',
     global: 'Global annual tree cover loss by dominant driver'
   },
-  types: ['global', 'country', 'geostore'],
+  types: ['global', 'country'],
   admins: ['global', 'adm0'],
   settingsConfig: [
     {

--- a/app/javascript/components/widgets/forest-change/tree-loss-tsc/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss-tsc/index.js
@@ -20,7 +20,7 @@ export default {
     initial: 'Annual tree cover loss by dominant driver in {location}',
     global: 'Global annual tree cover loss by dominant driver'
   },
-  types: ['global', 'country'],
+  types: ['global', 'country', 'geostore'],
   admins: ['global', 'adm0'],
   settingsConfig: [
     {

--- a/app/javascript/data/layers-datasets.js
+++ b/app/javascript/data/layers-datasets.js
@@ -5,6 +5,9 @@ export const FOREST_GAIN_DATASET = '190acb0d-2b06-48d8-b894-234a7413674b';
 
 export const FOREST_LOSS_DATASET = 'eab9655f-dd37-4bb3-b223-4c5df166564c';
 
+export const FOREST_LOSS_BY_DRIVER_DATASET =
+  'f23a1803-ba17-4fe3-a1ad-39abfbfb56c6';
+
 export const FOREST_EXTENT_DATASET = 'c92b6411-f0e5-4606-bbd9-138e40e50eb8';
 
 export const GLAD_DEFORESTATION_ALERTS_DATASET =


### PR DESCRIPTION
## Overview

This PR removes two widgets from two views in the app, as requested:
- Loss By Driver widget from Custom AOI dashboards.
- Old GLAD widget (7 day widget) from the map analysis.