### PR TITLE
Fix/at login move areas preview image to bottom

### DIFF
--- a/app/javascript/components/map-menu/components/sections/my-gfw/styles.scss
+++ b/app/javascript/components/map-menu/components/sections/my-gfw/styles.scss
@@ -172,6 +172,7 @@
 
     &.--login {
       position: relative;
+      bottom: 0;
     }
   }
 }


### PR DESCRIPTION
When logging in on the map, the areas preview image wasnt fixed to the bottom. Now it does.