### PR TITLE
Fix/open my gfw menu when closing save area form

### DIFF
--- a/app/javascript/components/modals/area-of-interest/component.jsx
+++ b/app/javascript/components/modals/area-of-interest/component.jsx
@@ -16,6 +16,7 @@ class AreaOfInterestModal extends PureComponent {
     loading: PropTypes.bool,
     canDelete: PropTypes.bool,
     setAreaOfInterestModalSettings: PropTypes.func,
+    setMenuSettings: PropTypes.func,
     viewAfterSave: PropTypes.bool
   };
 
@@ -24,8 +25,9 @@ class AreaOfInterestModal extends PureComponent {
   }
 
   handleCloseModal = () => {
-    const { setAreaOfInterestModalSettings } = this.props;
+    const { setAreaOfInterestModalSettings, setMenuSettings } = this.props;
     setAreaOfInterestModalSettings({ open: false, activeAreaId: null });
+    setMenuSettings({ menuSection: 'my-gfw' });
   };
 
   render() {

--- a/app/javascript/components/modals/area-of-interest/index.js
+++ b/app/javascript/components/modals/area-of-interest/index.js
@@ -1,7 +1,11 @@
 import { connect } from 'react-redux';
 
+import { setMenuSettings } from 'components/map-menu/actions';
+
 import Component from './component';
 import * as actions from './actions';
 import { getAOIModalProps } from './selectors';
 
-export default connect(getAOIModalProps, actions)(Component);
+export default connect(getAOIModalProps, { ...actions, setMenuSettings })(
+  Component
+);


### PR DESCRIPTION
When closing the save area of interest on the map always open the my gfw menu.