### PR TITLE
Feature/limit aoi size

### DIFF
--- a/app/javascript/components/analysis/component.jsx
+++ b/app/javascript/components/analysis/component.jsx
@@ -168,7 +168,7 @@ class AnalysisComponent extends PureComponent {
                 {...areaTooLarge && {
                   tooltip: {
                     text:
-                        'Your area is too large! Please try again with an area smaller than 1 billion hectares.'
+                        'Your area is too large! Please try again with an area smaller than 1 billion hectares (approximately the size of Brazil).'
                   }
                 }}
               >

--- a/app/javascript/components/analysis/component.jsx
+++ b/app/javascript/components/analysis/component.jsx
@@ -30,6 +30,7 @@ class AnalysisComponent extends PureComponent {
     setAreaOfInterestModalSettings: PropTypes.func,
     setShareModal: PropTypes.func,
     checkingShape: PropTypes.bool,
+    areaTooLarge: PropTypes.bool,
     uploadingShape: PropTypes.bool
   };
 
@@ -51,7 +52,8 @@ class AnalysisComponent extends PureComponent {
       endpoints,
       widgetLayers,
       embed,
-      setShareModal
+      setShareModal,
+      areaTooLarge
     } = this.props;
     const hasLayers = endpoints && !!endpoints.length;
     const hasWidgetLayers = widgetLayers && !!widgetLayers.length;
@@ -162,6 +164,13 @@ class AnalysisComponent extends PureComponent {
               <Button
                 className="analysis-action-btn save-to-mygfw-btn"
                 onClick={() => setAreaOfInterestModalSettings({ open: true })}
+                disabled={areaTooLarge}
+                {...areaTooLarge && {
+                  tooltip: {
+                    text:
+                        'Your area is too large! Please try again with an area smaller than 1 billion hectares.'
+                  }
+                }}
               >
                   save in my gfw
               </Button>

--- a/app/javascript/components/analysis/selectors.js
+++ b/app/javascript/components/analysis/selectors.js
@@ -28,6 +28,8 @@ const selectEmbed = state =>
   state.location.pathname.includes('/embed');
 const selectError = state => state.analysis && state.analysis.error;
 const selectDatasets = state => state.datasets && state.datasets.data;
+const selectGeostoreSize = state =>
+  state.geostore && state.geostore.data && state.geostore.data.areaHa;
 
 export const getLoading = createSelector(
   [
@@ -172,6 +174,17 @@ export const getLayerEndpoints = createSelector(
   }
 );
 
+export const checkGeostoreSize = createSelector(
+  [selectGeostoreSize, getDataLocation],
+  (areaHa, location) => {
+    if (!['aoi', 'geostore'].includes(location.type)) {
+      return false;
+    }
+
+    return areaHa > 100000000;
+  }
+);
+
 export const getAnalysisProps = createStructuredSelector({
   loading: getLoading,
   error: selectError,
@@ -183,5 +196,6 @@ export const getAnalysisProps = createStructuredSelector({
   widgetLayers: getWidgetLayers,
   analysisLocation: selectAnalysisLocation,
   activeArea: getActiveArea,
-  search: selectSearch
+  search: selectSearch,
+  areaTooLarge: checkGeostoreSize
 });

--- a/app/javascript/components/analysis/selectors.js
+++ b/app/javascript/components/analysis/selectors.js
@@ -177,11 +177,11 @@ export const getLayerEndpoints = createSelector(
 export const checkGeostoreSize = createSelector(
   [selectGeostoreSize, getDataLocation],
   (areaHa, location) => {
-    if (!['aoi', 'geostore'].includes(location.type)) {
-      return false;
+    if (['aoi', 'geostore'].includes(location.type)) {
+      return areaHa > 100000000;
     }
 
-    return areaHa > 100000000;
+    return false;
   }
 );
 

--- a/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
+++ b/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
@@ -21,7 +21,7 @@ const GLAD_ALERTS_WIDGET = 'gladAlerts';
 class WidgetDownloadButton extends PureComponent {
   static propTypes = {
     getDataURL: PropTypes.func,
-    gladAlertsDownloadUrls: PropTypes.obj,
+    gladAlertsDownloadUrls: PropTypes.object,
     settings: PropTypes.object,
     title: PropTypes.string,
     parentData: PropTypes.object,


### PR DESCRIPTION
## Overview

Adds a new check in the analysis map view that validates the size of a geostore is less than 1 billion hectares. If true the `save in my gfw` button which opens the `save area modal` is disabled and displays a tooltip explaining why. Only applies when looking at a custom area.

## Demo

<img width="937" alt="Screenshot 2020-04-03 at 15 06 53" src="https://user-images.githubusercontent.com/20288774/78363852-c81f0900-75bc-11ea-92eb-5325380e4e56.png">

## Testing

- draw a massive area and try and save it
- analyze a country, wdpa, use and make sure you can still save those

