### PR TITLE
Feature/add download disabled for widgets in large areas

### DIFF
--- a/app/javascript/components/widget/component.jsx
+++ b/app/javascript/components/widget/component.jsx
@@ -46,7 +46,8 @@ class Widget extends PureComponent {
     locationData: PropTypes.object,
     childData: PropTypes.object,
     location: PropTypes.object,
-    adminLevel: PropTypes.string
+    adminLevel: PropTypes.string,
+    geostore: PropTypes.object
   };
 
   render() {
@@ -87,7 +88,8 @@ class Widget extends PureComponent {
       childData,
       adminLevel,
       locationData,
-      location
+      location,
+      geostore
     } = this.props;
     const { main } = colors || {};
 
@@ -129,6 +131,7 @@ class Widget extends PureComponent {
           adminLevel={adminLevel}
           locationData={locationData}
           location={location}
+          geostore={geostore}
         />
         <WidgetBody
           chartType={chartType}

--- a/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
+++ b/app/javascript/components/widget/components/widget-header/components/widget-download-button/component.jsx
@@ -31,7 +31,8 @@ class WidgetDownloadButton extends PureComponent {
     adminLevel: PropTypes.string,
     metaKey: PropTypes.string,
     simple: PropTypes.bool,
-    widget: PropTypes.string
+    widget: PropTypes.string,
+    areaTooLarge: PropTypes.bool
   };
 
   generateZipFromURL = () => {
@@ -201,10 +202,17 @@ class WidgetDownloadButton extends PureComponent {
   };
 
   render() {
-    const tooltipText =
+    const { areaTooLarge } = this.props;
+
+    let tooltipText =
       this.isGladAlertsWidget() && this.isCustomShape()
         ? 'Download the data. Please add .csv to the filename if extension is missing.'
         : 'Download the data.';
+
+    if (areaTooLarge) {
+      tooltipText =
+        'Your area is too large for downloading data! Please try again with an area smaller than 1 billion hectares (approximately the size of Brazil).';
+    }
 
     return (
       <Button
@@ -216,6 +224,7 @@ class WidgetDownloadButton extends PureComponent {
         })}
         onClick={this.onClickDownloadBtn}
         tooltip={{ text: tooltipText }}
+        disabled={areaTooLarge}
       >
         <Icon icon={downloadIcon} className="download-icon" />
       </Button>

--- a/app/javascript/components/widget/components/widget-header/components/widget-download-button/selectors.js
+++ b/app/javascript/components/widget/components/widget-header/components/widget-download-button/selectors.js
@@ -1,11 +1,27 @@
-import { createStructuredSelector } from 'reselect';
+import { createStructuredSelector, createSelector } from 'reselect';
 
+import { getDataLocation } from 'utils/location';
+
+const selectGeostoreSize = state =>
+  state.geostore && state.geostore.data && state.geostore.data.areaHa;
 const getGladAlertsDownloadUrls = state =>
   state.widgets &&
   state.widgets.data &&
   state.widgets.data.gladAlerts &&
   state.widgets.data.gladAlerts.downloadUrls;
 
+export const checkGeostoreSize = createSelector(
+  [selectGeostoreSize, getDataLocation],
+  (areaHa, location) => {
+    if (['aoi', 'geostore'].includes(location.type)) {
+      return areaHa > 100000000;
+    }
+
+    return false;
+  }
+);
+
 export default createStructuredSelector({
-  gladAlertsDownloadUrls: getGladAlertsDownloadUrls
+  gladAlertsDownloadUrls: getGladAlertsDownloadUrls,
+  areaTooLarge: checkGeostoreSize
 });


### PR DESCRIPTION
## Overview

<img width="443" alt="Screenshot 2020-04-03 at 16 46 31" src="https://user-images.githubusercontent.com/20288774/78373277-afb5eb00-75ca-11ea-93a9-764fd6821c07.png">
Blocks the download button for geostore views with areas > 1 billion hectares.
