### PR TITLE
Show newly created areas on the top of the list - map menu my-gfw section

### DIFF
--- a/app/javascript/components/map-menu/components/sections/my-gfw/selectors.js
+++ b/app/javascript/components/map-menu/components/sections/my-gfw/selectors.js
@@ -1,5 +1,6 @@
-import { createStructuredSelector } from 'reselect';
+import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
+import sortBy from 'lodash/sortBy';
 
 import {
   getUserAreas,
@@ -7,17 +8,34 @@ import {
   getAreaTags
 } from 'providers/areas-provider/selectors';
 
+const PENDING_STATUS = 'pending';
+
+const isNewArea = area => area.status === PENDING_STATUS;
+
 const selectLoading = state =>
   state.areas && state.myGfw && (state.areas.loading || state.myGfw.loading);
 const selectLoggedIn = state => state.myGfw && !isEmpty(state.myGfw.data);
 const selectLocation = state => state.location && state.location.payload;
 const selectUserData = state => state.myGfw && state.myGfw.data;
 
+export const getUserAreasPendingOnTop = createSelector(
+  [getUserAreas],
+  areas => {
+    if (!areas) return null;
+
+    const newAreas = areas.filter(area => isNewArea(area));
+    return [
+      ...sortBy(newAreas, 'createdAt').reverse(),
+      ...areas.filter(area => !isNewArea(area))
+    ];
+  }
+);
+
 export const mapStateToProps = createStructuredSelector({
   loading: selectLoading,
   loggedIn: selectLoggedIn,
   location: selectLocation,
-  areas: getUserAreas,
+  areas: getUserAreasPendingOnTop,
   tags: getAreaTags,
   activeArea: getActiveArea,
   userData: selectUserData


### PR DESCRIPTION
This PR changes the order of user areas on the map menu. It will move the newly created areas to the top of the list based on the area's `status` prop (newly created have status `pending`)

## Testing

- Go to the map and draw a custom shape
- Save the area, give it a `zzzz` name (`saved` areas are ordered by name)
- Note that this area will be listed as the first one on the list
- New areas will be ordered by `createdAt` date

<img width="794" alt="reorderedAreas" src="https://user-images.githubusercontent.com/6136899/78562752-c8641200-7811-11ea-9ba9-a0da60c04fee.png">




