### PR TITLE
Change sublabel text in the multi select component

### DIFF
--- a/app/javascript/components/forms/components/select/component.jsx
+++ b/app/javascript/components/forms/components/select/component.jsx
@@ -65,10 +65,7 @@ class Select extends PureComponent {
             required={required}
           >
             {multiple && (
-              <p className="label sublabel">
-                Select all that apply, press &quot;ctrl&quot; to select multiple
-                options.
-              </p>
+              <p className="label sublabel">Select all that apply.</p>
             )}
             <select
               className={cx('c-form-select', { multiple })}


### PR DESCRIPTION
Change the sublabel text in select component with `multiselect` option to a more accurate one. (For Mac users it's not the `control` button but the `command`)