### PR TITLE
Fix/pass location correctly to geostore map

### DIFF
--- a/app/javascript/components/forms/area-of-interest/component.jsx
+++ b/app/javascript/components/forms/area-of-interest/component.jsx
@@ -169,13 +169,7 @@ class AreaOfInterestForm extends PureComponent {
                     <h1>{title}</h1>
                     <MapGeostore
                       className="aoi-map"
-                      location={
-                        initialValues &&
-                        initialValues.geostore && {
-                          type: 'geostore',
-                          adm0: initialValues.geostore
-                        }
-                      }
+                      location={initialValues && initialValues.location}
                       padding={50}
                       height={300}
                       width={600}

--- a/app/javascript/components/forms/area-of-interest/selectors.js
+++ b/app/javascript/components/forms/area-of-interest/selectors.js
@@ -44,6 +44,7 @@ export const getInitialValues = createSelector(
       language,
       userArea,
       id,
+      location,
       ...rest
     } =
       area || {};
@@ -55,6 +56,11 @@ export const getInitialValues = createSelector(
         monthlySummary ? 'monthlySummary' : false
       ]),
       geostore: geostoreId,
+      location: {
+        type: 'geostore',
+        adm0: geostoreId,
+        ...location
+      },
       ...rest,
       id: userArea ? id : null,
       userArea,

--- a/app/javascript/components/map-geostore/component.jsx
+++ b/app/javascript/components/map-geostore/component.jsx
@@ -89,7 +89,7 @@ class MapGeostore extends Component {
             const { data } = response.data || {};
             const geostore = buildGeostore(
               { id: data.id, ...data.attributes },
-              this.props
+              this.props.location
             );
             this.setState({ geostore });
           }


### PR DESCRIPTION
The geostore map for rendering inside aoi cards wasn't receiving the whole location object. This preventing the fitBounds function receiving the manually adjusted bbox's for countries that cross 180 longitudinal degrees. 