### PR TITLE
Fix AOI modal opening flow after logging in on the map to save an area

### DIFF
--- a/app/javascript/components/forms/login/component.jsx
+++ b/app/javascript/components/forms/login/component.jsx
@@ -149,9 +149,9 @@ class LoginForm extends PureComponent {
                           target="_self"
                           extLink={`${AUTH_URL}/${
                             s.value
-                          }?applications=gfw&token=true&callbackUrl=${
+                          }?applications=gfw&token=true&callbackUrl=${encodeURIComponent(
                             window.location.href
-                          }`}
+                          )}`}
                         >
                           Login with {s.label}
                         </Button>

--- a/app/javascript/components/modals/area-of-interest/component.jsx
+++ b/app/javascript/components/modals/area-of-interest/component.jsx
@@ -22,10 +22,6 @@ class AreaOfInterestModal extends PureComponent {
     activeArea: PropTypes.object
   };
 
-  componentWillUnmount() {
-    this.handleCloseModal();
-  }
-
   handleCloseModal = () => {
     const { setAreaOfInterestModalSettings, setMenuSettings } = this.props;
     setAreaOfInterestModalSettings({ open: false, activeAreaId: null });
@@ -33,7 +29,14 @@ class AreaOfInterestModal extends PureComponent {
   };
 
   render() {
-    const { open, loading, userData, canDelete, viewAfterSave, activeArea } = this.props;
+    const {
+      open,
+      loading,
+      userData,
+      canDelete,
+      viewAfterSave,
+      activeArea
+    } = this.props;
     const { email, fullName, lastName, loggedIn } = userData || {};
     const isProfileFormFilled = !!email && (!!fullName || !!lastName);
 


### PR DESCRIPTION
This PR fixes two issues:
* When logging in via **social** accounts on the saving an area flow - preserve the query params from the URL - keep the AOI modal open
* When logging in via typing login and password don't close the AOI model

Relevant Basecamp issue: https://basecamp.com/3063126/projects/10727890/todos/415045078