### PR TITLE
Fixed howto link in about page

### DIFF
--- a/app/javascript/pages/about/section-projects/section-projects-component.jsx
+++ b/app/javascript/pages/about/section-projects/section-projects-component.jsx
@@ -78,15 +78,15 @@ class SectionProjects extends PureComponent {
                 onClick={setCategorySelected}
               />
             )}
-            <Button className="how-to-btn" extLink="/howto">
+            <Button className="how-to-btn" link="/howto">
               LEARN HOW TO USE GFW
             </Button>
           </div>
         </div>
         <div className="visitors" style={{ backgroundImage: `url(${growth})` }}>
           <h4>
-            Since its launch in 2014, over 3.5 million people have visited Global
-            Forest Watch from every single country in the world.
+            Since its launch in 2014, over 3.5 million people have visited
+            Global Forest Watch from every single country in the world.
           </h4>
         </div>
       </div>


### PR DESCRIPTION
## Overview

Either we use `extLink=globalforestwatch.org/howto`, or we use a link within the app (Ended up using the 2nd approach).