### PR TITLE
Update land rights config for dashboards

### DIFF
--- a/app/javascript/data/land-categories.json
+++ b/app/javascript/data/land-categories.json
@@ -60,15 +60,15 @@
     ]
   },
   {
-    "label": "Indigenous Lands",
+    "label": "Landmark Indigenous and Community Lands",
     "value": "landmark",
     "metaKey": "gfw_land_rights",
-    "tableKey": "is__gfw_land_right",
+    "tableKey": "is__landmark",
     "global": true,
     "datasets": [
       {
-        "dataset": "101fb2b9-5a0a-4ec4-9f86-96c0819b97cd",
-        "layers": ["a0c1b479-10ed-4538-9c8d-cdc9815b7054"]
+        "dataset": "7261a40b-4fb5-46a7-9fb4-fd95458dcbee",
+        "layers": ["caa9b9b7-5dec-4ad6-adbf-d7c2965c9371"]
       }
     ]
   },


### PR DESCRIPTION
## Overview

Updates dashboard to use `is__landmark` key in queries In line with the new LandMark vector layer on staging.

Also, pulls the new layer for the dashboard map.

<img width="1262" alt="Screen Shot 2020-04-14 at 17 53 39" src="https://user-images.githubusercontent.com/30242314/79246221-6d699500-7e79-11ea-8784-c961067979d7.png">

Awaiting feedback from LandMark, but can be pushed to staging in the meantime.

## Testing

Affects all tables, please break me.