### PR TITLE
Added check for subsector in save AOI modal

### DIFF
--- a/app/javascript/components/forms/profile/component.jsx
+++ b/app/javascript/components/forms/profile/component.jsx
@@ -98,7 +98,7 @@ class ProfileForm extends PureComponent {
                           value: s
                         }))}
                         placeholder="Select a sector"
-                        required={source === 'AreaOfInterestModal'}
+                        required
                       />
                       {values.sector &&
                         sectors[values.sector] && (
@@ -111,7 +111,7 @@ class ProfileForm extends PureComponent {
                             radioInput: s === 'Other:'
                           }))}
                           selectedOption={values.subsector}
-                          required={source === 'AreaOfInterestModal'}
+                          required
                         />
                       )}
                       <Input name="jobTitle" label="job title" />

--- a/app/javascript/components/modals/area-of-interest/component.jsx
+++ b/app/javascript/components/modals/area-of-interest/component.jsx
@@ -43,6 +43,7 @@ class AreaOfInterestModal extends PureComponent {
       !!email &&
       (!!fullName || !!lastName) &&
       !!sector &&
+      subsector &&
       (subsector.includes('Other')
         ? // if it's 'Other: <input>', we make sure that the input is not empty
         !!subsector.split('Other:')[1].trim()

--- a/app/javascript/components/modals/area-of-interest/component.jsx
+++ b/app/javascript/components/modals/area-of-interest/component.jsx
@@ -44,8 +44,10 @@ class AreaOfInterestModal extends PureComponent {
       (!!fullName || !!lastName) &&
       !!sector &&
       (subsector.includes('Other')
-        ? !!subsector.split('Other:')[1].trim()
-        : false);
+        ? // if it's 'Other: <input>', we make sure that the input is not empty
+        !!subsector.split('Other:')[1].trim()
+        : // otherwise we just check the subsector
+        !!subsector);
 
     return (
       <Modal


### PR DESCRIPTION
## Overview

This fixes a bug where someone clicked "edit area" from the MyGFW page, the first page they saw is "my profile" page (see staging).

The reason behind this is that we didn't check for sub-sectors other than "Other: <something>". This caused the profile form to be considered "not filled" all the time if you selected another sub-sector.

To test:

1. Go to staging/my-gfw, try to update your profile with a sub-sector other than "Other", then try to edit an area.
2. Go to the branch deployment and try the same flow.
3. Also check the save AOI modal in the map.