### PR TITLE
Cumulative fires chart

### DIFF
--- a/app/javascript/components/charts/components/chart-tooltip/chart-tooltip-component.js
+++ b/app/javascript/components/charts/components/chart-tooltip/chart-tooltip-component.js
@@ -40,7 +40,9 @@ class ChartTooltip extends PureComponent {
                     </div>
                   )}
                   <div className="notranslate">
-                    {d.unit && d.unitFormat ? `${value}${d.unit}` : value}
+                    {value !== null && d.unit && d.unitFormat
+                      ? `${value}${d.unit}`
+                      : d.nullValue || value}
                   </div>
                 </div>
               );

--- a/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/index.js
+++ b/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/index.js
@@ -4,12 +4,6 @@ import uniq from 'lodash/uniq';
 
 import { fetchVIIRSAlerts, fetchVIIRSLatest } from 'services/analysis-cached';
 
-import { POLITICAL_BOUNDARIES_DATASET } from 'data/layers-datasets';
-import {
-  DISPUTED_POLITICAL_BOUNDARIES,
-  POLITICAL_BOUNDARIES
-} from 'data/layers';
-
 import getWidgetProps from './selectors';
 
 export default {
@@ -60,18 +54,6 @@ export default {
   types: ['country'],
   admins: ['adm0', 'adm1', 'adm2'],
   chartType: 'composedChart',
-  datasets: [
-    {
-      dataset: POLITICAL_BOUNDARIES_DATASET,
-      layers: [DISPUTED_POLITICAL_BOUNDARIES, POLITICAL_BOUNDARIES],
-      boundary: true
-    },
-    // fires
-    {
-      dataset: 'd8d93fbb-8304-424f-99fb-1e521b5df56a',
-      layers: ['d621ce0f-0872-41ef-b2ec-18faec3fd1d9']
-    }
-  ],
   hideLayers: true,
   dataType: 'fires',
   colors: 'fires',

--- a/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/index.js
+++ b/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/index.js
@@ -26,6 +26,7 @@ export default {
     {
       key: 'compareYear',
       label: 'Compare with the same period in',
+      placeholder: 'None',
       type: 'compare-select',
       clearable: true,
       border: true

--- a/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/index.js
+++ b/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/index.js
@@ -1,0 +1,338 @@
+import { all, spread } from 'axios';
+import moment from 'moment';
+import uniq from 'lodash/uniq';
+
+import { fetchVIIRSAlerts, fetchVIIRSLatest } from 'services/analysis-cached';
+
+import { POLITICAL_BOUNDARIES_DATASET } from 'data/layers-datasets';
+import {
+  DISPUTED_POLITICAL_BOUNDARIES,
+  POLITICAL_BOUNDARIES
+} from 'data/layers';
+
+import getWidgetProps from './selectors';
+
+export default {
+  widget: 'firesAlertsCumulative',
+  title: 'Cumulative Fire Alerts in {location}',
+  large: true,
+  categories: ['summary', 'forest-change'],
+  settingsConfig: [
+    {
+      key: 'dataset',
+      label: 'fires dataset',
+      type: 'select'
+    },
+    {
+      key: 'compareYear',
+      label: 'Compare with the same period in',
+      type: 'compare-select',
+      clearable: true,
+      border: true
+    },
+    {
+      key: 'confidence',
+      label: 'Confidence level',
+      type: 'select',
+      clearable: false,
+      border: true
+    },
+    {
+      key: 'forestType',
+      label: 'Forest Type',
+      type: 'select',
+      placeholder: 'All tree cover',
+      clearable: true
+    },
+    {
+      key: 'landCategory',
+      label: 'Land Category',
+      type: 'select',
+      placeholder: 'All categories',
+      clearable: true,
+      border: true
+    }
+  ],
+  refetchKeys: ['dataset', 'forestType', 'landCategory', 'confidence'],
+  preventRenderKeys: ['startIndex', 'endIndex'],
+  visible: ['dashboard', 'analysis'],
+  types: ['country'],
+  admins: ['adm0', 'adm1', 'adm2'],
+  chartType: 'composedChart',
+  datasets: [
+    {
+      dataset: POLITICAL_BOUNDARIES_DATASET,
+      layers: [DISPUTED_POLITICAL_BOUNDARIES, POLITICAL_BOUNDARIES],
+      boundary: true
+    },
+    // fires
+    {
+      dataset: 'd8d93fbb-8304-424f-99fb-1e521b5df56a',
+      layers: ['d621ce0f-0872-41ef-b2ec-18faec3fd1d9']
+    }
+  ],
+  hideLayers: true,
+  dataType: 'fires',
+  colors: 'fires',
+  metaKey: 'widget_fire_alert_location',
+  sortOrder: {
+    summary: 100,
+    forestChange: 100
+  },
+  settings: {
+    dataset: 'VIIRS',
+    confidence: 'h'
+  },
+  sentence:
+    'In {location} there were {count} {dataset} fire alerts reported between {start_date} and {end_date}. This total is {status} compared to the total for previous years going back to {dataset_start_year}. The worst year on record was {maxYear}, with {maxTotal} fires.',
+  whitelists: {
+    adm0: [
+      'AFG',
+      'AGO',
+      'ALB',
+      'AND',
+      'ANT',
+      'ARE',
+      'ARG',
+      'ARM',
+      'AUS',
+      'AUT',
+      'AZE',
+      'BDI',
+      'BEL',
+      'BEN',
+      'BFA',
+      'BGD',
+      'BGR',
+      'BHR',
+      'BHS',
+      'BIH',
+      'BLM',
+      'BLR',
+      'BLZ',
+      'BOL',
+      'BRA',
+      'BRB',
+      'BRN',
+      'BTN',
+      'BWA',
+      'CAF',
+      'CAN',
+      'CHE',
+      'CHL',
+      'CHN',
+      'CIV',
+      'CMR',
+      'COD',
+      'COG',
+      'COL',
+      'COM',
+      'CPV',
+      'CRI',
+      'CUB',
+      'CYP',
+      'CZE',
+      'DEU',
+      'DJI',
+      'DMA',
+      'DNK',
+      'DOM',
+      'DZA',
+      'ECU',
+      'EGY',
+      'ERI',
+      'ESP',
+      'EST',
+      'ETH',
+      'FIN',
+      'FJI',
+      'FLK',
+      'FRA',
+      'FSM',
+      'GAB',
+      'GBR',
+      'GEO',
+      'GHA',
+      'GIB',
+      'GIN',
+      'GLP',
+      'GMB',
+      'GNB',
+      'GNQ',
+      'GRC',
+      'GRL',
+      'GTM',
+      'GUF',
+      'GUM',
+      'GUY',
+      'HND',
+      'HRV',
+      'HTI',
+      'HUN',
+      'IDN',
+      'IND',
+      'IRL',
+      'IRN',
+      'IRQ',
+      'ISR',
+      'ITA',
+      'JAM',
+      'JOR',
+      'JPN',
+      'KAZ',
+      'KEN',
+      'KGZ',
+      'KHM',
+      'KIR',
+      'KNA',
+      'KOR',
+      'KWT',
+      'LAO',
+      'LBN',
+      'LBR',
+      'LBY',
+      'LCA',
+      'LIE',
+      'LKA',
+      'LSO',
+      'LTU',
+      'LUX',
+      'LVA',
+      'MAR',
+      'MCO',
+      'MDA',
+      'MDG',
+      'MDV',
+      'MEX',
+      'MHL',
+      'MKD',
+      'MLI',
+      'MLT',
+      'MMR',
+      'MNE',
+      'MNG',
+      'MNP',
+      'MOZ',
+      'MRT',
+      'MSR',
+      'MTQ',
+      'MUS',
+      'MWI',
+      'MYS',
+      'NAM',
+      'NCL',
+      'NER',
+      'NGA',
+      'NIC',
+      'NLD',
+      'NOR',
+      'NPL',
+      'NZL',
+      'OMN',
+      'PAK',
+      'PAN',
+      'PCN',
+      'PER',
+      'PHL',
+      'PNG',
+      'POL',
+      'PRI',
+      'PRK',
+      'PRT',
+      'PRY',
+      'PSE',
+      'PYF',
+      'QAT',
+      'REU',
+      'ROU',
+      'RUS',
+      'RWA',
+      'SAU',
+      'SDN',
+      'SEN',
+      'SGP',
+      'SLB',
+      'SLE',
+      'SLV',
+      'SOM',
+      'SRB',
+      'SSD',
+      'STP',
+      'SUR',
+      'SVK',
+      'SVN',
+      'SWE',
+      'SWZ',
+      'SYR',
+      'TCD',
+      'TGO',
+      'THA',
+      'TJK',
+      'TKL',
+      'TKM',
+      'TLS',
+      'TON',
+      'TTO',
+      'TUN',
+      'TUR',
+      'TUV',
+      'TZA',
+      'UGA',
+      'UKR',
+      'URY',
+      'USA',
+      'UZB',
+      'VAT',
+      'VEN',
+      'VIR',
+      'VNM',
+      'VUT',
+      'WSM',
+      'YEM',
+      'ZAF',
+      'ZMB',
+      'ZWE'
+    ]
+  },
+  getData: params =>
+    all([fetchVIIRSAlerts(params), fetchVIIRSLatest(params)]).then(
+      spread((alerts, latest) => {
+        const { data } = alerts.data;
+        const years = uniq(data.map(d => d.year));
+        const maxYear = Math.max(...years);
+
+        return (
+          {
+            alerts: data,
+            latest,
+            options: {
+              compareYear: years.filter(y => y !== maxYear).map(y => ({
+                label: y,
+                value: y
+              })),
+              confidence: [
+                { label: 'All', value: '' },
+                { label: 'High', value: 'h' }
+              ]
+            }
+          } || {}
+        );
+      })
+    ),
+  getDataURL: params => [fetchVIIRSAlerts({ ...params, download: true })],
+  getWidgetProps,
+  parseInteraction: payload => {
+    if (payload) {
+      const startDate = moment()
+        .year(payload.year)
+        .week(payload.week);
+
+      return {
+        startDate: startDate.format('YYYY-MM-DD'),
+        endDate: startDate.add(7, 'days'),
+        ...payload
+      };
+    }
+    return {};
+  }
+};

--- a/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/index.js
+++ b/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/index.js
@@ -85,7 +85,7 @@ export default {
     confidence: 'h'
   },
   sentence:
-    'In {location} there were {count} {dataset} fire alerts reported between {start_date} and {end_date}. This total is {status} compared to the total for previous years going back to {dataset_start_year}. The worst year on record was {maxYear}, with {maxTotal} fires.',
+    'In {location} there have been {count} {dataset} fire alerts reported so far in {latestYear}. This total is {status} compared to the total for previous years going back to {dataset_start_year}. The worst year on record was {maxYear}, with {maxTotal} fires.',
   whitelists: {
     adm0: [
       'AFG',

--- a/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/selectors.js
+++ b/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/selectors.js
@@ -340,8 +340,7 @@ export const parseSentence = createSelector(
     const params = {
       date: formattedData,
       location: location.label || '',
-      start_date: firstDate.date,
-      end_date: lastDate.date,
+      latestYear,
       dataset_start_year: dataset === 'VIIRS' ? 2012 : 2001,
       maxYear,
       maxTotal: {

--- a/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/selectors.js
+++ b/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/selectors.js
@@ -188,6 +188,7 @@ export const parseConfig = createSelector(
         labelFormat: value => moment(value).format('YYYY-MM-DD'),
         unit: ` ${dataset} alerts`,
         color: colors.main,
+        nullValue: 'No data available',
         unitFormat: value =>
           (Number.isInteger(value) ? format(',')(value) : value)
       }
@@ -206,6 +207,7 @@ export const parseConfig = createSelector(
         },
         unit: ` ${dataset} alerts`,
         color: '#49b5e3',
+        nullValue: 'No data available',
         unitFormat: value =>
           (Number.isInteger(value) ? format(',')(value) : value)
       });

--- a/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/selectors.js
+++ b/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/selectors.js
@@ -205,7 +205,7 @@ export const parseConfig = createSelector(
           return date.format('YYYY-MM-DD');
         },
         unit: ` ${dataset} alerts`,
-        color: '#00F',
+        color: '#49b5e3',
         unitFormat: value =>
           (Number.isInteger(value) ? format(',')(value) : value)
       });
@@ -252,7 +252,7 @@ export const parseConfig = createSelector(
                 isAnimationActive: false
               },
               compareCount: {
-                stroke: '#00F',
+                stroke: '#49b5e3',
                 isAnimationActive: false
               }
             }

--- a/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/selectors.js
+++ b/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/selectors.js
@@ -167,8 +167,39 @@ export const parseBrushedData = createSelector(
   }
 );
 
+export const getLegend = createSelector(
+  [parseBrushedData, getColors, getCompareYear],
+  (data, colors, compareYear) => {
+    if (!data) return {};
+
+    const end = data[data.length - 1];
+
+    return {
+      current: {
+        label: `${moment(end.date).format('YYYY')}`,
+        color: colors.main
+      },
+      ...(compareYear && {
+        compare: {
+          label: `${compareYear}`,
+          color: '#49b5e3'
+        }
+      }),
+      average: {
+        label: 'Average Band',
+        color: 'rgba(85,85,85, 0.15)'
+      },
+      unusual: {
+        label: 'Unusual Band',
+        color: 'rgba(85,85,85, 0.25)'
+      }
+    };
+  }
+);
+
 export const parseConfig = createSelector(
   [
+    getLegend,
     getColors,
     getLatest,
     getMaxMinDates,
@@ -177,7 +208,16 @@ export const parseConfig = createSelector(
     getStartIndex,
     getEndIndex
   ],
-  (colors, latest, maxminYear, compareYear, dataset, startIndex, endIndex) => {
+  (
+    legend,
+    colors,
+    latest,
+    maxminYear,
+    compareYear,
+    dataset,
+    startIndex,
+    endIndex
+  ) => {
     const tooltip = [
       {
         label: 'Fire alerts'
@@ -227,6 +267,7 @@ export const parseConfig = createSelector(
           tickFormatter: t => moment(t).format('MMM-DD')
         })
       },
+      legend,
       tooltip,
       brush: {
         width: '100%',

--- a/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/selectors.js
+++ b/app/javascript/components/widgets/forest-change/fires-alerts-cumulative/selectors.js
@@ -1,0 +1,370 @@
+import { createSelector, createStructuredSelector } from 'reselect';
+import moment from 'moment';
+import { format } from 'd3-format';
+import isEmpty from 'lodash/isEmpty';
+import sortBy from 'lodash/sortBy';
+import sumBy from 'lodash/sumBy';
+import groupBy from 'lodash/groupBy';
+import max from 'lodash/max';
+import maxBy from 'lodash/maxBy';
+import min from 'lodash/min';
+
+import { getColorPalette } from 'utils/data';
+
+import {
+  getCumulativeStatsData,
+  getDatesData,
+  getPeriodVariance,
+  getChartConfig
+} from 'components/widgets/utils/data';
+
+const getAlerts = state => state.data && state.data.alerts;
+const getLatest = state => state.data && state.data.latest;
+const getColors = state => state.colors || null;
+const getCompareYear = state => state.settings.compareYear || null;
+const getDataset = state => state.settings.dataset || null;
+const getStartIndex = state => state.settings.startIndex || 0;
+const getEndIndex = state => state.settings.endIndex || null;
+const getSentences = state => state.sentence || null;
+const getLocationObject = state => state.location;
+
+export const getData = createSelector(
+  [getAlerts, getLatest],
+  (data, latest) => {
+    if (!data || isEmpty(data)) return null;
+    const parsedData = data.map(d => ({
+      ...d,
+      count: d.alert__count,
+      week: parseInt(d.alert__week, 10),
+      year: parseInt(d.alert__year, 10)
+    }));
+    const groupedByYear = groupBy(sortBy(parsedData, ['year', 'week']), 'year');
+    const hasAlertsByYears = Object.values(groupedByYear).reduce(
+      (acc, next) => {
+        const { year } = next[0];
+        return {
+          ...acc,
+          [year]: next.some(item => item.alerts > 0)
+        };
+      },
+      {}
+    );
+
+    const dataYears = Object.keys(hasAlertsByYears).filter(
+      key => hasAlertsByYears[key] === true
+    );
+    const minYear = Math.min(...dataYears.map(el => parseInt(el, 10)));
+    const startYear =
+      minYear === moment().year() ? moment().year() - 1 : minYear;
+
+    const years = [];
+    const latestWeek = moment(latest);
+    const lastWeek = {
+      isoWeek: latestWeek.isoWeek(),
+      year: latestWeek.year()
+    };
+
+    for (let i = startYear; i <= lastWeek.year; i += 1) {
+      years.push(i);
+    }
+
+    const yearLengths = {};
+    years.forEach(y => {
+      if (moment(`${y}-12-31`).isoWeek() === 1) {
+        yearLengths[y] = moment(`${y}-12-31`)
+          .subtract('week', 1)
+          .isoWeek();
+      } else {
+        yearLengths[y] = moment(`${y}-12-31`).isoWeek();
+      }
+    });
+
+    const zeroFilledData = [];
+
+    years.forEach(d => {
+      let acc = 0;
+      const yearDataByWeek = groupBy(groupedByYear[d], 'week');
+      for (let i = 1; i <= yearLengths[d]; i += 1) {
+        const weekData = yearDataByWeek[i]
+          ? yearDataByWeek[i][0]
+          : { count: 0, week: i, year: parseInt(d, 10) };
+        acc += weekData.count;
+        if (parseInt(d, 10) === lastWeek.year && i > lastWeek.isoWeek) {
+          zeroFilledData.push({
+            ...weekData,
+            count: null
+          });
+        } else {
+          zeroFilledData.push({
+            ...weekData,
+            count: acc
+          });
+        }
+      }
+    });
+    return zeroFilledData;
+  }
+);
+
+export const getStats = createSelector([getData], data => {
+  if (!data) return null;
+  return getCumulativeStatsData(data);
+});
+
+export const getDates = createSelector([getStats], data => {
+  if (!data) return null;
+  return getDatesData(data);
+});
+
+export const getMaxMinDates = createSelector(
+  [getData, getDates],
+  (data, currentData) => {
+    if (!data || !currentData) return {};
+    const minYear = min(data.map(d => d.year));
+    const maxYear = max(data.map(d => d.year));
+
+    return {
+      min: minYear,
+      max: maxYear
+    };
+  }
+);
+
+export const parseData = createSelector(
+  [getData, getDates, getMaxMinDates, getCompareYear],
+  (data, currentData, maxminYear, compareYear) => {
+    if (!data || !currentData) return null;
+
+    return currentData.map(d => {
+      const yearDifference = maxminYear.max - d.year;
+      const week = d.week;
+
+      if (compareYear) {
+        const compareWeek = data.find(
+          dt => dt.year === compareYear - yearDifference && dt.week === week
+        );
+
+        return {
+          ...d,
+          compareCount: compareWeek ? compareWeek.count : null
+        };
+      }
+
+      return d;
+    });
+  }
+);
+
+export const parseBrushedData = createSelector(
+  [parseData, getStartIndex, getEndIndex],
+  (data, startIndex, endIndex) => {
+    if (!data) return null;
+
+    const start = startIndex || 0;
+    const end = endIndex || data.length - 1;
+
+    return data.slice(start, end + 1);
+  }
+);
+
+export const parseConfig = createSelector(
+  [
+    getColors,
+    getLatest,
+    getMaxMinDates,
+    getCompareYear,
+    getDataset,
+    getStartIndex,
+    getEndIndex
+  ],
+  (colors, latest, maxminYear, compareYear, dataset, startIndex, endIndex) => {
+    const tooltip = [
+      {
+        label: 'Fire alerts'
+      },
+      {
+        key: 'count',
+        labelKey: 'date',
+        labelFormat: value => moment(value).format('YYYY-MM-DD'),
+        unit: ` ${dataset} alerts`,
+        color: colors.main,
+        unitFormat: value =>
+          (Number.isInteger(value) ? format(',')(value) : value)
+      }
+    ];
+
+    if (compareYear) {
+      tooltip.push({
+        key: 'compareCount',
+        labelKey: 'date',
+        labelFormat: value => {
+          const date = moment(value);
+          const yearDifference = maxminYear.max - date.year();
+          date.set('year', compareYear - yearDifference);
+
+          return date.format('YYYY-MM-DD');
+        },
+        unit: ` ${dataset} alerts`,
+        color: '#00F',
+        unitFormat: value =>
+          (Number.isInteger(value) ? format(',')(value) : value)
+      });
+    }
+
+    return {
+      ...getChartConfig(colors, moment(latest)),
+      xAxis: {
+        tickCount: 12,
+        interval: 4,
+        tickFormatter: t => moment(t).format('MMM'),
+        ...(typeof endIndex === 'number' &&
+          typeof startIndex === 'number' &&
+          endIndex - startIndex < 12 && {
+          tickCount: 5,
+          interval: 0,
+          tickFormatter: t => moment(t).format('MMM-DD')
+        })
+      },
+      tooltip,
+      brush: {
+        width: '100%',
+        height: 60,
+        margin: {
+          top: 0,
+          right: 10,
+          left: 48,
+          bottom: 12
+        },
+        dataKey: 'date',
+        startIndex,
+        endIndex,
+        config: {
+          margin: {
+            top: 5,
+            right: 0,
+            left: 42,
+            bottom: 20
+          },
+          yKeys: {
+            lines: {
+              count: {
+                stroke: colors.main,
+                isAnimationActive: false
+              },
+              compareCount: {
+                stroke: '#00F',
+                isAnimationActive: false
+              }
+            }
+          },
+          xAxis: {
+            hide: true
+          },
+          yAxis: {
+            hide: true
+          },
+          cartesianGrid: {
+            horizontal: false,
+            vertical: false
+          },
+          height: 60
+        }
+      }
+    };
+  }
+);
+
+export const parseSentence = createSelector(
+  [
+    getData,
+    parseData,
+    getColors,
+    getSentences,
+    getDataset,
+    getLocationObject,
+    getStartIndex,
+    getEndIndex
+  ],
+  (
+    raw_data,
+    data,
+    colors,
+    sentence,
+    dataset,
+    location,
+    startIndex
+    // endIndex //broken?
+  ) => {
+    if (!data) return null;
+
+    const start = startIndex;
+
+    const latestYear = maxBy(data, 'year').year;
+    const lastDate =
+      maxBy(
+        data.filter(d => d.year === latestYear && d.count !== null),
+        'date'
+      ) || {};
+    const firstDate = data[start] || {};
+
+    const slicedData = data.filter(
+      el => el.date >= firstDate.date && el.date <= lastDate.date
+    );
+    const variance = getPeriodVariance(slicedData, raw_data);
+
+    const maxWeek = maxBy(raw_data, 'count');
+    const maxTotal = maxWeek.count;
+    const maxYear = maxWeek.year;
+
+    const total = sumBy(slicedData, 'count');
+    const colorRange = getColorPalette(colors.ramp, 5);
+    let statusColor = colorRange[4];
+    const { date } = lastDate || {};
+
+    let status = 'unusually low';
+    if (variance > 2) {
+      status = 'unusually high';
+      statusColor = colorRange[0];
+    } else if (variance <= 2 && variance > 1) {
+      status = 'high';
+      statusColor = colorRange[1];
+    } else if (variance <= 1 && variance > -1) {
+      status = 'average';
+      statusColor = colorRange[2];
+    } else if (variance <= -1 && variance > -2) {
+      status = 'low';
+      statusColor = colorRange[3];
+    }
+
+    const formattedData = moment(date).format('Do of MMMM YYYY');
+    const params = {
+      date: formattedData,
+      location: location.label || '',
+      start_date: firstDate.date,
+      end_date: lastDate.date,
+      dataset_start_year: dataset === 'VIIRS' ? 2012 : 2001,
+      maxYear,
+      maxTotal: {
+        value: maxTotal ? format(',')(maxTotal) : 0,
+        color: colors.main
+      },
+      dataset,
+      count: {
+        value: total ? format(',')(total) : 0,
+        color: colors.main
+      },
+      status: {
+        value: status,
+        color: statusColor
+      }
+    };
+    return { sentence, params };
+  }
+);
+
+export default createStructuredSelector({
+  originalData: parseData,
+  data: parseBrushedData,
+  config: parseConfig,
+  sentence: parseSentence
+});

--- a/app/javascript/components/widgets/manifest.js
+++ b/app/javascript/components/widgets/manifest.js
@@ -6,6 +6,7 @@ import treeLossRanked from 'components/widgets/forest-change/tree-loss-ranked';
 import faoDeforest from 'components/widgets/forest-change/fao-deforest';
 import faoReforest from 'components/widgets/forest-change/fao-reforest';
 import firesAlerts from 'components/widgets/forest-change/fires-alerts';
+import firesAlertsCumulative from 'components/widgets/forest-change/fires-alerts-cumulative';
 import firesRanked from 'components/widgets/forest-change/fires-ranked';
 import gladRanked from 'components/widgets/forest-change/glad-ranked';
 import treeCoverGain from 'components/widgets/forest-change/tree-cover-gain';
@@ -54,6 +55,7 @@ export default {
   treeLossGlobal,
   treeLossRanked,
   firesAlerts,
+  firesAlertsCumulative,
   fires,
   firesRanked,
   faoDeforest,

--- a/app/javascript/components/widgets/utils/data.js
+++ b/app/javascript/components/widgets/utils/data.js
@@ -85,10 +85,10 @@ const runningMeanWindowed = (data, windowSize) => {
   const buffer = Math.round(windowSize / 2);
   data.forEach((d, i) => {
     let slice = [];
-    if (i < buffer) {
-      slice = data.slice(0, i + buffer);
+    if (i < windowSize) {
+      slice = data.slice(0, i + 1);
     } else if (i > data.length - buffer) {
-      slice = data.slice(i - buffer, data.length - 1);
+      slice = data.slice(i - buffer, data.length);
     } else {
       slice = data.slice(i - buffer, i + buffer);
     }
@@ -241,16 +241,6 @@ export const getStdDevData = (data, rawData) => {
 };
 
 export const getCumulativeStatsData = data => {
-  /*
-  Creates yearly data structure and uses this to generate weekly mean and standard deviation stats.
-  Yearly data structure groups alert data by year and appends the first (or last) 6 weeks
-  of data from neighbouring years:
-
-  e.g. The element with year=2015 contains the last 6 weeks of 2014 data,
-  followed by 52 weeks of 2015 data, followed by the first 6 weeks of 2016 data
-
-  This is done so that when the data is smoothed we are left with 52 weeks of stats per year.
-  */
   const maxYear = maxBy(data, 'year').year;
 
   const allYears = getYearsObj(data, 0, data.length);
@@ -258,7 +248,6 @@ export const getCumulativeStatsData = data => {
   const stats = statsData(allYears);
   const smoothedMeans = runningMeanWindowed(stats.map(el => el.mean), 12);
   const smoothedStds = runningMeanWindowed(stats.map(el => el.std), 12);
-
   const pastYear = data.filter(d => d.year === maxYear);
   const parsedData = pastYear.map((d, i) => {
     const weekMean = (smoothedMeans && smoothedMeans[i]) || 0;

--- a/app/javascript/components/widgets/utils/data.js
+++ b/app/javascript/components/widgets/utils/data.js
@@ -309,7 +309,7 @@ export const getChartConfig = (colors, latest, unit = '') => {
           isAnimationActive: false
         },
         compareCount: {
-          stroke: '#00F',
+          stroke: '#49b5e3',
           isAnimationActive: false
         },
         target: {

--- a/app/javascript/components/widgets/utils/data.js
+++ b/app/javascript/components/widgets/utils/data.js
@@ -254,7 +254,7 @@ export const getCumulativeStatsData = data => {
   const smoothedMeans = runningMeanWindowed(stats.map(el => el.mean), 12);
   const smoothedStds = runningMeanWindowed(stats.map(el => el.std), 12);
 
-  const pastYear = data.filter(d => d.year === maxYear).slice(-52);
+  const pastYear = data.filter(d => d.year === maxYear).slice(0, 52);
   const parsedData = pastYear.map((d, i) => {
     const weekMean = (smoothedMeans && smoothedMeans[i]) || 0;
     const stdDev = (smoothedStds && smoothedStds[i]) || 0;

--- a/app/javascript/components/widgets/utils/data.js
+++ b/app/javascript/components/widgets/utils/data.js
@@ -268,8 +268,7 @@ export const getCumulativeStatsData = data => {
       const diff =
         (smoothedMeans && smoothedMeans[i - 1] - smoothedMeans[i - 2]) || 0;
       const step =
-        (smoothedMeans &&
-          mean([smoothedMeans[i - 1] - smoothedMeans[i - 2]])) ||
+        (smoothedMeans && mean([smoothedMeans[i - 1], smoothedMeans[i - 2]])) ||
         0;
       weekMean = diff + step;
       stdDev = (smoothedStds && smoothedStds[i - 1]) || 0;

--- a/app/javascript/components/widgets/utils/data.js
+++ b/app/javascript/components/widgets/utils/data.js
@@ -90,8 +90,8 @@ const runningMeanWindowed = (data, windowSize) => {
     if (i < buffer) {
       slice = data.slice(0, i + increment);
       increment += 1;
-    } else if (i >= data.length - buffer) {
-      slice = data.slice(i - increment, data.length);
+    } else if (i >= data.length - buffer - 1) {
+      slice = data.slice(i - increment, data.length - 1);
       increment -= 1;
     } else {
       slice = data.slice(i - buffer, i + buffer);

--- a/app/javascript/components/widgets/utils/data.js
+++ b/app/javascript/components/widgets/utils/data.js
@@ -251,13 +251,29 @@ export const getCumulativeStatsData = data => {
   const allYears = getYearsObj(data, 0, data.length);
 
   const stats = statsData(allYears);
-  const smoothedMeans = runningMeanWindowed(stats.map(el => el.mean), 12);
-  const smoothedStds = runningMeanWindowed(stats.map(el => el.std), 12);
+  const smoothedMeans = runningMeanWindowed(stats.map(el => el.mean), 12).slice(
+    0,
+    52
+  );
+  const smoothedStds = runningMeanWindowed(stats.map(el => el.std), 12).slice(
+    0,
+    52
+  );
 
-  const pastYear = data.filter(d => d.year === maxYear).slice(0, 52);
+  const pastYear = data.filter(d => d.year === maxYear);
   const parsedData = pastYear.map((d, i) => {
-    const weekMean = (smoothedMeans && smoothedMeans[i]) || 0;
-    const stdDev = (smoothedStds && smoothedStds[i]) || 0;
+    let weekMean = (smoothedMeans && smoothedMeans[i]) || 0;
+    let stdDev = (smoothedStds && smoothedStds[i]) || 0;
+    if (i === pastYear.length - 1) {
+      const diff =
+        (smoothedMeans && smoothedMeans[i - 1] - smoothedMeans[i - 2]) || 0;
+      const step =
+        (smoothedMeans &&
+          mean([smoothedMeans[i - 1] - smoothedMeans[i - 2]])) ||
+        0;
+      weekMean = diff + step;
+      stdDev = (smoothedStds && smoothedStds[i - 1]) || 0;
+    }
 
     return {
       ...d,


### PR DESCRIPTION
## Overview

Cumulative fires chart.

<img width="715" alt="Screen Shot 2020-04-24 at 15 28 35" src="https://user-images.githubusercontent.com/30242314/80224708-5cbfd880-864a-11ea-9b35-15522a4128cb.png">

## To do

- [x] - Add fires to map
- [x] - Fixed Jan-Dec x-axis dates
- [x] - Remove tooltip for points with `counts === null`  (i.e. dates after latest)
- [x] - Where possible, import functions from `fire-alerts`