### PR TITLE
Updating language to reflect AOI launch

### DIFF
--- a/app/javascript/components/analysis/components/show-analysis/component.jsx
+++ b/app/javascript/components/analysis/components/show-analysis/component.jsx
@@ -265,9 +265,7 @@ class ShowAnalysis extends PureComponent {
               <div className="content">
                 <h3>Interested in this particular area?</h3>
                 <p>
-                    Save this area to receive email alerts about forest cover
-                    change. We are currently developing the ability to create
-                    dashboards for custom areas.
+                    Save this area to create a dashboard with a more in-depth analysis and receive email alerts about forest cover change.
                 </p>
               </div>
             )}


### PR DESCRIPTION
I made a PR to change this from "Save this area to create a dashboard with a more in-depth analysis and receive email alerts about forest cover change" to "Save this area to receive email alerts about forest cover change. We are currently developing the ability to create dashboards for custom areas" text on March 24. Now that AOIs are launched, it's time to change it back.

## Overview

Brief description of what this PR does, and why it is needed.

## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

