### PR TITLE
Feature/historical fires by commodity category widget

### DIFF
--- a/app/javascript/components/widgets/forest-change/fires-commodities/index.js
+++ b/app/javascript/components/widgets/forest-change/fires-commodities/index.js
@@ -1,6 +1,7 @@
 import { all, spread } from 'axios';
 import {
   fetchFiresCommoditiesAlerts,
+  fetchFiresCommoditiesArea,
   fetchVIIRSLatest
 } from 'services/analysis-cached';
 
@@ -8,7 +9,7 @@ import getWidgetProps from './selectors';
 
 export default {
   widget: 'firesCommodities',
-  title: 'Regions with the most fire Alerts in {location}',
+  title: 'Density of fires alerts in {location} commodities concessions',
   categories: ['forest-change'],
   types: ['country'],
   admins: ['adm0', 'adm1'],
@@ -28,7 +29,7 @@ export default {
     forestChange: -1
   },
   sentences: {
-    initial: 'In the last {timeframe} in {location}, this is a test.'
+    initial: 'In the last {timeframe}, the {location} commodities concessions with the highest fires alerts density within {} was {highest_com}, with {density_val}.'
   },
   settings: {
     unit: '%',
@@ -41,11 +42,12 @@ export default {
     layerEndDate: null
   },
   getData: params =>
-    all([fetchFiresCommoditiesAlerts(params), fetchVIIRSLatest(params)]).then(
-      spread((alerts, latest) => {
+    all([fetchFiresCommoditiesAlerts(params), fetchFiresCommoditiesArea(params), fetchVIIRSLatest(params)]).then(
+      spread((alerts, area, latest) => {
         const { data } = alerts.data;
-        console.log('data', data)
-        return { alerts: data, latest: latest.attributes.updatedAt } || {};
+        //console.log('data_alerts', data)
+        //console.log('data_are',area.data)
+        return { alerts: data, area: area.data, latest: latest.attributes.updatedAt } || {};
       })
     ),
   // getDataURL: params => [

--- a/app/javascript/components/widgets/forest-change/fires-commodities/index.js
+++ b/app/javascript/components/widgets/forest-change/fires-commodities/index.js
@@ -44,6 +44,7 @@ export default {
     all([fetchFiresCommoditiesAlerts(params), fetchVIIRSLatest(params)]).then(
       spread((alerts, latest) => {
         const { data } = alerts.data;
+        console.log('data', data)
         return { alerts: data, latest: latest.attributes.updatedAt } || {};
       })
     ),

--- a/app/javascript/components/widgets/forest-change/fires-commodities/index.js
+++ b/app/javascript/components/widgets/forest-change/fires-commodities/index.js
@@ -15,6 +15,23 @@ export default {
   admins: ['adm0', 'adm1'],
   settingsConfig: [
     {
+      key: 'forestType',
+      label: 'Forest Type',
+      whitelist: ['ifl', 'primary_forest'],
+      type: 'select',
+      placeholder: 'All tree cover',
+      clearable: true
+    },
+    {
+      key: 'landCategory',
+      label: 'Land Category',
+      whitelist: ['wdpa'],
+      type: 'select',
+      placeholder: 'All categories',
+      clearable: true,
+      border: true
+    },
+    {
       key: 'weeks',
       label: 'weeks',
       type: 'select',
@@ -30,7 +47,9 @@ export default {
   },
   sentences: {
     initial:
-      'In the last {timeframe}, the {location} commodities concessions with the highest fires alerts density was {highest_com}, with {density_val}.'
+      'In the last {timeframe}, the {location} commodities concessions with the highest fires alerts density was {highest_com}, with {density_val}.',
+    withInd:
+      'In the last {timeframe}, the {location} commodities concessions with the highest fires alerts density within {indicator} was {highest_com}, with {density_val}.'
   },
   settings: {
     unit: 'alerts/Ha',

--- a/app/javascript/components/widgets/forest-change/fires-commodities/index.js
+++ b/app/javascript/components/widgets/forest-change/fires-commodities/index.js
@@ -29,10 +29,11 @@ export default {
     forestChange: -1
   },
   sentences: {
-    initial: 'In the last {timeframe}, the {location} commodities concessions with the highest fires alerts density within {} was {highest_com}, with {density_val}.'
+    initial:
+      'In the last {timeframe}, the {location} commodities concessions with the highest fires alerts density was {highest_com}, with {density_val}.'
   },
   settings: {
-    unit: '%',
+    unit: 'alerts/Ha',
     pageSize: 5,
     page: 0,
     period: 'week',
@@ -42,12 +43,22 @@ export default {
     layerEndDate: null
   },
   getData: params =>
-    all([fetchFiresCommoditiesAlerts(params), fetchFiresCommoditiesArea(params), fetchVIIRSLatest(params)]).then(
+    all([
+      fetchFiresCommoditiesAlerts(params),
+      fetchFiresCommoditiesArea(params),
+      fetchVIIRSLatest(params)
+    ]).then(
       spread((alerts, area, latest) => {
         const { data } = alerts.data;
-        //console.log('data_alerts', data)
-        //console.log('data_are',area.data)
-        return { alerts: data, area: area.data, latest: latest.attributes.updatedAt } || {};
+        // console.log('data_alerts', data)
+        // console.log('data_are',area.data)
+        return (
+          {
+            alerts: data,
+            area: area.data,
+            latest: latest.attributes.updatedAt
+          } || {}
+        );
       })
     ),
   // getDataURL: params => [

--- a/app/javascript/components/widgets/forest-change/fires-commodities/index.js
+++ b/app/javascript/components/widgets/forest-change/fires-commodities/index.js
@@ -1,0 +1,54 @@
+import { all, spread } from 'axios';
+import {
+  fetchFiresCommoditiesAlerts,
+  fetchVIIRSLatest
+} from 'services/analysis-cached';
+
+import getWidgetProps from './selectors';
+
+export default {
+  widget: 'firesCommodities',
+  title: 'Regions with the most fire Alerts in {location}',
+  categories: ['forest-change'],
+  types: ['country'],
+  admins: ['adm0', 'adm1'],
+  settingsConfig: [
+    {
+      key: 'weeks',
+      label: 'weeks',
+      type: 'select',
+      whitelist: [13, 26, 52],
+      noSort: true
+    }
+  ],
+  chartType: 'rankedList',
+  metaKey: '',
+  colors: 'fires',
+  sortOrder: {
+    forestChange: -1
+  },
+  sentences: {
+    initial: 'In the last {timeframe} in {location}, this is a test.'
+  },
+  settings: {
+    unit: '%',
+    pageSize: 5,
+    page: 0,
+    period: 'week',
+    weeks: 13,
+    dataset: 'VIIRS',
+    layerStartDate: null,
+    layerEndDate: null
+  },
+  getData: params =>
+    all([fetchFiresCommoditiesAlerts(params), fetchVIIRSLatest(params)]).then(
+      spread((alerts, latest) => {
+        const { data } = alerts.data;
+        return { alerts: data, latest: latest.attributes.updatedAt } || {};
+      })
+    ),
+  // getDataURL: params => [
+  //   fetchFiresAlertsGrouped({ ...params, download: true })
+  // ],
+  getWidgetProps
+};

--- a/app/javascript/components/widgets/forest-change/fires-commodities/selectors.js
+++ b/app/javascript/components/widgets/forest-change/fires-commodities/selectors.js
@@ -8,7 +8,7 @@ import sumBy from 'lodash/sumBy';
 import moment from 'moment';
 
 // get list data
-const getData = state => state.data && state.data.alerts;
+const getData = state => state.data && state.data;
 const getLatestDates = state => state.data && state.data.latest;
 const getSettings = state => state.settings;
 const getOptionsSelected = state => state.optionsSelected;
@@ -20,16 +20,21 @@ const getColors = state => state.colors;
 const getSentences = state => state.sentences;
 
 export const parseList = createSelector(
-  [getData, getLatestDates, getSettings, getAdm1, getLocationsMeta, getColors],
+  [getData,getLatestDates, getSettings, getAdm1, getLocationsMeta, getColors],
   (data, latest, settings, adm1, meta, colors) => {
-    if (!data || isEmpty(data) || !meta || isEmpty(meta)) return null;
+    if (!data || isEmpty(data)) return null;
+    console.log('data',data)
+    const alertsData = data.alerts || [];
+    const alertsArea = data.area || [];
+    if (!alertsData || isEmpty(alertsData) || !alertsArea || isEmpty(alertsArea)) return null;
+    
     const latestWeek = moment(latest)
       .subtract(1, 'weeks')
       .week();
     const latestYear = moment(latest)
       .subtract(1, 'weeks')
       .year();
-    const alertsByDate = data.filter(d =>
+    const alertsByDate = alertsData.filter(d =>
       moment()
         .week(d.week)
         .year(d.year)
@@ -40,26 +45,47 @@ export const parseList = createSelector(
             .subtract(settings.weeks, 'weeks')
         )
     );
-    const groupedAlerts = groupBy(alertsByDate, adm1 ? 'adm2' : 'adm1');
+    console.log('alertsByDate',alertsByDate)
+    const commodityKeys = ['is__gfw_logging', 'is__gfw_mining', 'is__gfw_oil_gas', 'is__gfw_oil_palm', 'is__gfw_wood_fiber']
+    
+    let reducedData = [];
+    alertsData.forEach(d => {
+      commodityKeys.forEach(key=> {
+        const commodity = d[key] && d[key]==='true' ? key : null;
+        if (commodity !== null) {reducedData.push({
+          ...d,
+          commodity,
+        })} 
+      })
+    })
 
-    const totalCounts = sumBy(alertsByDate, 'count');
+    const groupedAlerts = groupBy(reducedData,'commodity')
+    
     const mappedData = Object.keys(groupedAlerts).map(k => {
-      const locationId = parseInt(k, 10);
-      const region = meta[locationId];
-      const regionData = groupedAlerts[locationId];
-      const counts = sumBy(regionData, 'count');
-      const countsPerc = counts && totalCounts ? counts / totalCounts * 100 : 0;
+      const AlertbyCommodity = groupedAlerts[k]
+      const Alertcount = sumBy(AlertbyCommodity,'count')
+      const CommodityArea = sumBy(groupBy(alertsArea.data,k)['true'],'area__ha')
+      
+      const density = CommodityArea && CommodityArea !== 0 ? Alertcount / CommodityArea : null;
+      //const locationId = parseInt(k, 10);
+      //const region = meta[locationId];
+      console.log('density',density)
+      //const regionData = groupedAlerts[locationId];
+
+
+      //const counts = sumBy(regionData, 'count');
+      //const countsPerc = counts && totalCounts ? counts / totalCounts * 100 : 0;
 
       const buckets = colors && getColorBuckets(colors);
-      const colorBucket = buckets && getColorBucket(buckets, countsPerc);
+      const colorBucket = buckets && getColorBucket(buckets, Alertcount );//countsPerc);
 
       return {
         id: k,
         color: colorBucket.color,
-        percentage: `${format('.2r')(countsPerc)}%`,
-        count: counts,
-        value: countsPerc,
-        label: (region && region.label) || ''
+        density: `${format('.2r')(density)} alerts/Ha`,
+        count: density,//counts,
+        value: density,//countsPerc,
+        label: k//(region && region.label) || ''
       };
     });
     return sortBy(mappedData, 'area').reverse();
@@ -76,9 +102,9 @@ export const parseSentence = createSelector(
   (data, optionsSelected, indicator, locationName, sentences) => {
     if (!data || !optionsSelected || !locationName) return null;
     const { initial, withInd } = sentences;
-    const topRegion = data[0].label;
-    const topRegionCount = data[0].count;
-    const topRegionPerc = data[0].value;
+    //const topRegion = data[0].label;
+    //const topRegionCount = data[0].count;
+    //const topRegionPerc = data[0].value;
     const timeFrame = optionsSelected.weeks;
 
     const params = {
@@ -89,6 +115,7 @@ export const parseSentence = createSelector(
       location: locationName,
       indicator: `${indicator ? `${indicator.label}` : ''}`
     };
+    //console.log('indicator', indicator)
     const sentence = indicator ? withInd : initial;
     return { sentence, params };
   }

--- a/app/javascript/components/widgets/forest-change/fires-commodities/selectors.js
+++ b/app/javascript/components/widgets/forest-change/fires-commodities/selectors.js
@@ -1,0 +1,100 @@
+import { createSelector, createStructuredSelector } from 'reselect';
+import isEmpty from 'lodash/isEmpty';
+import sortBy from 'lodash/sortBy';
+import { format } from 'd3-format';
+import { getColorBuckets, getColorBucket } from 'utils/data';
+import groupBy from 'lodash/groupBy';
+import sumBy from 'lodash/sumBy';
+import moment from 'moment';
+
+// get list data
+const getData = state => state.data && state.data.alerts;
+const getLatestDates = state => state.data && state.data.latest;
+const getSettings = state => state.settings;
+const getOptionsSelected = state => state.optionsSelected;
+const getIndicator = state => state.indicator;
+const getAdm1 = state => state.adm1;
+const getLocationsMeta = state => state.childData;
+const getLocationName = state => state.locationLabel;
+const getColors = state => state.colors;
+const getSentences = state => state.sentences;
+
+export const parseList = createSelector(
+  [getData, getLatestDates, getSettings, getAdm1, getLocationsMeta, getColors],
+  (data, latest, settings, adm1, meta, colors) => {
+    if (!data || isEmpty(data) || !meta || isEmpty(meta)) return null;
+    const latestWeek = moment(latest)
+      .subtract(1, 'weeks')
+      .week();
+    const latestYear = moment(latest)
+      .subtract(1, 'weeks')
+      .year();
+    const alertsByDate = data.filter(d =>
+      moment()
+        .week(d.week)
+        .year(d.year)
+        .isAfter(
+          moment()
+            .week(latestWeek)
+            .year(latestYear)
+            .subtract(settings.weeks, 'weeks')
+        )
+    );
+    const groupedAlerts = groupBy(alertsByDate, adm1 ? 'adm2' : 'adm1');
+
+    const totalCounts = sumBy(alertsByDate, 'count');
+    const mappedData = Object.keys(groupedAlerts).map(k => {
+      const locationId = parseInt(k, 10);
+      const region = meta[locationId];
+      const regionData = groupedAlerts[locationId];
+      const counts = sumBy(regionData, 'count');
+      const countsPerc = counts && totalCounts ? counts / totalCounts * 100 : 0;
+
+      const buckets = colors && getColorBuckets(colors);
+      const colorBucket = buckets && getColorBucket(buckets, countsPerc);
+
+      return {
+        id: k,
+        color: colorBucket.color,
+        percentage: `${format('.2r')(countsPerc)}%`,
+        count: counts,
+        value: countsPerc,
+        label: (region && region.label) || ''
+      };
+    });
+    return sortBy(mappedData, 'area').reverse();
+  }
+);
+
+export const parseData = createSelector([parseList], data => {
+  if (isEmpty(data)) return null;
+  return sortBy(data, 'value').reverse();
+});
+
+export const parseSentence = createSelector(
+  [parseData, getOptionsSelected, getIndicator, getLocationName, getSentences],
+  (data, optionsSelected, indicator, locationName, sentences) => {
+    if (!data || !optionsSelected || !locationName) return null;
+    const { initial, withInd } = sentences;
+    const topRegion = data[0].label;
+    const topRegionCount = data[0].count;
+    const topRegionPerc = data[0].value;
+    const timeFrame = optionsSelected.weeks;
+
+    const params = {
+      timeframe: timeFrame && timeFrame.label,
+      // topRegion,
+      // topRegionCount: format(',')(topRegionCount),
+      // topRegionPerc: `${format('.2r')(topRegionPerc)}%`,
+      location: locationName,
+      indicator: `${indicator ? `${indicator.label}` : ''}`
+    };
+    const sentence = indicator ? withInd : initial;
+    return { sentence, params };
+  }
+);
+
+export default createStructuredSelector({
+  data: parseData,
+  sentence: parseSentence
+});

--- a/app/javascript/components/widgets/forest-change/fires-commodities/selectors.js
+++ b/app/javascript/components/widgets/forest-change/fires-commodities/selectors.js
@@ -12,6 +12,7 @@ const getData = state => state.data && state.data;
 const getLatestDates = state => state.data && state.data.latest;
 const getSettings = state => state.settings;
 const getOptionsSelected = state => state.optionsSelected;
+const getIndicator = state => state.indicator;
 const getLocationName = state => state.locationLabel;
 const getColors = state => state.colors;
 const getSentences = state => state.sentences;
@@ -110,10 +111,10 @@ export const parseData = createSelector([parseList], data => {
 });
 
 export const parseSentence = createSelector(
-  [parseData, getOptionsSelected, getLocationName, getSentences],
-  (data, optionsSelected, locationName, sentences) => {
+  [parseData, getOptionsSelected, getIndicator,getLocationName, getSentences],
+  (data, optionsSelected, indicator, locationName, sentences) => {
     if (!data || !optionsSelected || !locationName) return null;
-    const { initial } = sentences;
+    const { initial,withInd } = sentences;
     const density_val = data[0].value;
     const highest_com = data[0].label;
     const timeFrame = optionsSelected.weeks;
@@ -121,9 +122,10 @@ export const parseSentence = createSelector(
       timeframe: timeFrame && timeFrame.label,
       density_val: `${format('.2r')(density_val)} alerts/Ha`,
       highest_com,
-      location: locationName
+      location: locationName,
+      indicator: `${indicator ? `${indicator.label}` : ''}`
     };
-    const sentence = initial;
+    const sentence = indicator ? withInd : initial;
     return { sentence, params };
   }
 );

--- a/app/javascript/components/widgets/forest-change/fires-commodities/selectors.js
+++ b/app/javascript/components/widgets/forest-change/fires-commodities/selectors.js
@@ -12,111 +12,118 @@ const getData = state => state.data && state.data;
 const getLatestDates = state => state.data && state.data.latest;
 const getSettings = state => state.settings;
 const getOptionsSelected = state => state.optionsSelected;
-const getIndicator = state => state.indicator;
-const getAdm1 = state => state.adm1;
-const getLocationsMeta = state => state.childData;
 const getLocationName = state => state.locationLabel;
 const getColors = state => state.colors;
 const getSentences = state => state.sentences;
 
 export const parseList = createSelector(
-  [getData,getLatestDates, getSettings, getAdm1, getLocationsMeta, getColors],
-  (data, latest, settings, adm1, meta, colors) => {
+  [getData, getLatestDates, getSettings, getColors],
+  (data, latest, settings, colors) => {
     if (!data || isEmpty(data)) return null;
-    console.log('data',data)
     const alertsData = data.alerts || [];
     const alertsArea = data.area || [];
-    if (!alertsData || isEmpty(alertsData) || !alertsArea || isEmpty(alertsArea)) return null;
-    
-    const latestWeek = moment(latest)
-      .subtract(1, 'weeks')
-      .week();
-    const latestYear = moment(latest)
-      .subtract(1, 'weeks')
-      .year();
-    const alertsByDate = alertsData.filter(d =>
-      moment()
-        .week(d.week)
-        .year(d.year)
-        .isAfter(
-          moment()
-            .week(latestWeek)
-            .year(latestYear)
-            .subtract(settings.weeks, 'weeks')
-        )
-    );
-    console.log('alertsByDate',alertsByDate)
-    const commodityKeys = ['is__gfw_logging', 'is__gfw_mining', 'is__gfw_oil_gas', 'is__gfw_oil_palm', 'is__gfw_wood_fiber']
-    
-    let reducedData = [];
+    if (
+      !alertsData ||
+      isEmpty(alertsData) ||
+      !alertsArea ||
+      isEmpty(alertsArea)
+    ) {
+      return null;
+    }
+
+    // const latestWeek = moment(latest)
+    //   .subtract(1, 'weeks')
+    //   .week();
+    // const latestYear = moment(latest)
+    //   .subtract(1, 'weeks')
+    //   .year();
+    // const alertsByDate = alertsData.filter(d =>
+    //   moment()
+    //     .week(d.week)
+    //     .year(d.year)
+    //     .isAfter(
+    //       moment()
+    //         .week(latestWeek)
+    //         .year(latestYear)
+    //         .subtract(settings.weeks, 'weeks')
+    //     )
+    // );
+    const commodityKeys = [
+      'is__gfw_logging',
+      'is__gfw_mining',
+      'is__gfw_oil_gas',
+      'is__gfw_oil_palm',
+      'is__gfw_wood_fiber'
+    ];
+    const commoditylabel = {
+      is__gfw_logging: 'logging',
+      is__gfw_mining: 'mining',
+      is__gfw_oil_gas: 'oil gas',
+      is__gfw_oil_palm: 'oil palm',
+      is__gfw_wood_fiber: 'wood fiber'
+    };
+
+    const reducedData = [];
     alertsData.forEach(d => {
-      commodityKeys.forEach(key=> {
-        const commodity = d[key] && d[key]==='true' ? key : null;
-        if (commodity !== null) {reducedData.push({
-          ...d,
-          commodity,
-        })} 
-      })
-    })
+      commodityKeys.forEach(key => {
+        const commodity = d[key] && d[key] === 'true' ? key : null;
+        if (commodity !== null) {
+          reducedData.push({
+            ...d,
+            commodity
+          });
+        }
+      });
+    });
 
-    const groupedAlerts = groupBy(reducedData,'commodity')
-    
+    const groupedAlerts = groupBy(reducedData, 'commodity');
+
     const mappedData = Object.keys(groupedAlerts).map(k => {
-      const AlertbyCommodity = groupedAlerts[k]
-      const Alertcount = sumBy(AlertbyCommodity,'count')
-      const CommodityArea = sumBy(groupBy(alertsArea.data,k)['true'],'area__ha')
-      
-      const density = CommodityArea && CommodityArea !== 0 ? Alertcount / CommodityArea : null;
-      //const locationId = parseInt(k, 10);
-      //const region = meta[locationId];
-      console.log('density',density)
-      //const regionData = groupedAlerts[locationId];
+      const AlertbyCommodity = groupedAlerts[k];
+      const Alertcount = sumBy(AlertbyCommodity, 'count');
+      const CommodityArea =
+        alertsArea.data && alertsArea.data !== 0
+          ? sumBy(groupBy(alertsArea.data, k).true, 'area__ha')
+          : null;
 
-
-      //const counts = sumBy(regionData, 'count');
-      //const countsPerc = counts && totalCounts ? counts / totalCounts * 100 : 0;
+      const density =
+        CommodityArea && CommodityArea !== 0 ? Alertcount / CommodityArea : '';
 
       const buckets = colors && getColorBuckets(colors);
-      const colorBucket = buckets && getColorBucket(buckets, Alertcount );//countsPerc);
+      const colorBucket = buckets && getColorBucket(buckets, Alertcount);
 
       return {
         id: k,
         color: colorBucket.color,
         density: `${format('.2r')(density)} alerts/Ha`,
-        count: density,//counts,
-        value: density,//countsPerc,
-        label: k//(region && region.label) || ''
+        // count: density, // counts,
+        value: density || '', // density, // countsPerc,
+        label: density && k ? commoditylabel[k] : '' // (region && region.label) || ''
       };
     });
-    return sortBy(mappedData, 'area').reverse();
+    return sortBy(mappedData, 'value').reverse();
   }
 );
-
 export const parseData = createSelector([parseList], data => {
   if (isEmpty(data)) return null;
   return sortBy(data, 'value').reverse();
 });
 
 export const parseSentence = createSelector(
-  [parseData, getOptionsSelected, getIndicator, getLocationName, getSentences],
-  (data, optionsSelected, indicator, locationName, sentences) => {
+  [parseData, getOptionsSelected, getLocationName, getSentences],
+  (data, optionsSelected, locationName, sentences) => {
     if (!data || !optionsSelected || !locationName) return null;
-    const { initial, withInd } = sentences;
-    //const topRegion = data[0].label;
-    //const topRegionCount = data[0].count;
-    //const topRegionPerc = data[0].value;
+    const { initial } = sentences;
+    const density_val = data[0].value;
+    const highest_com = data[0].label;
     const timeFrame = optionsSelected.weeks;
-
     const params = {
       timeframe: timeFrame && timeFrame.label,
-      // topRegion,
-      // topRegionCount: format(',')(topRegionCount),
-      // topRegionPerc: `${format('.2r')(topRegionPerc)}%`,
-      location: locationName,
-      indicator: `${indicator ? `${indicator.label}` : ''}`
+      density_val: `${format('.2r')(density_val)} alerts/Ha`,
+      highest_com,
+      location: locationName
     };
-    //console.log('indicator', indicator)
-    const sentence = indicator ? withInd : initial;
+    const sentence = initial;
     return { sentence, params };
   }
 );

--- a/app/javascript/components/widgets/manifest.js
+++ b/app/javascript/components/widgets/manifest.js
@@ -6,6 +6,7 @@ import treeLossRanked from 'components/widgets/forest-change/tree-loss-ranked';
 import faoDeforest from 'components/widgets/forest-change/fao-deforest';
 import faoReforest from 'components/widgets/forest-change/fao-reforest';
 import firesAlerts from 'components/widgets/forest-change/fires-alerts';
+import firesCommodities from 'components/widgets/forest-change/fires-commodities';
 import firesRanked from 'components/widgets/forest-change/fires-ranked';
 import gladRanked from 'components/widgets/forest-change/glad-ranked';
 import treeCoverGain from 'components/widgets/forest-change/tree-cover-gain';
@@ -54,6 +55,7 @@ export default {
   treeLossGlobal,
   treeLossRanked,
   firesAlerts,
+  firesCommodities,
   fires,
   firesRanked,
   faoDeforest,

--- a/app/javascript/services/analysis-cached.js
+++ b/app/javascript/services/analysis-cached.js
@@ -52,9 +52,9 @@ const SQL_QUERIES = {
   fires:
     'SELECT {location}, alert__year, alert__week, SUM(alert__count) AS alert__count, SUM(alert_area__ha) AS alert_area__ha, confidence__cat FROM data {WHERE} GROUP BY {location}, alert__year, alert__week',
   firesAlertsCommodities:
-    'SELECT {location}, alert__year, alert__week, SUM(alert__count) AS alert__count, is__gfw_logging, is__gfw_mining, is__gfw_oil_gas, is__gfw_oil_palm, is__gfw_wood_fiber FROM data {WHERE} GROUP BY is__gfw_logging, is__gfw_mining, is__gfw_oil_gas, is__gfw_oil_palm, is__gfw_wood_fiber, alert__year, alert__week ORDER BY alert__year DESC, alert__week DESC ',
+    `SELECT {location}, alert__year, alert__week, SUM(alert__count) AS alert__count, is__gfw_logging, is__gfw_mining, is__gfw_oil_gas, is__gfw_oil_palm, is__gfw_wood_fiber FROM data {WHERE} AND (is__gfw_logging = 'true' or is__gfw_mining = 'true' or is__gfw_oil_gas = 'true' or is__gfw_oil_palm = 'true' or is__gfw_wood_fiber  = 'true') GROUP BY is__gfw_logging, is__gfw_mining, is__gfw_oil_gas, is__gfw_oil_palm, is__gfw_wood_fiber, alert__year, alert__week ORDER BY alert__year DESC, alert__week DESC`,
   firesCommmoditiesArea:
-    'SELECT {location} area__ha, is__gfw_logging, is__gfw_mining, is__gfw_oil_gas, is__gfw_oil_palm, is__gfw_wood_fiber FROM data {WHERE}',
+    `SELECT {location} area__ha, is__gfw_logging, is__gfw_mining, is__gfw_oil_gas, is__gfw_oil_palm, is__gfw_wood_fiber FROM data {WHERE} AND (is__gfw_logging = 'true' or is__gfw_mining = 'true' or is__gfw_oil_gas = 'true' or is__gfw_oil_palm = 'true' or is__gfw_wood_fiber  = 'true')`,
   nonGlobalDatasets:
     'SELECT {polynames} FROM polyname_whitelist WHERE iso is null AND adm1 is null AND adm2 is null',
   getLocationPolynameWhitelist:
@@ -939,7 +939,8 @@ export const fetchFiresCommoditiesAlerts = ({
     };
   }
 
-  const testresponse = apiRequest.get(url).then(testresponse => ({
+  console.log('url', url);
+  return apiRequest.get(url).then(testresponse => ({
     data: {
       data: testresponse.data.data.map(d => ({
         ...d,
@@ -951,9 +952,6 @@ export const fetchFiresCommoditiesAlerts = ({
       }))
     }
   }));
-  console.log('url', url);
-  console.log('testresponse', testresponse);
-  return testresponse;
 };
 
 export const fetchVIIRSLatest = () => {

--- a/app/javascript/services/analysis-cached.js
+++ b/app/javascript/services/analysis-cached.js
@@ -895,13 +895,11 @@ export const fetchFiresCommoditiesAlerts = ({
   forestType,
   landCategory,
   confidence,
-  ifl,
   grouped,
   download,
   ...params
 }) => {
   const { firesAlertsCommodities } = SQL_QUERIES;
-  console.log('firesAlertsCommodities', firesAlertsCommodities);
   const url = `${getRequestUrl({
     ...params,
     adm0,
@@ -909,7 +907,7 @@ export const fetchFiresCommoditiesAlerts = ({
     adm2,
     grouped,
     confidence,
-    allowedParams: 'firesAlertsCommodities'
+    allowedParams: 'fires'
   })}${firesAlertsCommodities}`
     .replace(
       /{location}/g,
@@ -926,14 +924,13 @@ export const fetchFiresCommoditiesAlerts = ({
         forestType,
         landCategory,
         confidence,
-        ifl,
         ...params,
-        allowedParams: 'firesAlertsCommodities'
+        allowedParams: 'fires'
       })
     );
 
   if (download) {
-    const indicator = getIndicator(forestType, landCategory, ifl);
+    const indicator = getIndicator(forestType, landCategory);
     return {
       name: `viirs_fire_alerts${
         indicator ? `_in_${snakeCase(indicator.label)}` : ''


### PR DESCRIPTION
## Overview

Start of the multiple category ranking list - commodity production areas widget. 

The widget contains:

-  An initial sentence for all the admin levels with no indicator option(just shows the ranked commodities within an admin area by density of alerts in alerts/ha and a title

- Parsing of the values to the bar chart.

Things that need attention/fixing:

- bar-chart config disappears when changing '%' value to 'alerts/Ha' in the index.js file.
- need to add timeline configuration to the barchart (keep it uncomment at the moment)

## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

