### PR TITLE
[FIX] Fixed /howto extLink in about page and TLD length in contact-us form.

### DIFF
--- a/app/javascript/components/forms/validations.js
+++ b/app/javascript/components/forms/validations.js
@@ -7,7 +7,7 @@ export const number = value =>
   (value && isNaN(Number(value)) ? 'Must be a number' : undefined);
 
 export const email = value =>
-  (value && !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(value)
+  (value && !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,10}$/i.test(value)
     ? 'Invalid email address'
     : undefined);
 
@@ -22,9 +22,7 @@ export const phoneNumber = value =>
     : undefined);
 
 export const hasValidOption = (value, options) =>
-  (!options.find(o => o.value === value)
-    ? 'Please select an option'
-    : undefined);
+  (!options.find(o => o.value === value) ? 'Please select an option' : undefined);
 
 export const composeValidators = (req, vals) => value => {
   let validations = req ? [required] : [];

--- a/app/javascript/pages/about/section-projects/section-projects-component.jsx
+++ b/app/javascript/pages/about/section-projects/section-projects-component.jsx
@@ -78,7 +78,10 @@ class SectionProjects extends PureComponent {
                 onClick={setCategorySelected}
               />
             )}
-            <Button className="how-to-btn" link="/howto">
+            <Button
+              className="how-to-btn"
+              extLink="https://www.globalforestwatch.org/howto/"
+            >
               LEARN HOW TO USE GFW
             </Button>
           </div>


### PR DESCRIPTION
## Overview

- Fixed an issue (probably related to the router?) in which the /howto link in the About page showed an error. Changed this link into an external link (opening a new tab) to gfw.org/howto.
- Changed the email validator to allow up to 10 character top level domains. Longest TLD every is way longer, but this should be enough for now...
