### PR TITLE
Feature/zero fill loss years

### DIFF
--- a/app/javascript/components/widget/components/widget-header/component.jsx
+++ b/app/javascript/components/widget/components/widget-header/component.jsx
@@ -52,11 +52,7 @@ class WidgetHeader extends PureComponent {
       status
     } = this.props;
 
-    /*
-    PLEASE DO NOT FORGET TO STASH THIS THING BEFORE GIT ADD
-    */
-    // const showSettingsBtn =  !embed && !simple && !isEmpty(settingsConfig);
-    const showSettingsBtn = !simple && !isEmpty(settingsConfig);
+    const showSettingsBtn = !embed && !simple && !isEmpty(settingsConfig);
     const showDownloadBtn = !embed && getDataURL && status !== 'pending';
     const showMapBtn = !embed && !simple && datasets;
     const showSeparator = showSettingsBtn || showMapBtn;

--- a/app/javascript/components/widget/components/widget-header/component.jsx
+++ b/app/javascript/components/widget/components/widget-header/component.jsx
@@ -52,7 +52,11 @@ class WidgetHeader extends PureComponent {
       status
     } = this.props;
 
-    const showSettingsBtn = !embed && !simple && !isEmpty(settingsConfig);
+    /*
+    PLEASE DO NOT FORGET TO STASH THIS THING BEFORE GIT ADD
+    */
+    // const showSettingsBtn =  !embed && !simple && !isEmpty(settingsConfig);
+    const showSettingsBtn = !simple && !isEmpty(settingsConfig);
     const showDownloadBtn = !embed && getDataURL && status !== 'pending';
     const showMapBtn = !embed && !simple && datasets;
     const showSeparator = showSettingsBtn || showMapBtn;

--- a/app/javascript/components/widgets/climate/emissions-deforestation/index.js
+++ b/app/javascript/components/widgets/climate/emissions-deforestation/index.js
@@ -12,7 +12,7 @@ import {
   BIOMASS_LOSS
 } from 'data/layers';
 
-import { getYearsRange } from 'components/widgets/utils/data';
+import { getYearsRangeFromData } from 'components/widgets/utils/data';
 
 import { shouldQueryPrecomputedTables } from 'components/widgets/utils/helpers';
 
@@ -45,7 +45,7 @@ const getDataFromAPI = params =>
       loss = data.years;
     }
 
-    const { startYear, endYear, range } = getYearsRange(loss);
+    const { startYear, endYear, range } = getYearsRangeFromData(loss);
 
     return {
       loss,
@@ -124,7 +124,7 @@ export default {
     if (shouldQueryPrecomputedTables(params)) {
       return getLoss(params).then(response => {
         const loss = response.data.data;
-        const { startYear, endYear, range } = getYearsRange(loss);
+        const { startYear, endYear, range } = getYearsRangeFromData(loss);
 
         return {
           loss,

--- a/app/javascript/components/widgets/climate/emissions-deforestation/index.js
+++ b/app/javascript/components/widgets/climate/emissions-deforestation/index.js
@@ -12,11 +12,13 @@ import {
   BIOMASS_LOSS
 } from 'data/layers';
 
-import { getYearsRangeFromData } from 'components/widgets/utils/data';
-
+import { getYearsRangeFromMinMax } from 'components/widgets/utils/data';
 import { shouldQueryPrecomputedTables } from 'components/widgets/utils/helpers';
 
 import getWidgetProps from './selectors';
+
+const MIN_YEAR = 2001;
+const MAX_YEAR = 2019;
 
 const getDataFromAPI = params =>
   fetchAnalysisEndpoint({
@@ -45,7 +47,10 @@ const getDataFromAPI = params =>
       loss = data.years;
     }
 
-    const { startYear, endYear, range } = getYearsRangeFromData(loss);
+    const { startYear, endYear, range } = getYearsRangeFromMinMax(
+      MIN_YEAR,
+      MAX_YEAR
+    );
 
     return {
       loss,
@@ -124,13 +129,17 @@ export default {
     if (shouldQueryPrecomputedTables(params)) {
       return getLoss(params).then(response => {
         const loss = response.data.data;
-        const { startYear, endYear, range } = getYearsRangeFromData(loss);
+        const { startYear, endYear, range } = getYearsRangeFromMinMax(
+          MIN_YEAR,
+          MAX_YEAR
+        );
 
         return {
           loss,
           settings: {
             startYear,
-            endYear
+            endYear,
+            yearsRange: range
           },
           options: {
             years: range

--- a/app/javascript/components/widgets/climate/emissions-deforestation/selectors.js
+++ b/app/javascript/components/widgets/climate/emissions-deforestation/selectors.js
@@ -3,7 +3,10 @@ import { format } from 'd3-format';
 import isEmpty from 'lodash/isEmpty';
 
 import { formatNumber } from 'utils/format';
-import { yearTicksFormatter } from 'components/widgets/utils/data';
+import {
+  yearTicksFormatter,
+  zeroFillYears
+} from 'components/widgets/utils/data';
 
 // get list data
 const getData = state => state.data && state.data.loss;
@@ -17,15 +20,31 @@ export const parseData = createSelector(
   [getData, getSettings],
   (data, settings) => {
     if (isEmpty(data)) return null;
-    const { startYear, endYear } = settings;
-
+    const { startYear, endYear, yearsRange } = settings;
+    const years = yearsRange.map(yearObj => yearObj.value);
+    const fillObj = {
+      area: 0,
+      biomassLoss: 0,
+      bound1: null,
+      emissions: 0,
+      percentage: 0
+    };
+    const zeroFilledData = zeroFillYears(
+      data,
+      startYear,
+      endYear,
+      years,
+      fillObj
+    );
     return (
-      data &&
-      data.filter(d => d.year >= startYear && d.year <= endYear).map(d => ({
-        ...d,
-        co2LossByYear: d.emissions,
-        biomassLoss: d.biomassLoss
-      }))
+      zeroFilledData &&
+      zeroFilledData
+        .filter(d => d.year >= startYear && d.year <= endYear)
+        .map(d => ({
+          ...d,
+          co2LossByYear: d.emissions,
+          biomassLoss: d.biomassLoss
+        }))
     );
   }
 );

--- a/app/javascript/components/widgets/forest-change/tree-loss-located/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss-located/index.js
@@ -2,7 +2,7 @@ import { getExtentGrouped, getLossGrouped } from 'services/analysis-cached';
 import groupBy from 'lodash/groupBy';
 import { all, spread } from 'axios';
 
-import { getYearsRange } from 'components/widgets/utils/data';
+import { getYearsRangeFromData } from 'components/widgets/utils/data';
 
 import {
   POLITICAL_BOUNDARIES_DATASET,
@@ -139,7 +139,9 @@ export default {
         }
 
         const { startYear, endYear, range } =
-          (lossMappedData[0] && getYearsRange(lossMappedData[0].loss)) || {};
+          (lossMappedData[0] &&
+            getYearsRangeFromData(lossMappedData[0].loss)) ||
+          {};
 
         return {
           lossByRegion: lossMappedData,

--- a/app/javascript/components/widgets/forest-change/tree-loss-pct/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss-pct/index.js
@@ -1,7 +1,7 @@
 import { all, spread } from 'axios';
 
 import { getExtent, getLoss, getLossGrouped } from 'services/analysis-cached';
-import { getYearsRange } from 'components/widgets/utils/data';
+import { getYearsRangeFromData } from 'components/widgets/utils/data';
 import { fetchAnalysisEndpoint } from 'services/analysis';
 
 import { shouldQueryPrecomputedTables } from 'components/widgets/utils/helpers';
@@ -42,7 +42,7 @@ export const getDataAPI = params =>
       }));
     const extent = data.attributes.treeExtent;
 
-    const { startYear, endYear, range } = getYearsRange(loss);
+    const { startYear, endYear, range } = getYearsRangeFromData(loss);
 
     return {
       loss,
@@ -173,7 +173,7 @@ export default {
             };
           }
 
-          const { startYear, endYear, range } = getYearsRange(
+          const { startYear, endYear, range } = getYearsRangeFromData(
             data.loss.filter(d => d.year > 2001)
           );
           return {

--- a/app/javascript/components/widgets/forest-change/tree-loss-pct/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss-pct/index.js
@@ -1,7 +1,7 @@
 import { all, spread } from 'axios';
 
 import { getExtent, getLoss, getLossGrouped } from 'services/analysis-cached';
-import { getYearsRangeFromData } from 'components/widgets/utils/data';
+import { getYearsRangeFromMinMax } from 'components/widgets/utils/data';
 import { fetchAnalysisEndpoint } from 'services/analysis';
 
 import { shouldQueryPrecomputedTables } from 'components/widgets/utils/helpers';
@@ -16,6 +16,9 @@ import {
 } from 'data/layers';
 
 import getWidgetProps from './selectors';
+
+const MIN_YEAR = 2002;
+const MAX_YEAR = 2019;
 
 const getGlobalLocation = params => ({
   adm0: params.type === 'global' ? null : params.adm0,
@@ -42,7 +45,10 @@ export const getDataAPI = params =>
       }));
     const extent = data.attributes.treeExtent;
 
-    const { startYear, endYear, range } = getYearsRangeFromData(loss);
+    const { startYear, endYear, range } = getYearsRangeFromMinMax(
+      MIN_YEAR,
+      MAX_YEAR
+    );
 
     return {
       loss,
@@ -172,15 +178,16 @@ export default {
               extent: (loss.data.data && extent.data.data[0].extent) || 0
             };
           }
-
-          const { startYear, endYear, range } = getYearsRangeFromData(
-            data.loss.filter(d => d.year > 2001)
+          const { startYear, endYear, range } = getYearsRangeFromMinMax(
+            MIN_YEAR,
+            MAX_YEAR
           );
           return {
             ...data,
             settings: {
               startYear,
-              endYear
+              endYear,
+              yearsRange: range
             },
             options: {
               years: range

--- a/app/javascript/components/widgets/forest-change/tree-loss-plantations/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss-plantations/index.js
@@ -1,6 +1,6 @@
-import range from 'lodash/range';
 import { all, spread } from 'axios';
 import { getLoss } from 'services/analysis-cached';
+import { getYearsRangeFromMinMax } from 'components/widgets/utils/data';
 
 import {
   POLITICAL_BOUNDARIES_DATASET,
@@ -32,10 +32,6 @@ export default {
       label: 'years',
       endKey: 'endYear',
       startKey: 'startYear',
-      options: range(MIN_YEAR, MAX_YEAR, 1).map(y => ({
-        label: y,
-        value: y
-      })),
       type: 'range-select',
       border: true
     },
@@ -78,8 +74,8 @@ export default {
   },
   settings: {
     threshold: 30,
-    startYear: 2013,
-    endYear: 2019,
+    startYear: MIN_YEAR,
+    endYear: MAX_YEAR,
     extentYear: 2010
   },
   getData: params =>
@@ -103,7 +99,21 @@ export default {
             totalLoss
           };
         }
-        return data;
+        const { startYear, endYear, range } = getYearsRangeFromMinMax(
+          MIN_YEAR,
+          MAX_YEAR
+        );
+        return {
+          ...data,
+          settings: {
+            startYear,
+            endYear,
+            yearsRange: range
+          },
+          options: {
+            years: range
+          }
+        };
       })
     ),
   getDataURL: params => [

--- a/app/javascript/components/widgets/forest-change/tree-loss-plantations/selectors.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss-plantations/selectors.js
@@ -5,6 +5,7 @@ import uniqBy from 'lodash/uniqBy';
 import { format } from 'd3-format';
 import { formatNumber } from 'utils/format';
 import { getColorPalette } from 'utils/data';
+import { zeroFillYears } from 'components/widgets/utils/data';
 
 // get list data
 const getLossPlantations = state => state.data && state.data.lossPlantations;
@@ -19,10 +20,25 @@ export const parseData = createSelector(
   [getLossPlantations, getTotalLoss, getSettings],
   (lossPlantations, totalLoss, settings) => {
     if (!lossPlantations || !totalLoss) return null;
-    const { startYear, endYear } = settings;
+    const { startYear, endYear, yearsRange } = settings;
+    const years = yearsRange.map(yearObj => yearObj.value);
+    const fillObj = {
+      area: 0,
+      biomassLoss: 0,
+      bound1: null,
+      emissions: 0,
+      percentage: 0
+    };
+    const zeroFilledData = zeroFillYears(
+      lossPlantations,
+      startYear,
+      endYear,
+      years,
+      fillObj
+    );
     const totalLossByYear = groupBy(totalLoss, 'year');
-    return uniqBy(
-      lossPlantations
+    const parsedData = uniqBy(
+      zeroFilledData
         .filter(d => d.year >= startYear && d.year <= endYear)
         .map(d => {
           const groupedPlantations = groupBy(lossPlantations, 'year')[d.year];
@@ -46,6 +62,7 @@ export const parseData = createSelector(
         }),
       'year'
     );
+    return parsedData;
   }
 );
 

--- a/app/javascript/components/widgets/forest-change/tree-loss-ranked/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss-ranked/index.js
@@ -1,7 +1,7 @@
 import { all, spread } from 'axios';
 
 import { getLossGrouped, getExtentGrouped } from 'services/analysis-cached';
-import { getYearsRange } from 'components/widgets/utils/data';
+import { getYearsRangeFromData } from 'components/widgets/utils/data';
 
 import {
   POLITICAL_BOUNDARIES_DATASET,
@@ -131,7 +131,7 @@ export default {
           });
         }
 
-        const { startYear, endYear, range } = getYearsRange(mappedData);
+        const { startYear, endYear, range } = getYearsRangeFromData(mappedData);
         return {
           loss: mappedData,
           extent: extentResponse.data.data,

--- a/app/javascript/components/widgets/forest-change/tree-loss-tsc/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss-tsc/index.js
@@ -1,6 +1,6 @@
 import { all, spread } from 'axios';
 import moment from 'moment';
-import { getYearsRangeFromData } from 'components/widgets/utils/data';
+import { getYearsRangeFromMinMax } from 'components/widgets/utils/data';
 
 import {
   POLITICAL_BOUNDARIES_DATASET,
@@ -17,6 +17,7 @@ import { getExtent, getLoss } from 'services/analysis-cached';
 
 import getWidgetProps from './selectors';
 
+const MIN_YEAR = 2001;
 const MAX_YEAR = 2019;
 
 export default {
@@ -106,7 +107,10 @@ export default {
           };
         }
 
-        const { startYear, endYear, range } = getYearsRangeFromData(data.loss);
+        const { startYear, endYear, range } = getYearsRangeFromMinMax(
+          MIN_YEAR,
+          MAX_YEAR
+        );
 
         return {
           ...data,
@@ -115,7 +119,7 @@ export default {
             endYear
           },
           options: {
-            years: range.filter(y => y.value <= MAX_YEAR)
+            years: range
           }
         };
       })

--- a/app/javascript/components/widgets/forest-change/tree-loss-tsc/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss-tsc/index.js
@@ -1,6 +1,6 @@
 import { all, spread } from 'axios';
 import moment from 'moment';
-import { getYearsRange } from 'components/widgets/utils/data';
+import { getYearsRangeFromData } from 'components/widgets/utils/data';
 
 import {
   POLITICAL_BOUNDARIES_DATASET,
@@ -106,7 +106,7 @@ export default {
           };
         }
 
-        const { startYear, endYear, range } = getYearsRange(data.loss);
+        const { startYear, endYear, range } = getYearsRangeFromData(data.loss);
 
         return {
           ...data,

--- a/app/javascript/components/widgets/forest-change/tree-loss/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss/index.js
@@ -1,7 +1,7 @@
 import { all, spread } from 'axios';
 
 import { getExtent, getLoss, getLossGrouped } from 'services/analysis-cached';
-import { getYearsRange } from 'components/widgets/utils/data';
+import { getYearsRangeFromMinMax } from 'components/widgets/utils/data';
 import { fetchAnalysisEndpoint } from 'services/analysis';
 
 import { shouldQueryPrecomputedTables } from 'components/widgets/utils/helpers';
@@ -16,6 +16,9 @@ import {
 } from 'data/layers';
 
 import getWidgetProps from './selectors';
+
+const MAX_YEAR = 2019;
+const MIN_YEAR = 2001;
 
 const getGlobalLocation = params => ({
   adm0: params.type === 'global' ? null : params.adm0,
@@ -42,7 +45,10 @@ export const getDataAPI = params =>
       }));
     const extent = data.attributes.treeExtent;
 
-    const { startYear, endYear, range } = getYearsRange(loss);
+    const { startYear, endYear, range } = getYearsRangeFromMinMax(
+      MIN_YEAR,
+      MAX_YEAR
+    );
 
     return {
       loss,
@@ -163,17 +169,16 @@ export default {
             };
           }
 
-          const { startYear, endYear, range } = getYearsRange(data.loss);
-
+          const { startYear, endYear, range } = getYearsRangeFromMinMax(
+            MIN_YEAR,
+            MAX_YEAR
+          );
           return {
             ...data,
             settings: {
-              forestType:
-                params && params.adm0 && params.adm0 === 'IDN'
-                  ? 'primary_forest'
-                  : null,
               startYear,
-              endYear
+              endYear,
+              yearsRange: range
             },
             options: {
               years: range

--- a/app/javascript/components/widgets/forest-change/tree-loss/selectors.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss/selectors.js
@@ -34,6 +34,30 @@ const parseData = createSelector(
   }
 );
 
+const zeroFillData = createSelector(
+  [parseData, getSettings],
+  (data, settings) => {
+    if (!data || isEmpty(data)) return null;
+    const { startYear, endYear, yearsRange } = settings;
+    const zeroFilledData = [];
+    yearsRange
+      .filter(d => d.value >= startYear && d.value <= endYear)
+      .forEach(y => {
+        const year = y.value || null;
+        const yearData = data.find(o => o.year === year) || {
+          year,
+          area: 0,
+          biomassLoss: 0,
+          bound1: null,
+          emissions: 0,
+          percentage: 0
+        };
+        zeroFilledData.push(yearData);
+      });
+    return zeroFilledData;
+  }
+);
+
 const parseConfig = createSelector([getColors], colors => ({
   height: 250,
   xKey: 'year',
@@ -70,7 +94,7 @@ const parseConfig = createSelector([getColors], colors => ({
 
 const parseSentence = createSelector(
   [
-    parseData,
+    zeroFillData,
     getExtent,
     getSettings,
     getIsTropical,
@@ -121,7 +145,7 @@ const parseSentence = createSelector(
 );
 
 export default createStructuredSelector({
-  data: parseData,
+  data: zeroFillData,
   config: parseConfig,
   sentence: parseSentence
 });

--- a/app/javascript/components/widgets/forest-change/tree-loss/selectors.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss/selectors.js
@@ -3,7 +3,10 @@ import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import { format } from 'd3-format';
 import { formatNumber } from 'utils/format';
-import { yearTicksFormatter } from 'components/widgets/utils/data';
+import {
+  yearTicksFormatter,
+  zeroFillYears
+} from 'components/widgets/utils/data';
 
 // get list data
 const getLoss = state => state.data && state.data.loss;
@@ -39,22 +42,15 @@ const zeroFillData = createSelector(
   (data, settings) => {
     if (!data || isEmpty(data)) return null;
     const { startYear, endYear, yearsRange } = settings;
-    const zeroFilledData = [];
-    yearsRange
-      .filter(d => d.value >= startYear && d.value <= endYear)
-      .forEach(y => {
-        const year = y.value || null;
-        const yearData = data.find(o => o.year === year) || {
-          year,
-          area: 0,
-          biomassLoss: 0,
-          bound1: null,
-          emissions: 0,
-          percentage: 0
-        };
-        zeroFilledData.push(yearData);
-      });
-    return zeroFilledData;
+    const years = yearsRange.map(yearObj => yearObj.value);
+    const fillObj = {
+      area: 0,
+      biomassLoss: 0,
+      bound1: null,
+      emissions: 0,
+      percentage: 0
+    };
+    return zeroFillYears(data, startYear, endYear, years, fillObj);
   }
 );
 

--- a/app/javascript/components/widgets/utils/data.js
+++ b/app/javascript/components/widgets/utils/data.js
@@ -215,3 +215,12 @@ export const getYearsRangeFromMinMax = (yearMin, yearMax, interval) => ({
     value: y
   }))
 });
+
+export const zeroFillYears = (data, startYear, endYear, years, fillObj) => {
+  const zeroFilledData = [];
+  years.filter(year => year >= startYear && year <= endYear).forEach(year => {
+    const yearData = data.find(o => o.year === year) || { ...fillObj, year };
+    zeroFilledData.push(yearData);
+  });
+  return zeroFilledData;
+};

--- a/app/javascript/components/widgets/utils/data.js
+++ b/app/javascript/components/widgets/utils/data.js
@@ -206,3 +206,12 @@ export const getYearsRange = (data, interval) => {
     }))
   };
 };
+
+export const getYearsRangeFromMinMax = (yearMin, yearMax, interval) => ({
+  startYear: yearMin,
+  endYear: yearMax,
+  range: range(yearMin, yearMax + 1, interval || 1).map(y => ({
+    label: y,
+    value: y
+  }))
+});

--- a/app/javascript/components/widgets/utils/data.js
+++ b/app/javascript/components/widgets/utils/data.js
@@ -191,7 +191,7 @@ export const yearTicksFormatter = (tick, startYear, endYear) => {
   return `'${year.format('YY')}`;
 };
 
-export const getYearsRange = (data, interval) => {
+export const getYearsRangeFromData = (data, interval) => {
   const startYearObj = minBy(data, 'year');
   const endYearObj = maxBy(data, 'year');
   const startYear = startYearObj && startYearObj.year;


### PR DESCRIPTION
## Overview

Adds a `zeroFillYears` helper for use across all loss-table-using widgets. Also replaces `getYearsRange` helper with a pair of functions: `getYearsRangeFromData` and `getYearsRangeFromMinMax`.

## Todo

- [x] Add helpers
- [x] Implement helper in emissions widget
- [ ] ~~Implement helper in loss-by-driver widget~~ (to be removed)
- [x] Implement helper in primary loss widget
- [x] Implement helper in plantations loss widget