### PR TITLE
Fix/order tooltip by values using a sortBy tooltip config key.

### DIFF
--- a/app/javascript/components/charts/components/chart-tooltip/component.jsx
+++ b/app/javascript/components/charts/components/chart-tooltip/component.jsx
@@ -1,26 +1,66 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import sortBy from 'lodash/sortBy';
+import isEqual from 'lodash/isEqual';
 
 import './styles.scss';
 
 class ChartTooltip extends PureComponent {
-  render() {
-    const { payload, settings, hideZeros, simple } = this.props;
+  constructor(props) {
+    super(props);
+    this.state = { data: null };
+  }
+
+  componentDidUpdate(prevProps) {
+    const { payload, settings } = this.props;
     const values = payload && payload.length > 0 && payload[0].payload;
+    const prevValues =
+      prevProps.payload &&
+      prevProps.payload.length > 0 &&
+      prevProps.payload[0].payload;
+    if (settings && !isEqual(values, prevValues)) {
+      const data =
+        settings.length &&
+        settings.map(d => ({
+          ...d,
+          label: d.labelFormat
+            ? d.labelFormat(d.label || values[d.labelKey])
+            : d.label || values[d.labelKey],
+          value: d.unitFormat ? d.unitFormat(values[d.key]) : values[d.key],
+          valueNum: values[d.key]
+        }));
+
+      const sorting = settings.find(s => !!s.sortBy);
+      if (sorting && sorting.sortBy === 'value') {
+        const sortedData = sortBy(data, 'valueNum').reverse();
+
+        // Optional: empty 2020 value at the bottom.
+        const currentYearValue = values[new Date().getFullYear()];
+        if (!currentYearValue) {
+          const currentYearData = sortedData.findIndex(s => s.key === 'count');
+          sortedData.push(...sortedData.splice(currentYearData, 1));
+        }
+
+        // eslint-disable-next-line react/no-did-update-set-state
+        this.setState({ data: sortedData });
+      } else {
+        // eslint-disable-next-line react/no-did-update-set-state
+        this.setState({ data });
+      }
+    }
+  }
+
+  render() {
+    const { payload, hideZeros, simple } = this.props;
+    const values = payload && payload.length > 0 && payload[0].payload;
+
     return (
       <div>
-        {settings &&
-          settings.length && (
+        {this.state.data && (
           <div className={cx('c-chart-tooltip', { simple })}>
-            {settings.map(d => {
-              const label = d.labelFormat
-                ? d.labelFormat(d.label || values[d.labelKey])
-                : d.label || values[d.labelKey];
-
-              const value = d.unitFormat
-                ? d.unitFormat(values[d.key])
-                : values[d.key];
+            {this.state.data.map(d => {
+              const { label, value } = d;
 
               return hideZeros && (!values || !value) ? null : (
                 <div
@@ -30,17 +70,17 @@ class ChartTooltip extends PureComponent {
                   {label && (
                     <div className="data-label">
                       {d.color &&
-                          (d.dashline ? (
-                            <div
-                              className="data-color data-dash"
-                              style={{ borderColor: d.color }}
-                            />
-                          ) : (
-                            <div
-                              className="data-color"
-                              style={{ backgroundColor: d.color }}
-                            />
-                          ))}
+                        (d.dashline ? (
+                          <div
+                            className="data-color data-dash"
+                            style={{ borderColor: d.color }}
+                          />
+                        ) : (
+                          <div
+                            className="data-color"
+                            style={{ backgroundColor: d.color }}
+                          />
+                        ))}
                       {d.key === 'break' ? (
                         <span className="break-label">{d.label}</span>
                       ) : (

--- a/app/javascript/components/charts/components/chart-tooltip/component.jsx
+++ b/app/javascript/components/charts/components/chart-tooltip/component.jsx
@@ -1,66 +1,29 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import sortBy from 'lodash/sortBy';
-import isEqual from 'lodash/isEqual';
 
 import './styles.scss';
 
 class ChartTooltip extends PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = { data: null };
-  }
-
-  componentDidUpdate(prevProps) {
-    const { payload, settings } = this.props;
-    const values = payload && payload.length > 0 && payload[0].payload;
-    const prevValues =
-      prevProps.payload &&
-      prevProps.payload.length > 0 &&
-      prevProps.payload[0].payload;
-    if (settings && !isEqual(values, prevValues)) {
-      const data =
-        settings.length &&
-        settings.map(d => ({
-          ...d,
-          label: d.labelFormat
-            ? d.labelFormat(d.label || values[d.labelKey])
-            : d.label || values[d.labelKey],
-          value: d.unitFormat ? d.unitFormat(values[d.key]) : values[d.key],
-          valueNum: values[d.key]
-        }));
-
-      const sorting = settings.find(s => !!s.sortBy);
-      if (sorting && sorting.sortBy === 'value') {
-        const sortedData = sortBy(data, 'valueNum').reverse();
-
-        // Optional: empty 2020 value at the bottom.
-        const currentYearValue = values[new Date().getFullYear()];
-        if (!currentYearValue) {
-          const currentYearData = sortedData.findIndex(s => s.key === 'count');
-          sortedData.push(...sortedData.splice(currentYearData, 1));
-        }
-
-        // eslint-disable-next-line react/no-did-update-set-state
-        this.setState({ data: sortedData });
-      } else {
-        // eslint-disable-next-line react/no-did-update-set-state
-        this.setState({ data });
-      }
-    }
-  }
-
   render() {
-    const { payload, hideZeros, simple } = this.props;
+    const { payload, settings, parseData, hideZeros, simple } = this.props;
     const values = payload && payload.length > 0 && payload[0].payload;
+
+    const data = parseData ? parseData({ settings, values }) : settings;
 
     return (
       <div>
-        {this.state.data && (
+        {data &&
+          data.length && (
           <div className={cx('c-chart-tooltip', { simple })}>
-            {this.state.data.map(d => {
-              const { label, value } = d;
+            {data.map(d => {
+              const label = d.labelFormat
+                ? d.labelFormat(d.label || values[d.labelKey])
+                : d.label || values[d.labelKey];
+
+              const value = d.unitFormat
+                ? d.unitFormat(values[d.key])
+                : values[d.key];
 
               return hideZeros && (!values || !value) ? null : (
                 <div
@@ -70,17 +33,17 @@ class ChartTooltip extends PureComponent {
                   {label && (
                     <div className="data-label">
                       {d.color &&
-                        (d.dashline ? (
-                          <div
-                            className="data-color data-dash"
-                            style={{ borderColor: d.color }}
-                          />
-                        ) : (
-                          <div
-                            className="data-color"
-                            style={{ backgroundColor: d.color }}
-                          />
-                        ))}
+                          (d.dashline ? (
+                            <div
+                              className="data-color data-dash"
+                              style={{ borderColor: d.color }}
+                            />
+                          ) : (
+                            <div
+                              className="data-color"
+                              style={{ backgroundColor: d.color }}
+                            />
+                          ))}
                       {d.key === 'break' ? (
                         <span className="break-label">{d.label}</span>
                       ) : (
@@ -106,6 +69,7 @@ class ChartTooltip extends PureComponent {
 ChartTooltip.propTypes = {
   payload: PropTypes.array,
   settings: PropTypes.array,
+  parseData: PropTypes.func,
   hideZeros: PropTypes.bool,
   simple: PropTypes.bool
 };

--- a/app/javascript/components/charts/composed-chart/component.jsx
+++ b/app/javascript/components/charts/composed-chart/component.jsx
@@ -75,6 +75,7 @@ class CustomComposedChart extends PureComponent {
       rightYAxis,
       gradients,
       tooltip,
+      tooltipParseData,
       unit,
       unitFormat,
       height,
@@ -222,7 +223,9 @@ class CustomComposedChart extends PureComponent {
                     ((isVertical ? 45 : 100) / data.length)}%`
                 })
               }}
-              content={<ChartToolTip settings={tooltip} />}
+              content={
+                <ChartToolTip settings={tooltip} parseData={tooltipParseData} />
+              }
             />
             {bars &&
               Object.keys(bars).map(key => (

--- a/app/javascript/components/widgets/fires/fires-alerts-cumulative/selectors.js
+++ b/app/javascript/components/widgets/fires/fires-alerts-cumulative/selectors.js
@@ -236,9 +236,6 @@ export const parseConfig = createSelector(
 
     const tooltip = [
       {
-        label: 'Fire alerts'
-      },
-      {
         key: 'count',
         labelKey: 'date',
         labelFormat: value => moment(value).format('YYYY-MM-DD'),
@@ -303,7 +300,19 @@ export const parseConfig = createSelector(
         })
       },
       legend,
-      tooltip: [...tooltip, { sortBy: 'value' }],
+      tooltip: [...tooltip],
+      tooltipParseData: ({ settings, values }) => {
+        const sorted =
+          settings &&
+          values &&
+          settings.sort((a, b) => values[a.key] - values[b.key]).reverse();
+        return [
+          {
+            label: 'Fire alerts'
+          },
+          ...sorted
+        ];
+      },
       referenceLine: {
         x: presentDay,
         stroke: '#CCC',

--- a/app/javascript/components/widgets/fires/fires-alerts-cumulative/selectors.js
+++ b/app/javascript/components/widgets/fires/fires-alerts-cumulative/selectors.js
@@ -303,7 +303,7 @@ export const parseConfig = createSelector(
         })
       },
       legend,
-      tooltip,
+      tooltip: [...tooltip, { sortBy: 'value' }],
       referenceLine: {
         x: presentDay,
         stroke: '#CCC',


### PR DESCRIPTION
## Overview

Fixes issue num. 7 in the Cumulative Fires Widget: "Order tooltip by fire count, not chronologically".

I propose adding a sortBy=value key in the tooltip config of the widget, that is evaluated in the chart tooltip. The data is re-sorted every time the `payload` prop changes, as it needs to reevaluate the order.