### PR TITLE
Added chart legend to lollipop widget

### DIFF
--- a/app/javascript/components/charts/lollipop-chart/component.jsx
+++ b/app/javascript/components/charts/lollipop-chart/component.jsx
@@ -6,6 +6,7 @@ import cx from 'classnames';
 
 import { formatNumber } from 'utils/format';
 import { SCREEN_M } from 'utils/constants';
+import Legend from 'components/charts/components/chart-legend';
 
 import './styles.scss';
 
@@ -16,10 +17,13 @@ class LollipopChart extends PureComponent {
       data,
       settings,
       settingsConfig,
+      config,
       linksDisabled,
-      linksExt
+      linksExt,
+      simple
     } = this.props;
     const { unit } = settings;
+    const { legend } = config || {};
 
     const unitsConfig = settingsConfig.find(conf => conf.key === 'unit');
     const selectedUnitConfig =
@@ -56,6 +60,7 @@ class LollipopChart extends PureComponent {
       <MediaQuery minWidth={SCREEN_M}>
         {isDesktop => (
           <div className={cx('c-lollipop-chart', className)}>
+            {!simple && legend && <Legend config={legend} simple={simple} />}
             <div className="unit-legend">{`${unit
               .charAt(0)
               .toUpperCase()}${unit.slice(1)} (${formatUnit})`}</div>
@@ -210,7 +215,7 @@ class LollipopChart extends PureComponent {
                   })}
               </ul>
             </div>
-            {isDesktop &&
+            {isDesktop && (
               <div
                 className="cartesian-grid"
                 style={{
@@ -251,7 +256,7 @@ class LollipopChart extends PureComponent {
                   />
                 ))}
               </div>
-            }
+            )}
           </div>
         )}
       </MediaQuery>
@@ -263,9 +268,11 @@ LollipopChart.propTypes = {
   data: PropTypes.array.isRequired,
   settings: PropTypes.object.isRequired,
   settingsConfig: PropTypes.array,
+  config: PropTypes.object,
   className: PropTypes.string,
   linksDisabled: PropTypes.bool,
-  linksExt: PropTypes.bool
+  linksExt: PropTypes.bool,
+  simple: PropTypes.bool
 };
 
 export default LollipopChart;

--- a/app/javascript/components/widget/components/widget-lollipop/component.jsx
+++ b/app/javascript/components/widget/components/widget-lollipop/component.jsx
@@ -11,6 +11,7 @@ class WidgetLollipop extends PureComponent {
       data,
       settings,
       settingsConfig,
+      config,
       handleChangeSettings,
       embed
     } = this.props;
@@ -19,6 +20,7 @@ class WidgetLollipop extends PureComponent {
       <Lollipop
         className="c-widget-lollipop-chart"
         data={data}
+        config={config}
         settings={{
           ...settings,
           format: settings.unit === '%' ? '.2r' : '.3s'
@@ -37,6 +39,7 @@ WidgetLollipop.propTypes = {
   data: PropTypes.array,
   settings: PropTypes.object.isRequired,
   settingsConfig: PropTypes.array,
+  config: PropTypes.object,
   handleChangeSettings: PropTypes.func.isRequired,
   embed: PropTypes.bool
 };

--- a/app/javascript/components/widgets/fires/fires-ranked/index.js
+++ b/app/javascript/components/widgets/fires/fires-ranked/index.js
@@ -67,30 +67,34 @@ export default {
   },
   whitelistType: 'fires',
   sentences: {
-    initial:
-      'In the last {timeframe} in {location}, the region with the most <b>significant</b> number of fire alerts was {topRegion}, with {topRegionCount} fire alerts.  This represents {topRegionPerc} of all alerts detected in {location} and is {status} compared to the number of fires in the same period going back to <b>2012</b>.',
-    withInd:
-      'In the last {timeframe} in {location}, the region with the most <b>significant</b> number of fire alerts within {indicator} was {topRegion}, with {topRegionCount} fire alerts.  This represents {topRegionPerc} of all alerts detected in {location} and is {status} compared to the number of fires in the same period going back to <b>2012</b>.',
-    densityInitial:
-      'In the last {timeframe} in {location}, the region with the <b>highest density</b> of fires was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of all alerts detected in {location} in the same period.',
-    densityWithInd:
-      'In the last {timeframe} in {location}, the region with the <b>highest density</b> of fires within {indicator} was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of all alerts detected in {location} in the same period.',
-    countsInitial:
-      'In the last {timeframe} in {location}, the region with the <b>most</b> fire alerts was {topRegion}, with {topRegionCount} fire alerts. This represents {topRegionPerc} of all alerts detected in {location} in the same period.',
-    countsWithInd:
-      'In the last {timeframe} in {location}, the region with the <b>most</b> fire alerts within {indicator} was {topRegion}, with {topRegionCount} fire alerts. This represents {topRegionPerc} of all alerts detected in {location} in the same period.',
-    initialGlobal:
-      'In the last {timeframe}, the region with the most <b>significant</b> number of fire alerts <b>globally</b> was {topRegion}, with {topRegionCount} fire alerts.  This represents {topRegionPerc} of all alerts detected in {location} and is {status} compared to the number of fires in the same period going back to <b>2012</b>.',
-    withIndGlobal:
-      'In the last {timeframe}, the region with the most <b>significant</b> number of fire alerts within {indicator} <b>globally</b> was {topRegion}, with {topRegionCount} fire alerts.  This represents {topRegionPerc} of all alerts detected <b>globally</b> and is {status} compared to the number of fires in the same period going back to <b>2012</b>.',
-    densityInitialGlobal:
-      'In the last {timeframe}, the region with the <b>highest density</b> of fires <b>globally</b> was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of all alerts detected <b>globally</b> in the same period.',
-    densityWithIndGlobal:
-      'In the last {timeframe}, the region with the <b>highest density</b> of fires within {indicator} <b>globally</b> was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of all alerts detected <b>globally</b> in the same period.',
-    countsInitialGlobal:
-      'In the last {timeframe}, the region with the <b>most</b> fire alerts <b>globally</b> was {topRegion}, with {topRegionCount} fire alerts. This represents {topRegionPerc} of all alerts detected <b>globally</b> in the same period.',
-    countsWithIndGlobal:
-      'In the last {timeframe}, the region with the <b>most</b> fire alerts within {indicator} <b>globally</b> was {topRegion}, with {topRegionCount} fire alerts. This represents {topRegionPerc} of all alerts detected <b>globally</b> in the same periodd.'
+    initial: `In the last {timeframe} in {location}, the region with the most <b>significant</b> number of fire alerts was {topRegion}, with
+      {topRegionCount} fire alerts.  This represents {topRegionPerc} of all alerts detected in {location} and is {status} compared to the
+      number of fires in the same period going back to <b>2012</b>.`,
+    withInd: `In the last {timeframe} in {location}, the region with the most <b>significant</b> number of fire alerts within {indicator} was
+      {topRegion}, with {topRegionCount} fire alerts.  This represents {topRegionPerc} of all alerts detected in {location} and is {status}
+      compared to the number of fires in the same period going back to <b>2012</b>.`,
+    densityInitial: `In the last {timeframe} in {location}, the region with the <b>highest density</b> of fires was {topRegion}, with {topRegionDensity}.
+      This represents {topRegionPerc} of all alerts detected in {location} in the same period.`,
+    densityWithInd: `In the last {timeframe} in {location}, the region with the <b>highest density</b> of fires within {indicator} was {topRegion}, with
+      {topRegionDensity}. This represents {topRegionPerc} of all alerts detected in {location} in the same period.`,
+    countsInitial: `In the last {timeframe} in {location}, the region with the <b>most</b> fire alerts was {topRegion}, with {topRegionCount} fire
+      alerts. This represents {topRegionPerc} of all alerts detected in {location} in the same period.`,
+    countsWithInd: `In the last {timeframe} in {location}, the region with the <b>most</b> fire alerts within {indicator} was {topRegion}, with
+      {topRegionCount} fire alerts. This represents {topRegionPerc} of all alerts detected in {location} in the same period.`,
+    initialGlobal: `In the last {timeframe}, the region with the most <b>significant</b> number of fire alerts <b>globally</b> was {topRegion}, with
+      {topRegionCount} fire alerts.  This represents {topRegionPerc} of all alerts detected in {location} and is {status} compared to the
+      number of fires in the same period going back to <b>2012</b>.`,
+    withIndGlobal: `In the last {timeframe}, the region with the most <b>significant</b> number of fire alerts within {indicator} <b>globally</b> was
+      {topRegion}, with {topRegionCount} fire alerts.  This represents {topRegionPerc} of all alerts detected <b>globally</b> and is
+      {status} compared to the number of fires in the same period going back to <b>2012</b>.`,
+    densityInitialGlobal: `In the last {timeframe}, the region with the <b>highest density</b> of fires <b>globally</b> was {topRegion}, with
+      {topRegionDensity}. This represents {topRegionPerc} of all alerts detected <b>globally</b> in the same period.`,
+    densityWithIndGlobal: `In the last {timeframe}, the region with the <b>highest density</b> of fires within {indicator} <b>globally</b> was {topRegion}, with
+      {topRegionDensity}. This represents {topRegionPerc} of all alerts detected <b>globally</b> in the same period.`,
+    countsInitialGlobal: `In the last {timeframe}, the region with the <b>most</b> fire alerts <b>globally</b> was {topRegion}, with {topRegionCount} fire
+      alerts. This represents {topRegionPerc} of all alerts detected <b>globally</b> in the same period.`,
+    countsWithIndGlobal: `In the last {timeframe}, the region with the <b>most</b> fire alerts within {indicator} <b>globally</b> was {topRegion}, with
+      {topRegionCount} fire alerts. This represents {topRegionPerc} of all alerts detected <b>globally</b> in the same periodd.`
   },
   settings: {
     unit: 'significance',
@@ -132,7 +136,9 @@ export default {
       }),
   getDataURL: async params => {
     const latestResponse = await fetchVIIRSLatest(params);
-    const latest = (latestResponse.attributes && latestResponse.attributes.updatedAt) || null;
+    const latest =
+      (latestResponse.attributes && latestResponse.attributes.updatedAt) ||
+      null;
 
     return [
       fetchVIIRSAlertsGrouped({ ...params, latest, download: true }),

--- a/app/javascript/components/widgets/fires/fires-ranked/selectors.js
+++ b/app/javascript/components/widgets/fires/fires-ranked/selectors.js
@@ -224,6 +224,35 @@ export const parseSentence = createSelector(
   }
 );
 
+export const parseConfig = createSelector([getColors], colors => {
+  const colorRange = colors.ramp;
+
+  return {
+    legend: {
+      uhigh: {
+        label: 'Unusually high',
+        color: colorRange[0]
+      },
+      high: {
+        label: 'High',
+        color: colorRange[2]
+      },
+      average: {
+        label: 'Average',
+        color: colorRange[4]
+      },
+      low: {
+        label: 'Low',
+        color: colorRange[6]
+      },
+      ulow: {
+        label: 'Unusually low',
+        color: colorRange[8]
+      }
+    }
+  };
+});
+
 export const parseTitle = createSelector(
   [getTitle, getLocationName],
   (title, name) => {
@@ -237,6 +266,7 @@ export const parseTitle = createSelector(
 
 export default createStructuredSelector({
   data: parseData,
+  config: parseConfig,
   sentence: parseSentence,
   title: parseTitle
 });


### PR DESCRIPTION
## Overview

Solves issue num. 8 of the Fire ranking widget (feedback doc): adding a legend to explain what the colours correspond to. Uses the chart legend component to draw a legend on top of the lollipop chart, as it's shown on the designs.


![image](https://user-images.githubusercontent.com/7013170/84025649-45d00e00-a98c-11ea-829f-e62e3e955df9.png)
