### PR TITLE
Add uppercase key to land categories

### DIFF
--- a/app/javascript/components/widgets/forest-change/glad-alerts/index.js
+++ b/app/javascript/components/widgets/forest-change/glad-alerts/index.js
@@ -34,7 +34,7 @@ export default {
   colors: 'loss',
   chartType: 'composedChart',
   source: 'gadm',
-  dataType: 'loss',
+  dataType: 'glad',
   categories: ['summary', 'forest-change'],
   types: ['country', 'geostore', 'wdpa', 'use'],
   admins: ['adm0', 'adm1', 'adm2'],

--- a/app/javascript/components/widgets/utils/config.js
+++ b/app/javascript/components/widgets/utils/config.js
@@ -141,12 +141,18 @@ export const getIndicator = (forestType, landCategory) => {
   if (!forestType && !landCategory) return null;
   let label = '';
   let value = '';
-  const forestTypeLabel = landCategory.upperCase
-    ? landCategory.label
-    : landCategory.label.toLowerCase();
-  const landCatLabel = forestType.upperCase
-    ? forestType.label
-    : forestType.label.toLowerCase();
+  let forestTypeLabel = (forestType && forestType.label) || '';
+  let landCatLabel = (landCategory && landCategory.label) || '';
+
+  forestTypeLabel =
+    forestType && forestType.preserveString === true
+      ? forestTypeLabel
+      : forestTypeLabel.toLowerCase();
+  landCatLabel =
+    landCategory && landCategory.preserveString === true
+      ? landCatLabel
+      : landCatLabel.toLowerCase();
+
   if (forestType && landCategory) {
     label = `${forestTypeLabel} in ${landCatLabel}`;
     value = `${forestType.value}__${landCategory.value}`;

--- a/app/javascript/components/widgets/utils/config.js
+++ b/app/javascript/components/widgets/utils/config.js
@@ -141,18 +141,21 @@ export const getIndicator = (forestType, landCategory) => {
   if (!forestType && !landCategory) return null;
   let label = '';
   let value = '';
+  const forestTypeLabel = landCategory.upperCase
+    ? landCategory.label
+    : landCategory.label.toLowerCase();
+  const landCatLabel = forestType.upperCase
+    ? forestType.label
+    : forestType.label.toLowerCase();
   if (forestType && landCategory) {
-    label = `${forestType.label} in ${landCategory.label}`;
+    label = `${forestTypeLabel} in ${landCatLabel}`;
     value = `${forestType.value}__${landCategory.value}`;
   } else if (landCategory) {
-    label = landCategory.label;
+    label = landCatLabel;
     value = landCategory.value;
   } else {
-    label = forestType.label;
+    label = forestTypeLabel;
     value = forestType.value;
-  }
-  if (value !== 'kba' && value !== 'idn_forest_moratorium') {
-    label = label.toLowerCase();
   }
 
   return {
@@ -316,7 +319,9 @@ export const getStatements = ({
     threshold || threshold === 0
       ? translateText('>{threshold}% tree canopy', { threshold })
       : null,
-    dataType === 'fires' && active && '*when on the map you can show up to 3 months of fires data',
+    dataType === 'fires' &&
+      active &&
+      '*when on the map you can show up to 3 months of fires data',
     dataType === 'loss'
       ? translateText(
         'these estimates do not take tree cover gain into account'

--- a/app/javascript/data/land-categories.js
+++ b/app/javascript/data/land-categories.js
@@ -53,7 +53,7 @@ export default [
   },
   {
     label: 'Key Biodiversity Areas',
-    upperCase: true,
+    preserveString: true,
     value: 'kba',
     metaKey: 'key_biodiversity_areas',
     tableKey: 'is__birdlife_alliance_for_zero_extinction_site',
@@ -100,7 +100,7 @@ export default [
   },
   {
     label: 'Indonesia peat lands',
-    upperCase: true,
+    preserveString: true,
     value: 'idn_mys_peatlands',
     metaKey: 'idn_peat_lands',
     tableKey: 'is__peatland',
@@ -115,7 +115,7 @@ export default [
   },
   {
     label: 'Indonesia forest moratorium areas',
-    upperCase: true,
+    preserveString: true,
     value: 'idn_forest_moratorium',
     metaKey: 'idn_forest_moratorium',
     tableKey: 'is__idn_forest_moratorium',

--- a/app/javascript/data/land-categories.js
+++ b/app/javascript/data/land-categories.js
@@ -53,6 +53,7 @@ export default [
   },
   {
     label: 'Key Biodiversity Areas',
+    upperCase: true,
     value: 'kba',
     metaKey: 'key_biodiversity_areas',
     tableKey: 'is__birdlife_alliance_for_zero_extinction_site',
@@ -99,6 +100,7 @@ export default [
   },
   {
     label: 'Indonesia peat lands',
+    upperCase: true,
     value: 'idn_mys_peatlands',
     metaKey: 'idn_peat_lands',
     tableKey: 'is__peatland',
@@ -112,7 +114,8 @@ export default [
     hidden: true
   },
   {
-    label: 'Indonesia forest moratorium',
+    label: 'Indonesia forest moratorium areas',
+    upperCase: true,
     value: 'idn_forest_moratorium',
     metaKey: 'idn_forest_moratorium',
     tableKey: 'is__idn_forest_moratorium',

--- a/app/javascript/utils/format.js
+++ b/app/javascript/utils/format.js
@@ -134,12 +134,18 @@ export const getIndicator = (activeForestType, activeLandCategory, ifl) => {
   if (!forestType && !landCategory) return null;
   let label = '';
   let value = '';
-  const forestTypeLabel = landCategory.upperCase
-    ? landCategory.label
-    : landCategory.label.toLowerCase();
-  const landCatLabel = forestType.upperCase
-    ? forestType.label
-    : forestType.label.toLowerCase();
+  let forestTypeLabel = (forestType && forestType.label) || '';
+  let landCatLabel = (landCategory && landCategory.label) || '';
+
+  forestTypeLabel =
+    forestType && forestType.preserveString === true
+      ? forestTypeLabel
+      : forestTypeLabel.toLowerCase();
+  landCatLabel =
+    landCategory && landCategory.preserveString === true
+      ? landCatLabel
+      : landCatLabel.toLowerCase();
+
   if (forestType && landCategory) {
     label = `${forestTypeLabel} in ${landCatLabel}`;
     value = `${forestType.value}__${landCategory.value}`;

--- a/app/javascript/utils/format.js
+++ b/app/javascript/utils/format.js
@@ -134,18 +134,21 @@ export const getIndicator = (activeForestType, activeLandCategory, ifl) => {
   if (!forestType && !landCategory) return null;
   let label = '';
   let value = '';
+  const forestTypeLabel = landCategory.upperCase
+    ? landCategory.label
+    : landCategory.label.toLowerCase();
+  const landCatLabel = forestType.upperCase
+    ? forestType.label
+    : forestType.label.toLowerCase();
   if (forestType && landCategory) {
-    label = `${forestType.label} in ${landCategory.label}`;
+    label = `${forestTypeLabel} in ${landCatLabel}`;
     value = `${forestType.value}__${landCategory.value}`;
   } else if (landCategory) {
-    label = landCategory.label;
+    label = landCatLabel;
     value = landCategory.value;
   } else {
-    label = forestType.label;
+    label = forestTypeLabel;
     value = forestType.value;
-  }
-  if (value !== 'kba') {
-    label = label.toLowerCase();
   }
 
   return {


### PR DESCRIPTION
## Overview

Adds a general case check for all indicators.

If `upperCase =True` in the forestType or landCategory, then dynamic sentence preserves the original string (no lower casing).

Also, adds `dataType='glad'` in order to remove gain discalimer from the widget.