### PR TITLE
Fixed lollipop ticks on compact view, turned all ranked list widgets into lollipops

### DIFF
--- a/app/javascript/components/charts/lollipop-chart/component.jsx
+++ b/app/javascript/components/charts/lollipop-chart/component.jsx
@@ -3,6 +3,7 @@ import MediaQuery from 'react-responsive';
 import Link from 'redux-first-router-link';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import { format } from 'd3-format';
 
 import { formatNumber } from 'utils/format';
 import { SCREEN_M } from 'utils/constants';
@@ -20,7 +21,8 @@ class LollipopChart extends PureComponent {
       config,
       linksDisabled,
       linksExt,
-      simple
+      simple,
+      large
     } = this.props;
     const { unit } = settings;
     const { legend } = config || {};
@@ -47,9 +49,16 @@ class LollipopChart extends PureComponent {
     const interpolate = num =>
       Math.abs(num) * 100 / (dataMax + Math.abs(dataMin) || 1);
 
-    let ticks = [dataMin, dataMin / 2, 0, dataMax / 2, dataMax];
-    if (dataMin === 0) ticks = [0, dataMax * 0.33, dataMax * 0.66, dataMax];
-    if (dataMax === 0) ticks = [dataMin, dataMin * 0.66, dataMin * 0.33, 0];
+    let ticks;
+    if (large) {
+      if (dataMin === 0) ticks = [0, dataMax * 0.33, dataMax * 0.66, dataMax];
+      if (dataMax === 0) ticks = [dataMin, dataMin * 0.66, dataMin * 0.33, 0];
+      else ticks = [dataMin, dataMin / 2, 0, dataMax / 2, dataMax];
+    } else {
+      if (dataMin === 0) ticks = [0, dataMax / 2, dataMax];
+      if (dataMax === 0) ticks = [dataMin, dataMin / 2, 0];
+      else ticks = [dataMin, 0, dataMax];
+    }
 
     const allNegative = !data.some(item => item.value > 0);
     const allPositive = !data.some(item => item.value < 0);
@@ -94,7 +103,7 @@ class LollipopChart extends PureComponent {
                               `calc(${interpolate(tick - dataMin)}% - 8px)`
                       }}
                     >
-                      {Math.round(tick)}
+                      {tick > 999 ? format('.2s')(tick) : Math.round(tick)}
                     </div>
                   ))}
                 </div>
@@ -272,7 +281,8 @@ LollipopChart.propTypes = {
   className: PropTypes.string,
   linksDisabled: PropTypes.bool,
   linksExt: PropTypes.bool,
-  simple: PropTypes.bool
+  simple: PropTypes.bool,
+  large: PropTypes.bool
 };
 
 export default LollipopChart;

--- a/app/javascript/components/widget/component.jsx
+++ b/app/javascript/components/widget/component.jsx
@@ -152,6 +152,7 @@ class Widget extends PureComponent {
         />
         <WidgetBody
           chartType={chartType}
+          large={large}
           loading={loading}
           metaLoading={metaLoading}
           error={error}

--- a/app/javascript/components/widget/components/widget-lollipop/component.jsx
+++ b/app/javascript/components/widget/components/widget-lollipop/component.jsx
@@ -13,7 +13,8 @@ class WidgetLollipop extends PureComponent {
       settingsConfig,
       config,
       handleChangeSettings,
-      embed
+      embed,
+      large
     } = this.props;
 
     return (
@@ -30,6 +31,7 @@ class WidgetLollipop extends PureComponent {
           handleChangeSettings({ page: settings.page + change })
         }
         linksExt={embed}
+        large={large}
       />
     );
   }
@@ -41,7 +43,8 @@ WidgetLollipop.propTypes = {
   settingsConfig: PropTypes.array,
   config: PropTypes.object,
   handleChangeSettings: PropTypes.func.isRequired,
-  embed: PropTypes.bool
+  embed: PropTypes.bool,
+  large: PropTypes.bool
 };
 
 export default WidgetLollipop;

--- a/app/javascript/components/widgets/biodiversity/glad-biodiversity/index.js
+++ b/app/javascript/components/widgets/biodiversity/glad-biodiversity/index.js
@@ -20,7 +20,7 @@ export default {
     period: 'week',
     weeks: 13
   },
-  chartType: 'rankedList',
+  chartType: 'lollipop',
   datasets: [
     {
       dataset: POLITICAL_BOUNDARIES_DATASET,

--- a/app/javascript/components/widgets/climate/soil-organic/index.js
+++ b/app/javascript/components/widgets/climate/soil-organic/index.js
@@ -42,7 +42,7 @@ export default {
     }
   ],
   refetchKeys: ['variable'],
-  chartType: 'rankedList',
+  chartType: 'lollipop',
   visible: ['dashboard', 'analysis'],
   colors: 'climate',
   metaKey: 'soil_organic_carbon',

--- a/app/javascript/components/widgets/climate/whrc-biomass/index.js
+++ b/app/javascript/components/widgets/climate/whrc-biomass/index.js
@@ -37,7 +37,7 @@ export default {
     }
   ],
   refetchKeys: ['variable', 'threshold'],
-  chartType: 'rankedList',
+  chartType: 'lollipop',
   datasets: [
     {
       dataset: POLITICAL_BOUNDARIES_DATASET,

--- a/app/javascript/components/widgets/forest-change/fao-deforest/index.js
+++ b/app/javascript/components/widgets/forest-change/fao-deforest/index.js
@@ -20,7 +20,7 @@ export default {
       type: 'select'
     }
   ],
-  chartType: 'rankedList',
+  chartType: 'lollipop',
   dataType: 'fao',
   colors: 'loss',
   metaKey: 'widget_deforestation_fao',

--- a/app/javascript/components/widgets/forest-change/fao-reforest/index.js
+++ b/app/javascript/components/widgets/forest-change/fao-reforest/index.js
@@ -18,7 +18,7 @@ export default {
       type: 'select'
     }
   ],
-  chartType: 'rankedList',
+  chartType: 'lollipop',
   dataType: 'fao',
   metaKey: 'widget_rate_of_restoration_fao',
   sortOrder: {

--- a/app/javascript/components/widgets/forest-change/fires-ranked/index.js
+++ b/app/javascript/components/widgets/forest-change/fires-ranked/index.js
@@ -18,7 +18,7 @@ export default {
       noSort: true
     }
   ],
-  chartType: 'rankedList',
+  chartType: 'lollipop',
   metaKey: 'widget_fire_ranking',
   colors: 'fires',
   sortOrder: {

--- a/app/javascript/components/widgets/forest-change/glad-ranked/index.js
+++ b/app/javascript/components/widgets/forest-change/glad-ranked/index.js
@@ -65,7 +65,7 @@ export default {
   ],
   pendingKeys: ['extentYear', 'threshold'],
   refetchKeys: ['forestType', 'landCategory', 'extentYear', 'threshold'],
-  chartType: 'rankedList',
+  chartType: 'lollipop',
   metaKey: 'widget_deforestation_alert_location',
   colors: 'loss',
   datasets: [

--- a/app/javascript/components/widgets/forest-change/tree-cover-gain/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-cover-gain/index.js
@@ -47,7 +47,7 @@ export default {
     }
   ],
   refetchKeys: ['forestType', 'landCategory', 'threshold'],
-  chartType: 'rankedList',
+  chartType: 'lollipop',
   colors: 'gain',
   metaKey: 'widget_tree_cover_gain',
   datasets: [

--- a/app/javascript/components/widgets/forest-change/tree-gain-located/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-gain-located/index.js
@@ -38,7 +38,7 @@ export default {
     }
   ],
   refetchKeys: ['forestType', 'landCategory'],
-  chartType: 'rankedList',
+  chartType: 'lollipop',
   colors: 'gain',
   datasets: [
     {

--- a/app/javascript/components/widgets/forest-change/tree-loss-located/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss-located/index.js
@@ -67,7 +67,7 @@ export default {
       metaKey: 'widget_canopy_density'
     }
   ],
-  chartType: 'rankedList',
+  chartType: 'lollipop',
   colors: 'loss',
   layers: ['loss'],
   refetchKeys: ['forestType', 'landCategory', 'extentYear', 'threshold'],

--- a/app/javascript/components/widgets/forest-change/tree-loss-ranked/index.js
+++ b/app/javascript/components/widgets/forest-change/tree-loss-ranked/index.js
@@ -67,7 +67,7 @@ export default {
       metaKey: 'widget_canopy_density'
     }
   ],
-  chartType: 'rankedList',
+  chartType: 'lollipop',
   colors: 'loss',
   dataType: 'loss',
   metaKey: 'widget_tree_cover_loss_ranking',

--- a/app/javascript/components/widgets/land-cover/tree-cover-located/index.js
+++ b/app/javascript/components/widgets/land-cover/tree-cover-located/index.js
@@ -58,7 +58,7 @@ export default {
     }
   ],
   refetchKeys: ['extentYear', 'forestType', 'landCategory', 'threshold'],
-  chartType: 'rankedList',
+  chartType: 'lollipop',
   colors: 'extent',
   metaKey: 'widget_forest_location',
   datasets: [

--- a/app/javascript/components/widgets/land-cover/tree-cover-ranked/index.js
+++ b/app/javascript/components/widgets/land-cover/tree-cover-ranked/index.js
@@ -21,7 +21,7 @@ export default {
   admins: ['adm0'],
   colors: 'extent',
   dataType: 'extent',
-  chartType: 'rankedList',
+  chartType: 'lollipop',
   metaKey: 'widget_forest_cover_ranking',
   settingsConfig: [
     {


### PR DESCRIPTION
## Overview

~~Look, Morty, i turned myself into a lollipop!~~

All ranked list widgets are now lollipops. To avoid the number on the ticks overlapping on compact view, I halved the number of ticks when `large=false` and formatted the numbers.