### PR TITLE
Added days to the xAxis ticks on the firesAlertsHistorical widget.

### DIFF
--- a/app/javascript/components/widgets/fires/fires-alerts-historical/selectors.js
+++ b/app/javascript/components/widgets/fires/fires-alerts-historical/selectors.js
@@ -113,7 +113,7 @@ export const parseConfig = createSelector(
       ...getChartConfig(colors),
       tooltip,
       xAxis: {
-        tickFormatter: t => moment(t).format('MMM YY')
+        tickFormatter: t => moment(t).format('MMM DD, YY')
       },
       brush: {
         width: '100%',


### PR DESCRIPTION
## Overview

![image](https://user-images.githubusercontent.com/7013170/84516030-84880000-accd-11ea-8023-24a54c515bd7.png)

This removes duplicated ticks on the xAxis as previously there were several ticks with the same month and year (daily resolution).