### PR TITLE
Feature/add monthly summary field back to areas form

### DIFF
--- a/app/javascript/components/forms/area-of-interest/component.jsx
+++ b/app/javascript/components/forms/area-of-interest/component.jsx
@@ -253,11 +253,11 @@ class AreaOfInterestForm extends PureComponent {
                         {
                           label: 'As soon as forest change is detected',
                           value: 'deforestationAlerts'
+                        },
+                        {
+                          label: 'Monthly summary',
+                          value: 'monthlySummary'
                         }
-                        // {
-                        //   label: 'Monthly summary',
-                        //   value: 'monthlySummary'
-                        // }
                       ]}
                     />
                     <Select


### PR DESCRIPTION
Areas form now contains a check box to allow users to select receiving monthly summart emails.