### PR TITLE
Update tooltips for consitent date formatting

### DIFF
--- a/app/javascript/components/widgets/fires/fires-alerts-cumulative/selectors.js
+++ b/app/javascript/components/widgets/fires/fires-alerts-cumulative/selectors.js
@@ -21,7 +21,10 @@ const getAlerts = state => state.data && state.data.alerts;
 const getLatest = state => state.data && state.data.latest;
 const getColors = state => state.colors || null;
 const getCompareYear = state => state.settings.compareYear || null;
-const getAllYears = state => state.data && state.data.options && state.data.options.compareYear.map(y => y.value);
+const getAllYears = state =>
+  state.data &&
+  state.data.options &&
+  state.data.options.compareYear.map(y => y.value);
 const getDataset = state => state.settings.dataset || null;
 const getStartIndex = state => state.settings.startIndex || 0;
 const getEndIndex = state => state.settings.endIndex || null;
@@ -275,7 +278,7 @@ export const parseConfig = createSelector(
             const yearDifference = maxminYear.max - date.year();
             date.set('year', year - yearDifference);
 
-            return date.format('YYYY-MM-DD');
+            return date.format('MMM DD YYYY');
           },
           unit: ` ${dataset.toUpperCase()} alerts`,
           color: compareYears.length === 1 ? colors.compareYear : colorRange[i],

--- a/app/javascript/components/widgets/fires/fires-alerts/selectors.js
+++ b/app/javascript/components/widgets/fires/fires-alerts/selectors.js
@@ -232,15 +232,7 @@ export const parseConfig = createSelector(
     getDataset,
     getStartEndIndexes
   ],
-  (
-    legend,
-    colors,
-    latest,
-    maxminYear,
-    compareYear,
-    dataset,
-    indexes
-  ) => {
+  (legend, colors, latest, maxminYear, compareYear, dataset, indexes) => {
     const { startIndex, endIndex } = indexes;
 
     const tooltip = [
@@ -267,7 +259,7 @@ export const parseConfig = createSelector(
           const yearDifference = maxminYear.max - date.year();
           date.set('year', compareYear - yearDifference);
 
-          return date.format('YYYY-MM-DD');
+          return date.format('MMM DD YYYY');
         },
         unit: ` ${dataset.toUpperCase()} alerts`,
         color: '#49b5e3',


### PR DESCRIPTION
## Overview

Makes compare years tooltip dates consistent to the default year in both weekly fires widgets