### PR TITLE
Change year order to capture seasons across year

### DIFF
--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -3,6 +3,7 @@ import moment from 'moment';
 import { format } from 'd3-format';
 import isEmpty from 'lodash/isEmpty';
 import sortBy from 'lodash/sortBy';
+import orderBy from 'lodash/orderBy';
 import sumBy from 'lodash/sumBy';
 import groupBy from 'lodash/groupBy';
 import max from 'lodash/max';
@@ -388,9 +389,9 @@ export const parseSentence = createSelector(
     const halfMax = (maxMean - minMean) * 0.5;
 
     const peakWeeks = data.filter(d => d.mean > halfMax);
-    const sortedPeakWeeks = sortBy(peakWeeks, ['year', 'week']);
-
+    const sortedPeakWeeks = orderBy(peakWeeks, ['year', 'week'], ['desc', 'asc']);
     const seasonStartDate = sortedPeakWeeks.length && sortedPeakWeeks[0].date;
+    
     const seasonMonth = moment(seasonStartDate).format('MMMM');
     const seasonDay = parseInt(moment(seasonStartDate).format('D'), 10);
 


### PR DESCRIPTION
## Overview

Hotfix! The fire season statement can be incorrect if it wraps around a year. Now orders by descending years to always get the most recent.