### PR TITLE
feature/remove-one-click-analysis

### DIFF
--- a/components/analysis/components/chose-analysis/component.jsx
+++ b/components/analysis/components/chose-analysis/component.jsx
@@ -2,7 +2,6 @@ import React, { PureComponent, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Dropzone from 'react-dropzone';
 import cx from 'classnames';
-import { Media } from 'utils/responsive';
 import { track } from 'analytics';
 import { format } from 'd3-format';
 
@@ -51,10 +50,7 @@ class ChoseAnalysis extends PureComponent {
 
     return (
       <div className="layer-menu">
-        <div className="layer-title">
-          <Media greaterThanOrEqual="md">One click analysis on shape or:</Media>
-          <Media lessThan="md">Analysis on shape or:</Media>
-        </div>
+        <div className="layer-title">Analysis on shape or:</div>
         <Dropdown
           className="boundary-selector analysis-boundary-menu"
           options={boundaries}
@@ -63,9 +59,7 @@ class ChoseAnalysis extends PureComponent {
           native
         />
         <div className="layer-description">
-          <Media greaterThanOrEqual="md">One-click analysis </Media>
-          <Media lessThan="md">Analysis </Media>
-          is also available by default for most data layers under the
+          Analysis is also available by default for most data layers under the
           {' '}
           <button
             onClick={() =>
@@ -154,7 +148,7 @@ class ChoseAnalysis extends PureComponent {
           {!hasError && !uploading && (
             <Fragment>
               <p>
-                Drag and drop your
+                Drag and drop your 
                 {' '}
                 <b>polygon data file</b>
                 {' '}

--- a/layouts/map/component.jsx
+++ b/layouts/map/component.jsx
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Media } from 'utils/responsive';
-import { Tooltip } from 'react-tippy';
 
 import CountryDataProvider from 'providers/country-data-provider';
 import GeostoreProvider from 'providers/geostore-provider';
@@ -16,7 +15,6 @@ import Map from 'components/map';
 import ModalMeta from 'components/modals/meta';
 import ModalSource from 'components/modals/sources';
 import Share from 'components/modals/share';
-import Tip from 'components/ui/tip';
 import AreaOfInterestModal from 'components/modals/area-of-interest';
 import MapPrompts from 'components/prompts/map-prompts';
 import ModalWelcome from 'components/modals/welcome';
@@ -30,15 +28,12 @@ import './styles.scss';
 
 class MainMapComponent extends PureComponent {
   static propTypes = {
-    handleShowTooltip: PropTypes.func,
     onDrawComplete: PropTypes.func,
     handleClickAnalysis: PropTypes.func,
     handleClickMap: PropTypes.func,
     hidePanels: PropTypes.bool,
     embed: PropTypes.bool,
     recentActive: PropTypes.bool,
-    tooltipData: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-    showTooltip: PropTypes.bool,
     setMainMapAnalysisView: PropTypes.func,
   };
 
@@ -52,10 +47,7 @@ class MainMapComponent extends PureComponent {
     const {
       embed,
       hidePanels,
-      showTooltip,
-      tooltipData,
       handleClickMap,
-      handleShowTooltip,
       recentActive,
       handleClickAnalysis,
       setMainMapAnalysisView,
@@ -75,38 +67,18 @@ class MainMapComponent extends PureComponent {
           role="button"
           tabIndex={0}
           onClick={handleClickMap}
-          onMouseOver={() => handleShowTooltip(true, 'Click shape to analyze.')}
-          onFocus={() => handleShowTooltip(true, 'Click shape to analyze.')}
-          onMouseOut={() => handleShowTooltip(false, '')}
-          onBlur={() => handleShowTooltip(false, '')}
         >
-          <Tooltip
-            className="map-tooltip"
-            theme="tip"
-            html={(
-              <Tip
-                className="map-hover-tooltip"
-                text={this.renderInfoTooltip(tooltipData)}
-              />
-            )}
-            position="top"
-            followCursor
-            hideOnClick
-            animateFill={false}
-            open={showTooltip}
-          >
-            <Map
-              className="main-map"
-              onSelectBoundary={setMainMapAnalysisView}
-              onDrawComplete={onDrawComplete}
-              popupActions={[
-                {
-                  label: 'Analyze',
-                  action: handleClickAnalysis,
-                },
-              ]}
-            />
-          </Tooltip>
+          <Map
+            className="main-map"
+            onSelectBoundary={setMainMapAnalysisView}
+            onDrawComplete={onDrawComplete}
+            popupActions={[
+              {
+                label: 'Analyze',
+                action: handleClickAnalysis,
+              },
+            ]}
+          />
         </div>
         {!hidePanels && (
           <Media greaterThanOrEqual="md">

--- a/layouts/map/component.jsx
+++ b/layouts/map/component.jsx
@@ -34,7 +34,6 @@ class MainMapComponent extends PureComponent {
     onDrawComplete: PropTypes.func,
     handleClickAnalysis: PropTypes.func,
     handleClickMap: PropTypes.func,
-    oneClickAnalysis: PropTypes.bool,
     hidePanels: PropTypes.bool,
     embed: PropTypes.bool,
     recentActive: PropTypes.bool,
@@ -53,7 +52,6 @@ class MainMapComponent extends PureComponent {
     const {
       embed,
       hidePanels,
-      oneClickAnalysis,
       showTooltip,
       tooltipData,
       handleClickMap,
@@ -77,12 +75,8 @@ class MainMapComponent extends PureComponent {
           role="button"
           tabIndex={0}
           onClick={handleClickMap}
-          onMouseOver={() =>
-            oneClickAnalysis &&
-            handleShowTooltip(true, 'Click shape to analyze.')}
-          onFocus={() =>
-            oneClickAnalysis &&
-            handleShowTooltip(true, 'Click shape to analyze.')}
+          onMouseOver={() => handleShowTooltip(true, 'Click shape to analyze.')}
+          onFocus={() => handleShowTooltip(true, 'Click shape to analyze.')}
           onMouseOut={() => handleShowTooltip(false, '')}
           onBlur={() => handleShowTooltip(false, '')}
         >

--- a/layouts/map/index.js
+++ b/layouts/map/index.js
@@ -24,11 +24,6 @@ const actions = {
 };
 
 class MainMapContainer extends PureComponent {
-  state = {
-    showTooltip: false,
-    tooltipData: {},
-  };
-
   componentDidMount() {
     const { activeDatasets, basemap } = this.props;
     const layerIds = flatMap(activeDatasets?.map((d) => d.layers));
@@ -57,10 +52,6 @@ class MainMapContainer extends PureComponent {
       this.props.setMenuSettings({ menuSection: 'my-gfw' });
     }
   }
-
-  handleShowTooltip = (show, data) => {
-    this.setState({ showTooltip: show, tooltipData: data });
-  };
 
   handleClickMap = () => {
     if (this.props.menuSection) {
@@ -101,7 +92,6 @@ class MainMapContainer extends PureComponent {
     return createElement(MapComponent, {
       ...this.props,
       ...this.state,
-      handleShowTooltip: this.handleShowTooltip,
       handleClickAnalysis: this.handleClickAnalysis,
       handleClickMap: this.handleClickMap,
       onDrawComplete: this.onDrawComplete,

--- a/layouts/map/index.js
+++ b/layouts/map/index.js
@@ -1,8 +1,6 @@
 import { createElement, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import isEqual from 'lodash/isEqual';
-import isEmpty from 'lodash/isEmpty';
 import flatMap from 'lodash/flatMap';
 import { track } from 'analytics';
 import reducerRegistry from 'redux/registry';
@@ -42,24 +40,11 @@ class MainMapContainer extends PureComponent {
 
   componentDidUpdate(prevProps) {
     const {
-      selectedInteraction,
-      setMainMapAnalysisView,
       setMainMapSettings,
-      oneClickAnalysis,
       analysisActive,
       geostoreId,
       location,
     } = this.props;
-
-    // set analysis view if interaction changes
-    if (
-      oneClickAnalysis &&
-      selectedInteraction &&
-      !isEmpty(selectedInteraction.data) &&
-      !isEqual(selectedInteraction, prevProps.selectedInteraction)
-    ) {
-      setMainMapAnalysisView(selectedInteraction);
-    }
 
     if (!analysisActive && geostoreId && geostoreId !== prevProps.geostoreId) {
       setMainMapSettings({ showAnalysis: true });
@@ -125,10 +110,8 @@ class MainMapContainer extends PureComponent {
 }
 
 MainMapContainer.propTypes = {
-  oneClickAnalysis: PropTypes.bool,
   setMainMapAnalysisView: PropTypes.func,
   getGeostoreId: PropTypes.func,
-  selectedInteraction: PropTypes.object,
   setMenuSettings: PropTypes.func,
   setMainMapSettings: PropTypes.func,
   setMapPromptsSettings: PropTypes.func,

--- a/layouts/map/selectors.js
+++ b/layouts/map/selectors.js
@@ -1,8 +1,6 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 
 import {
-  getDrawing,
-  getMapLoading,
   getActiveDatasetsFromState,
   getInteractionSelected,
   getBasemapFromState,
@@ -14,7 +12,6 @@ const selectLocationPayload = (state) =>
   state.location && state.location.payload;
 const selectMenuSection = (state) => state.mapMenu?.settings?.menuSection;
 const getDrawGeostoreId = (state) => state.draw && state.draw.geostoreId;
-const getShowDraw = (state) => state.analysis?.settings?.showDraw;
 
 // SELECTORS
 export const getEmbed = createSelector(
@@ -47,25 +44,9 @@ export const getShowAnalysis = createSelector(
   (settings) => settings.showAnalysis
 );
 
-export const getOneClickAnalysis = createSelector(
-  [
-    getShowDraw,
-    selectLocationPayload,
-    getDrawing,
-    getMapLoading,
-    getShowAnalysis,
-  ],
-  (showDraw, location, draw, loading, showAnalysis) => {
-    const hasLocation = !!location?.adm0;
-    const isDrawing = draw || showDraw;
-    return !hasLocation && !isDrawing && !loading && showAnalysis;
-  }
-);
-
 export const getMapProps = createStructuredSelector({
   analysisActive: getShowAnalysis,
   recentActive: getShowRecentImagery,
-  oneClickAnalysis: getOneClickAnalysis,
   hidePanels: getHidePanels,
   menuSection: selectMenuSection,
   activeDatasets: getActiveDatasetsFromState,


### PR DESCRIPTION
## Overview

This pr removes one-click analysis logic when clicking a shape on the map—also removed content within the analysis component related to one-click analysis. 

We also remove the tooltip showing the user that they can one-click analysis by interacting with the shape.

## Demo

_not required_ 

## Notes

1. Ensure that all logic related to the tooltip is removed as we don't need it. 
2. Ensure that all logic related to the one-click is removed as well, as some functionality is no longer required. Check `layouts/map/index.js#componentDidUpdate` where we used to call `setMainMapAnalysisView` as it has some prop dependences.

## Testing

- Ensure copy does not include one-click analysis in the analysis view and that the copy makes sense.
- Ensure that when you click a shape, we don't automatically analyze it. This should be true both if a shape is already analyzed or not. 
