### PR TITLE
fires layers needs some filters to be parsed before render

### DIFF
--- a/components/map/selectors.js
+++ b/components/map/selectors.js
@@ -12,24 +12,26 @@ import { getActiveArea } from 'providers/areas-provider/selectors';
 import basemaps from './basemaps';
 
 // map state
-const getMapSettings = state => state.map?.settings || {};
-const selectMapLoading = state => state.map && state.map.loading;
-const selectGeostoreLoading = state => state.geostore && state.geostore.loading;
-const selectLatestLoading = state => state.latest && state.latest.loading;
-const selectDatasetsLoading = state => state.datasets && state.datasets.loading;
-const selectRecentImageryLoading = state =>
+const getMapSettings = (state) => state.map?.settings || {};
+const selectMapLoading = (state) => state.map && state.map.loading;
+const selectGeostoreLoading = (state) =>
+  state.geostore && state.geostore.loading;
+const selectLatestLoading = (state) => state.latest && state.latest.loading;
+const selectDatasetsLoading = (state) =>
+  state.datasets && state.datasets.loading;
+const selectRecentImageryLoading = (state) =>
   state.recentImagery && state.recentImagery.loading;
-const selectMapData = state => state.map && state.map.data;
-const selectDatasets = state => state.datasets && state.datasets.data;
-const selectLatest = state => state.latest && state.latest.data;
-export const selectGeostore = state => state.geostore && state.geostore.data;
-const selectLocation = state => state.location && state.location.payload;
+const selectMapData = (state) => state.map && state.map.data;
+const selectDatasets = (state) => state.datasets && state.datasets.data;
+const selectLatest = (state) => state.latest && state.latest.data;
+export const selectGeostore = (state) => state.geostore && state.geostore.data;
+const selectLocation = (state) => state.location && state.location.payload;
 
 // CONSTS
 export const getBasemaps = () => basemaps;
 
 // SELECTORS
-export const getMapViewport = createSelector([getMapSettings], settings => {
+export const getMapViewport = createSelector([getMapSettings], (settings) => {
   const { zoom, bearing, pitch, center } = settings;
   return {
     zoom,
@@ -37,40 +39,40 @@ export const getMapViewport = createSelector([getMapSettings], settings => {
     pitch,
     latitude: center?.lat,
     longitude: center?.lng,
-    transitionDuration: 500
+    transitionDuration: 500,
   };
 });
 
 export const getMapZoom = createSelector(
   [getMapSettings],
-  settings => settings.zoom
+  (settings) => settings.zoom
 );
 
 export const getMapMinZoom = createSelector(
   [getMapSettings],
-  settings => settings.minZoom
+  (settings) => settings.minZoom
 );
 
 export const getMapMaxZoom = createSelector(
   [getMapSettings],
-  settings => settings.maxZoom
+  (settings) => settings.maxZoom
 );
 
 export const getBasemapFromState = createSelector(
   getMapSettings,
-  settings => settings.basemap
+  (settings) => settings.basemap
 );
 
 export const getBasemap = createSelector(
   [getBasemapFromState],
-  basemapState => {
+  (basemapState) => {
     const basemap = {
       ...basemaps[basemapState?.value],
-      ...basemapState
+      ...basemapState,
     };
     let url = basemap && basemap.url;
     if (url) {
-      Object.keys(basemap).forEach(key => {
+      Object.keys(basemap).forEach((key) => {
         if (url.includes(`{${key}}`)) {
           url = url.replace(`{${key}}`, basemap[key]);
         }
@@ -83,37 +85,37 @@ export const getBasemap = createSelector(
 
 export const getMapStyle = createSelector(
   getBasemap,
-  basemap => basemap.mapStyle
+  (basemap) => basemap.mapStyle
 );
 
 export const getMapLabels = createSelector(
   getMapSettings,
-  settings => settings.labels
+  (settings) => settings.labels
 );
 
 export const getMapRoads = createSelector(
   getMapSettings,
-  settings => settings.roads
+  (settings) => settings.roads
 );
 
 export const getDrawing = createSelector(
   [getMapSettings],
-  settings => settings.drawing
+  (settings) => settings.drawing
 );
 
 export const getCanBound = createSelector(
   getMapSettings,
-  settings => settings.canBound
+  (settings) => settings.canBound
 );
 
 export const getGeostoreBbox = createSelector(
   [selectGeostore],
-  geostore => geostore && geostore.bbox
+  (geostore) => geostore && geostore.bbox
 );
 
 export const getStateBbox = createSelector(
   [getMapSettings],
-  settings => settings && settings.bbox
+  (settings) => settings && settings.bbox
 );
 
 export const getMapLoading = createSelector(
@@ -122,7 +124,7 @@ export const getMapLoading = createSelector(
     selectGeostoreLoading,
     selectLatestLoading,
     selectDatasetsLoading,
-    selectRecentImageryLoading
+    selectRecentImageryLoading,
   ],
   (
     mapLoading,
@@ -149,14 +151,14 @@ export const getLoadingMessage = createSelector(
 
 export const getActiveDatasetsFromState = createSelector(
   getMapSettings,
-  settings => settings.datasets
+  (settings) => settings.datasets
 );
 
 export const getActiveDatasetIds = createSelector(
   [getActiveDatasetsFromState],
-  activeDatasetsState => {
+  (activeDatasetsState) => {
     if (!activeDatasetsState || !activeDatasetsState.length) return null;
-    return activeDatasetsState?.map(l => l.dataset);
+    return activeDatasetsState?.map((l) => l.dataset);
   }
 );
 
@@ -164,7 +166,7 @@ export const getActiveDatasets = createSelector(
   [selectDatasets, getActiveDatasetIds],
   (datasets, datasetIds) => {
     if (isEmpty(datasets) || isEmpty(datasetIds)) return null;
-    return datasets.filter(d => datasetIds.includes(d.id));
+    return datasets.filter((d) => datasetIds.includes(d.id));
   }
 );
 
@@ -174,9 +176,9 @@ export const getDatasetsWithConfig = createSelector(
   (datasets, activeDatasetsState, latestDates) => {
     if (isEmpty(datasets) || isEmpty(activeDatasetsState)) return null;
 
-    return datasets.map(d => {
+    return datasets.map((d) => {
       const layerConfig =
-        activeDatasetsState.find(l => l.dataset === d.id) || {};
+        activeDatasetsState.find((l) => l.dataset === d.id) || {};
       const {
         params,
         sqlParams,
@@ -185,9 +187,8 @@ export const getDatasetsWithConfig = createSelector(
         layers,
         visibility,
         opacity,
-        bbox
-      } =
-        layerConfig || {};
+        bbox,
+      } = layerConfig || {};
 
       return {
         ...d,
@@ -196,16 +197,16 @@ export const getDatasetsWithConfig = createSelector(
           selectorLayerConfig: {
             ...d.selectorLayerConfig,
             selected: d.selectorLayerConfig.options.find(
-              l => l.value === layers[0]
-            )
-          }
+              (l) => l.value === layers[0]
+            ),
+          },
         }),
-        layers: d.layers.map(l => {
+        layers: d.layers.map((l) => {
           const {
             hasParamsTimeline,
             hasDecodeTimeline,
             timelineConfig: timelineConfigInit,
-            id
+            id,
           } = l;
           const maxDate = latestDates[id];
           const { latestFormat } = l.params || {};
@@ -213,26 +214,39 @@ export const getDatasetsWithConfig = createSelector(
             ? moment(maxDate).format(latestFormat)
             : maxDate;
 
-          const { min: minRange, max: maxRange, interval: rangeInterval } = timelineConfigInit && timelineConfigInit.dateRange || {};
+          const { min: minRange, max: maxRange, interval: rangeInterval } =
+            (timelineConfigInit && timelineConfigInit.dateRange) || {};
 
           const timelineConfig = {
             ...timelineConfigInit,
-            ...maxRange && rangeInterval && timelineConfigInit && {
-              startDate: moment(maxDate || timelineConfigInit.maxDate).subtract(maxRange, rangeInterval).format('YYYY-MM-DD'),
-              startDateAbsolute: moment(maxDate || timelineConfigInit.maxDate).subtract(maxRange, rangeInterval).format('YYYY-MM-DD')
-            },
+            ...(maxRange &&
+              rangeInterval &&
+              timelineConfigInit && {
+                startDate: moment(maxDate || timelineConfigInit.maxDate)
+                  .subtract(maxRange, rangeInterval)
+                  .format('YYYY-MM-DD'),
+                startDateAbsolute: moment(maxDate || timelineConfigInit.maxDate)
+                  .subtract(maxRange, rangeInterval)
+                  .format('YYYY-MM-DD'),
+              }),
             maxRange,
             minRange,
-            rangeInterval
+            rangeInterval,
           };
 
           const layerParams = {
             ...l.params,
-            ...maxRange && rangeInterval && timelineConfigInit && {
-              startDate: moment(maxDate || timelineConfigInit.maxDate).subtract(maxRange, rangeInterval).format('YYYY-MM-DD'),
-              startDateAbsolute: moment(maxDate || timelineConfigInit.maxDate).subtract(maxRange, rangeInterval).format('YYYY-MM-DD'),
-              endDateAbsolute: maxDate || l.params.endDate
-            }
+            ...(maxRange &&
+              rangeInterval &&
+              timelineConfigInit && {
+                startDate: moment(maxDate || timelineConfigInit.maxDate)
+                  .subtract(maxRange, rangeInterval)
+                  .format('YYYY-MM-DD'),
+                startDateAbsolute: moment(maxDate || timelineConfigInit.maxDate)
+                  .subtract(maxRange, rangeInterval)
+                  .format('YYYY-MM-DD'),
+                endDateAbsolute: maxDate || l.params.endDate,
+              }),
           };
 
           return {
@@ -246,63 +260,63 @@ export const getDatasetsWithConfig = createSelector(
               params: {
                 ...layerParams,
                 ...(maxDate && {
-                  endDate: maxDate
+                  endDate: maxDate,
                 }),
                 ...params,
                 ...(maxDateFormatted && {
-                  date: maxDateFormatted
+                  date: maxDateFormatted,
                 }),
                 ...(hasParamsTimeline && {
-                  ...timelineParams
+                  ...timelineParams,
                 }),
                 ...(maxDate && {
-                  maxDate
-                })
-              }
+                  maxDate,
+                }),
+              },
             }),
             ...(!isEmpty(l.sqlParams) && {
               sqlParams: {
                 ...l.sqlParams,
-                ...sqlParams
-              }
+                ...sqlParams,
+              },
             }),
             ...(l.decodeFunction && {
               decodeParams: {
                 ...l.decodeParams,
                 ...(layers && {
-                  confirmedOnly: layers.includes('confirmedOnly') ? 1 : 0
+                  confirmedOnly: layers.includes('confirmedOnly') ? 1 : 0,
                 }),
                 ...(maxDate && {
-                  endDate: maxDate
+                  endDate: maxDate,
                 }),
                 ...decodeParams,
                 ...(hasDecodeTimeline && {
-                  ...timelineParams
+                  ...timelineParams,
                 }),
                 ...(maxDate && {
-                  maxDate
-                })
-              }
+                  maxDate,
+                }),
+              },
             }),
             ...((l.hasParamsTimeline || l.hasDecodeTimeline) && {
               timelineParams: {
                 ...timelineConfig,
                 ...(l.hasParamsTimeline && {
-                  ...layerParams
+                  ...layerParams,
                 }),
                 ...(l.hasDecodeTimeline && {
-                  ...l.decodeParams
+                  ...l.decodeParams,
                 }),
                 ...(maxDate && {
                   endDate: maxDate,
                   maxDate,
-                  trimEndDate: maxDate
+                  trimEndDate: maxDate,
                 }),
-                ...timelineParams
-              }
-            })
+                ...timelineParams,
+              },
+            }),
           };
-        })
+        }),
       };
     });
   }
@@ -315,30 +329,30 @@ export const getLayerGroups = createSelector(
     if (isEmpty(datasets) || isEmpty(activeDatasetsState)) return null;
 
     return activeDatasetsState
-      .map(layer => {
-        const dataset = datasets.find(d => d.id === layer.dataset);
+      .map((layer) => {
+        const dataset = datasets.find((d) => d.id === layer.dataset);
         const { metadata } =
-          (dataset && dataset.layers.find(l => l.active)) || {};
+          (dataset && dataset.layers.find((l) => l.active)) || {};
         const newMetadata = metadata || (dataset && dataset.metadata);
 
         return {
           ...dataset,
           ...(newMetadata && {
-            metadata: newMetadata
-          })
+            metadata: newMetadata,
+          }),
         };
       })
-      .filter(d => !isEmpty(d));
+      .filter((d) => !isEmpty(d));
   }
 );
 
 // flatten datasets into layers for the layer manager
-export const getAllLayers = createSelector(getLayerGroups, layerGroups => {
+export const getAllLayers = createSelector(getLayerGroups, (layerGroups) => {
   if (isEmpty(layerGroups)) return null;
 
   return sortBy(
-    flatten(layerGroups.map(d => d.layers))
-      .filter(l => l && l.active && (!l.isRecentImagery || l.params.url))
+    flatten(layerGroups.map((d) => d.layers))
+      .filter((l) => l && l.active && (!l.isRecentImagery || l.params.url))
       .map((l, i) => {
         let zIndex = 1000 - i;
         if (l.isRecentImagery) zIndex = 500;
@@ -347,8 +361,8 @@ export const getAllLayers = createSelector(getLayerGroups, layerGroups => {
           ...l,
           zIndex,
           ...(l.isRecentImagery && {
-            id: l.params.url
-          })
+            id: l.params.url,
+          }),
         };
       }),
     'zIndex'
@@ -360,7 +374,7 @@ export const getActiveLayers = createSelector(
   [getAllLayers, selectGeostore, selectLocation, getActiveArea],
   (layers, geostore, location, activeArea) => {
     if (isEmpty(layers)) return [];
-    const filteredLayers = layers.filter(l => !l.confirmedOnly);
+    const filteredLayers = layers.filter((l) => !l.confirmedOnly);
     if (!geostore || !geostore.id) return filteredLayers;
     const { type, adm0 } = location || {};
     const isAoI = type === 'aoi' && adm0;
@@ -371,10 +385,10 @@ export const getActiveLayers = createSelector(
         features: [
           {
             ...geostore.geojson.features[0],
-            properties: activeArea
-          }
-        ]
-      })
+            properties: activeArea,
+          },
+        ],
+      }),
     };
 
     const parsedLayers = filteredLayers.concat({
@@ -384,40 +398,40 @@ export const getActiveLayers = createSelector(
         type: 'geojson',
         source: {
           data: geojson,
-          type: 'geojson'
+          type: 'geojson',
         },
         render: {
           layers: [
             {
               type: 'fill',
               paint: {
-                'fill-color': 'transparent'
-              }
+                'fill-color': 'transparent',
+              },
             },
             {
               type: 'line',
               paint: {
                 'line-color': '#C0FF24',
                 'line-width': isAoI ? 3 : 1,
-                'line-offset': isAoI ? 2 : 0
-              }
+                'line-offset': isAoI ? 2 : 0,
+              },
             },
             {
               type: 'line',
               paint: {
                 'line-color': '#000',
-                'line-width': 2
-              }
-            }
-          ]
-        }
+                'line-width': 2,
+              },
+            },
+          ],
+        },
       },
       ...(isAoI && {
         interactionConfig: {
-          output: []
-        }
+          output: [],
+        },
       }),
-      zIndex: 1060
+      zIndex: 1060,
     });
 
     return parsedLayers;
@@ -426,31 +440,70 @@ export const getActiveLayers = createSelector(
 
 export const getActiveLayersWithDates = createSelector(
   getActiveLayers,
-  layers => {
+  (layers) => {
     if (isEmpty(layers)) return [];
-    return layers.map(l => {
+    return layers.map((l) => {
       const { decodeFunction, decodeParams } = l;
       const { startDate, endDate } = decodeParams || {};
+      const { layerConfig } = l;
+      const { params_config = [] } = layerConfig;
+
+      // Some filters requires values to be spread
+      // this modifies the filters that has those requirements to return all values
+      const requiresSpread = params_config.filter((config) =>
+        Array.isArray(config.default)
+      );
 
       return {
         ...l,
+        ...(requiresSpread.length > 0 && {
+          layerConfig: {
+            ...layerConfig,
+            ...(layerConfig.render &&
+              layerConfig.render.layers && {
+                render: {
+                  ...layerConfig.render,
+                  layers: layerConfig.render.layers.map((layer) => ({
+                    ...layer,
+                    ...(layer.filter && {
+                      filter: layer.filter.map((filter) => {
+                        if (Array.isArray(filter)) {
+                          const filterKey = filter[2];
+                          const spreadValues = requiresSpread.find(
+                            (k) => `{${k.key}}` === filterKey
+                          );
+                          if (spreadValues) {
+                            return [
+                              ...filter.slice(0, 2),
+                              ...spreadValues.default,
+                            ];
+                          }
+                        }
+                        return filter;
+                      }),
+                    }),
+                  })),
+                },
+              }),
+          },
+        }),
         ...(decodeFunction &&
           decodeParams && {
-          decodeParams: {
-            ...decodeParams,
-            ...(startDate && {
-              startYear: moment(startDate).year(),
-              startMonth: moment(startDate).month(),
-              startDay: moment(startDate).dayOfYear()
-            }),
-            ...(endDate && {
-              endYear: moment(endDate).year(),
-              endMonth: moment(endDate).month(),
-              endDay: moment(endDate).dayOfYear()
-            }),
-            ...getDayRange(decodeParams)
-          }
-        })
+            decodeParams: {
+              ...decodeParams,
+              ...(startDate && {
+                startYear: moment(startDate).year(),
+                startMonth: moment(startDate).month(),
+                startDay: moment(startDate).dayOfYear(),
+              }),
+              ...(endDate && {
+                endYear: moment(endDate).year(),
+                endMonth: moment(endDate).month(),
+                endDay: moment(endDate).dayOfYear(),
+              }),
+              ...getDayRange(decodeParams),
+            },
+          }),
       };
     });
   }
@@ -458,11 +511,11 @@ export const getActiveLayersWithDates = createSelector(
 
 export const getInteractiveLayerIds = createSelector(
   getActiveLayers,
-  layers => {
+  (layers) => {
     if (isEmpty(layers)) return [];
 
     const interactiveLayers = layers.filter(
-      l =>
+      (l) =>
         !isEmpty(l.interactionConfig) &&
         l.layerConfig &&
         l.layerConfig.render &&
@@ -476,7 +529,7 @@ export const getInteractiveLayerIds = createSelector(
 
         return [
           ...arr,
-          clickableLayers.map((l, i) => `${layer.id}-${l.type}-${i}`)
+          clickableLayers.map((l, i) => `${layer.id}-${l.type}-${i}`),
         ];
       }, [])
     );
@@ -485,31 +538,31 @@ export const getInteractiveLayerIds = createSelector(
 
 export const getInteractionsState = createSelector(
   [selectMapData],
-  mapData => mapData && mapData.interactions
+  (mapData) => mapData && mapData.interactions
 );
 
 export const getInteractionsLatLng = createSelector(
   [getInteractionsState],
-  interactionData => interactionData && interactionData.latlng
+  (interactionData) => interactionData && interactionData.latlng
 );
 
 export const getInteractionsData = createSelector(
   [getInteractionsState],
-  interactionData => interactionData && interactionData.interactions
+  (interactionData) => interactionData && interactionData.interactions
 );
 
 export const getInteractionSelectedId = createSelector(
   [getInteractionsState],
-  interactionData => interactionData && interactionData.selected
+  (interactionData) => interactionData && interactionData.selected
 );
 
 export const getInteractions = createSelector(
   [getInteractionsData, getActiveLayers],
   (interactions, activeLayers) => {
     if (isEmpty(interactions)) return null;
-    return Object.keys(interactions).map(i => {
-      const layer = activeLayers.find(l => l.id === i);
-      const data = interactions[i].data;
+    return Object.keys(interactions).map((i) => {
+      const layer = activeLayers.find((l) => l.id === i);
+      const { data = [] } = interactions[i];
 
       return {
         data: Object.keys(data).reduce(
@@ -517,8 +570,8 @@ export const getInteractions = createSelector(
             ...obj,
             ...(data[d] &&
               data[d] !== 'null' && {
-              [d]: data[d]
-            })
+                [d]: data[d],
+              }),
           }),
           {}
         ),
@@ -528,7 +581,7 @@ export const getInteractions = createSelector(
         value: layer && layer.id,
         aoi: layer && layer.name === 'Area of Interest',
         article:
-          layer && layer.interactionConfig && layer.interactionConfig.article
+          layer && layer.interactionConfig && layer.interactionConfig.article,
       };
     });
   }
@@ -539,37 +592,39 @@ export const getInteractionSelected = createSelector(
   (interactions, selected, layers) => {
     if (isEmpty(interactions)) return null;
     const layersWithoutBoundaries = layers.filter(
-      l => !l.isBoundary && !isEmpty(l.interactionConfig)
+      (l) => !l.isBoundary && !isEmpty(l.interactionConfig)
     );
     const layersWithoutBoundariesIds =
       layersWithoutBoundaries &&
       layersWithoutBoundaries.length &&
-      layersWithoutBoundaries.map(l => l.id);
+      layersWithoutBoundaries.map((l) => l.id);
     // if there is an article (icon layer) then choose that
-    let selectedData = interactions.find(o => o.data.cluster);
-    selectedData = interactions.find(o => o.article);
+    let selectedData = interactions.find((o) => o.data.cluster);
+    selectedData = interactions.find((o) => o.article);
     // if there is nothing selected get the top layer
     if (!selected && !!layersWithoutBoundaries.length) {
       selectedData = interactions.find(
-        o => o.layer && layersWithoutBoundariesIds.includes(o.layer.id)
+        (o) => o.layer && layersWithoutBoundariesIds.includes(o.layer.id)
       );
     }
 
     // if only one layer then get that
     if (!selectedData && interactions.length === 1) {
-      selectedData = interactions[0];
+      selectedData = interactions[0]; // eslint-disable-line
     }
 
     // otherwise get based on selected
     if (!selectedData) {
-      selectedData = interactions.find(o => o.layer && o.layer.id === selected);
+      selectedData = interactions.find(
+        (o) => o.layer && o.layer.id === selected
+      );
     }
 
     return selectedData;
   }
 );
 
-export const getActiveMapLang = createSelector(selectActiveLang, lang => {
+export const getActiveMapLang = createSelector(selectActiveLang, (lang) => {
   if (lang === 'pt_BR') return 'pt';
   if (lang === 'es_MX') return 'es';
   if (lang === 'id') return 'en';
@@ -592,5 +647,5 @@ export const getMapProps = createStructuredSelector({
   interaction: getInteractionSelected,
   interactiveLayerIds: getInteractiveLayerIds,
   basemap: getBasemap,
-  lang: getActiveMapLang
+  lang: getActiveMapLang,
 });


### PR DESCRIPTION
## Overview

Using the Mapbox `"in"` expression requires us to be able to pass an array of  strings (or numbers, potentially) to the render. Currently this is unsupported on our end prior to passing the config to the Layer Manager library.

This feature not spreads arrays passed by `params_config` into the render by default.

e.g.

```
"params_config": [
{
"default": [
"h",
"n",
"l"
],
"key": "confidence_level",
"required": true
}, ...
```
passed into render with:
```
[
"in",
"confidence__cat",
"{confidence_level}"
]
```

becomes:

```
[
"in",
"confidence__cat",
"h",
"n",
"l"
]
```

## Notes

Fires layer: https://api.resourcewatch.org/v1/layer/2f1f6c86-bef8-4f58-b146-ee51e228a7e0?includes=vocabulary,metadata
