### PR TITLE
bugfix/argentina dashboard crash and trase widget

### DIFF
--- a/components/widgets/index.js
+++ b/components/widgets/index.js
@@ -104,7 +104,11 @@ class WidgetsContainer extends PureComponent {
         (mapSettingsChanged || activeWidgetChanged)
       ) {
         this.syncWidgetWithMap();
-      } else if (!datasets && activeWidgetChanged) {
+      } else if (
+        !datasets &&
+        activeWidgetChanged &&
+        !isEqual(settings, prevSettings)
+      ) {
         this.clearMap();
       }
     }

--- a/services/trase.js
+++ b/services/trase.js
@@ -1,6 +1,6 @@
 import request from 'utils/request';
 
-const { TRASE_API } = 'utils/constants';
+import { TRASE_API } from 'utils/constants';
 
 export const fetchTraseContexts = () => request.get(`${TRASE_API}/contexts`);
 


### PR DESCRIPTION
## Overview

These fixes solves the issue where argentina crashes. as we where ending up in a infinite loop on `clearMap` @ widgets/index. Also fixes issues where the trase widget endpoint URL was not imported correctly causing in a undefined request to trase. Also found out that the trase widget using `react-simple-maps` was not working, so this pr also makes sure that widget renders correctly. 

TLDR;

1. Fix issue causing infinite loop on argentina dashboard, constantly clearing the map
2. Fix issue where the trase endpoint was not parsed correctly 
3. Fix issue as the trase map was not rendered at all. 

## Testing

- Make sure data is correct on dashboards now with this fix
- Argentina dashboard should not crash 
- Trase widget should display correctly

