### PR TITLE
fix: disable download for glad

### DIFF
--- a/components/widget/components/widget-header/component.jsx
+++ b/components/widget/components/widget-header/component.jsx
@@ -36,6 +36,7 @@ class WidgetHeader extends PureComponent {
 
   render() {
     const {
+      widget,
       title,
       loading,
       active,
@@ -87,7 +88,12 @@ class WidgetHeader extends PureComponent {
           )}
           {showSeparator && <span className="separator" />}
           <div className="small-options">
-            {showDownloadBtn && <WidgetDownloadButton {...this.props} />}
+            {showDownloadBtn && (
+              <WidgetDownloadButton
+                disabled={widget === 'gladAlerts' || widget === 'gladRanked'}
+                {...this.props}
+              />
+            )}
             <WidgetInfoButton
               square={simple}
               handleOpenInfo={() => handleShowInfo(metaKey)}

--- a/components/widget/components/widget-header/components/widget-download-button/component.jsx
+++ b/components/widget/components/widget-header/components/widget-download-button/component.jsx
@@ -23,6 +23,7 @@ const isServer = typeof window === 'undefined';
 
 class WidgetDownloadButton extends PureComponent {
   static propTypes = {
+    disabled: PropTypes.bool,
     getDataURL: PropTypes.func,
     gladAlertsDownloadUrls: PropTypes.object,
     settings: PropTypes.object,
@@ -204,7 +205,7 @@ class WidgetDownloadButton extends PureComponent {
   };
 
   render() {
-    const { areaTooLarge } = this.props;
+    const { areaTooLarge, disabled } = this.props;
 
     let tooltipText =
       this.isGladAlertsWidget() && this.isCustomShape()
@@ -225,8 +226,8 @@ class WidgetDownloadButton extends PureComponent {
           'theme-button-grey-filled theme-button-xsmall': this.props.simple,
         })}
         onClick={this.onClickDownloadBtn}
-        tooltip={{ text: tooltipText }}
-        disabled={areaTooLarge}
+        tooltip={{ text: disabled ? 'Temporarily unavailable' : tooltipText }}
+        disabled={areaTooLarge || disabled}
       >
         <Icon icon={downloadIcon} className="download-icon" />
       </Button>

--- a/components/widget/components/widget-header/components/widget-download-button/styles.scss
+++ b/components/widget/components/widget-header/components/widget-download-button/styles.scss
@@ -1,6 +1,14 @@
 @import '~styles/settings.scss';
 
 .c-widget-download-button {
+  &.disabled:not(.theme-button-grey-filled) {
+    background: rgba($green-gfw, 0.5);
+
+    svg {
+      fill: $white;
+    }
+  }
+
   .download-icon {
     width: rem(10px);
     height: rem(10px);

--- a/components/widgets/forest-change/glad-alerts/index.js
+++ b/components/widgets/forest-change/glad-alerts/index.js
@@ -124,7 +124,7 @@ export default {
       spread((alertsResponse, latestResponse) => {
         const alerts = alertsResponse.data.data.attributes.value;
         const latestDate = latestResponse.attributes.updatedAt;
-        const {downloadUrls} = alertsResponse.data.data.attributes;
+        const { downloadUrls } = alertsResponse.data.data.attributes;
 
         return {
           alerts:
@@ -140,7 +140,8 @@ export default {
       })
     );
   },
-  getDataURL: (params) => [fetchGladAlerts({ ...params, download: true })],
+  // https://www.notion.so/Remove-downloads-from-GLAD-alert-widget-4831737872e64d7793cebb1fea1f354a
+  // getDataURL: (params) => [fetchGladAlerts({ ...params, download: true })],
   getWidgetProps,
   parseInteraction: (payload) => {
     if (payload) {

--- a/components/widgets/forest-change/glad-alerts/index.js
+++ b/components/widgets/forest-change/glad-alerts/index.js
@@ -140,8 +140,7 @@ export default {
       })
     );
   },
-  // https://www.notion.so/Remove-downloads-from-GLAD-alert-widget-4831737872e64d7793cebb1fea1f354a
-  // getDataURL: (params) => [fetchGladAlerts({ ...params, download: true })],
+  getDataURL: (params) => [fetchGladAlerts({ ...params, download: true })],
   getWidgetProps,
   parseInteraction: (payload) => {
     if (payload) {

--- a/components/widgets/forest-change/glad-ranked/index.js
+++ b/components/widgets/forest-change/glad-ranked/index.js
@@ -124,10 +124,9 @@ export default {
           : {};
       })
     ),
-  // https://www.notion.so/Remove-downloads-from-GLAD-alert-widget-4831737872e64d7793cebb1fea1f354a
-  // getDataURL: (params) => [
-  //   fetchGladAlerts({ ...params, download: true }),
-  //   getExtentGrouped({ ...params, download: true }),
-  // ],
+  getDataURL: (params) => [
+    fetchGladAlerts({ ...params, download: true }),
+    getExtentGrouped({ ...params, download: true }),
+  ],
   getWidgetProps,
 };

--- a/components/widgets/forest-change/glad-ranked/index.js
+++ b/components/widgets/forest-change/glad-ranked/index.js
@@ -124,9 +124,10 @@ export default {
           : {};
       })
     ),
-  getDataURL: (params) => [
-    fetchGladAlerts({ ...params, download: true }),
-    getExtentGrouped({ ...params, download: true }),
-  ],
+  // https://www.notion.so/Remove-downloads-from-GLAD-alert-widget-4831737872e64d7793cebb1fea1f354a
+  // getDataURL: (params) => [
+  //   fetchGladAlerts({ ...params, download: true }),
+  //   getExtentGrouped({ ...params, download: true }),
+  // ],
   getWidgetProps,
 };

--- a/components/widgets/utils/config.js
+++ b/components/widgets/utils/config.js
@@ -378,6 +378,11 @@ export const getStatements = ({
           '*raw NLCD categories have been re-classed to match IPCC categories'
         )
       : null,
+    dataType === 'glad' && type === 'country'
+      ? translateText(
+          'Caution: GLAD alerts from the last six months are preliminary. Revisions are made as unconfirmed alerts are removed from the data and alert totals are finalized six months after posting.'
+        )
+      : null,
     ...(indicatorStatements || []),
   ]);
 


### PR DESCRIPTION
## Overview

This pr disables download button for glad, and adds a disclamer to widget/layer

Notion: https://www.notion.so/9dd860f5dfd64475b92f4a3f79f0ff37?v=2098a476c4fa407981718cb4eafad507&p=4831737872e64d7793cebb1fea1f354a
