### PR TITLE
allow to enter map without location, and default to global

### DIFF
--- a/components/url/index.js
+++ b/components/url/index.js
@@ -13,6 +13,12 @@ const URL = ({
 }) => {
   const { pathname, asPath, replace, query } = useRouter();
 
+  let fullPathname = asPath?.split('?')?.[0];
+  // If path is map and we have no location, we need to default to global
+  if (pathname === '/map/[...location]' && fullPathname === '/map/') {
+    fullPathname = '/map/global/';
+  }
+
   useDeepCompareEffect(() => {
     if (query.location) {
       delete query.location;
@@ -26,7 +32,6 @@ const URL = ({
       { ...query, ...queryParams },
       options
     );
-    const fullPathname = asPath?.split('?')?.[0];
 
     replace(
       `${pathname}${queryParamsSerialized ? `?${queryParamsSerialized}` : ''}`,


### PR DESCRIPTION
## Overview

This pr fixes a bug when you enter the map without defining a location, for example these scenarios: 

1. Using the blog/help-center and pressing map link within the header, redirects to /map/ without location
2. Using the browser url field and entering gfw.com/map only. 
3. Using any external link that does not specify location for entering the map

Initially the solution was to update the gfw header component and append `global` to the main navigation, but it still would break entering from an url. As its quite logical to just enter /map without global, its better to catch this scenario when rendering the map page. 

Locally you will see this error: https://github.com/zeit/next.js/blob/master/errors/incompatible-href-as.md and map properties wont update when panning the map, as its in a error state. On production this error is silent but the map properties still wont work as reported here: https://basecamp.com/3063126/projects/10728552/todos/423949675#comment_777114029

## Testing

1. Try to enter gfw.com/map it should default to global if no location is present in the url field. 
2. Make sure map parameters are working when panning the map when doing the step above

