### PR TITLE
add mobile search button

### DIFF
--- a/layouts/map/components/map-controls/component.jsx
+++ b/layouts/map/components/map-controls/component.jsx
@@ -13,6 +13,7 @@ import shareIcon from 'assets/icons/share.svg?sprite';
 import fullscreenIcon from 'assets/icons/fit-zoom.svg?sprite';
 import printIcon from 'assets/icons/print.svg?sprite';
 import helpIocn from 'assets/icons/help.svg?sprite';
+import searchIcon from 'assets/icons/search.svg?sprite';
 import globeIcon from 'assets/icons/globe.svg?sprite';
 import satelliteIcon from 'assets/icons/satellite.svg?sprite';
 
@@ -281,12 +282,26 @@ class MapControlsButtons extends PureComponent {
     );
   };
 
-  renderShareButton = () => {
-    const { setShareModal } = this.props;
+  renderSearchButton = () => {
+    const { setMenuSettings } = this.props;
 
     return (
       <Button
         className="theme-button-map-control"
+        onClick={() => setMenuSettings({ menuSection: 'search' })}
+        tooltip={{ text: 'Search' }}
+      >
+        <Icon icon={searchIcon} />
+      </Button>
+    );
+  };
+
+  renderShareButton() {
+    const { setShareModal } = this.props;
+
+    return (
+      <Button
+        className="theme-button-map-control -share"
         onClick={() =>
           setShareModal({
             title: 'Share this view',
@@ -306,7 +321,7 @@ class MapControlsButtons extends PureComponent {
         <Icon icon={shareIcon} />
       </Button>
     );
-  };
+  }
 
   renderPrintButton = () => (
     <Button
@@ -346,7 +361,7 @@ class MapControlsButtons extends PureComponent {
           {format('.2f')(zoom)}
         </span>
         <span className="notranslate">
-          lat, lon:
+          lat, lon: 
           {' '}
           {`${format('.5f')(latitude)}, ${format('.5f')(longitude)}`}
         </span>
@@ -379,10 +394,15 @@ class MapControlsButtons extends PureComponent {
             </div>
           </Fragment>
         ) : (
-          <div className="mobile-controls-wrapper">
-            {this.renderShareButton()}
-            {this.renderRecentImageryBtn()}
-          </div>
+          <Fragment>
+            <div className="mobile-controls-wrapper">
+              {this.renderRecentImageryBtn()}
+            </div>
+            <div className="mobile-controls-wrapper">
+              {this.renderSearchButton()}
+              {this.renderShareButton()}
+            </div>
+          </Fragment>
         )}
       </div>
     );

--- a/layouts/map/components/map-controls/styles.scss
+++ b/layouts/map/components/map-controls/styles.scss
@@ -142,7 +142,6 @@
     }
 
     > * {
-      border-bottom: solid 1px $border;
       border-right: solid 1px $border;
 
       &:last-child {

--- a/layouts/map/components/map-controls/styles.scss
+++ b/layouts/map/components/map-controls/styles.scss
@@ -127,11 +127,23 @@
 
   .mobile-controls-wrapper {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    margin-left: 10px;
     box-shadow: 0 1px 2px rgba($black, 0.25);
+
+    .theme-button-map-control {
+      min-width: rem(40px);
+      height: rem(40px);
+
+      svg {
+        width: 25px;
+        height: 25px;
+      }
+    }
 
     > * {
       border-bottom: solid 1px $border;
+      border-right: solid 1px $border;
 
       &:last-child {
         border-bottom: 0;

--- a/layouts/map/styles.scss
+++ b/layouts/map/styles.scss
@@ -49,10 +49,12 @@
     top: rem(15px);
     right: rem(15px);
     z-index: 5;
+    display: flex;
 
     @media screen and (min-width: $screen-m) {
       bottom: rem(15px);
       top: auto;
+      display: block;
     }
   }
 


### PR DESCRIPTION
## Overview

This pr adds search button to mobile map controls as seen here: https://projects.invisionapp.com/d/main?origin=v7#/console/17055239/353550704/preview?scrollOffset=533

[notion](https://www.notion.so/Bugs-47e054fc0652498d9fb555ca2070c238?p=a2618b6af8824de7842d5060430873cb)

Changes: 

1. Design increased btn size from 38 -> 40 px for bigger touch control on mobile navigation
2. new direction for mobile screen (vertical) and split RSI from search + share
3. Increased icon size for easier readability 

## Demo

<img width="585" alt="Screenshot 2020-09-11 at 11 02 47" src="https://user-images.githubusercontent.com/971129/92899043-c89ab600-f41e-11ea-9cfd-e420abe624b1.png">


## Testing

- Ensure search works as expected + resize window to make sure "desktop" menu does not break with these css changes. 

