### PR TITLE
Bump TCL by Driver year

### DIFF
--- a/components/widgets/forest-change/tree-loss-tsc/index.js
+++ b/components/widgets/forest-change/tree-loss-tsc/index.js
@@ -18,7 +18,7 @@ import { getExtent, getLoss } from 'services/analysis-cached';
 import getWidgetProps from './selectors';
 
 const MIN_YEAR = 2001;
-const MAX_YEAR = 2018;
+const MAX_YEAR = 2019;
 
 export default {
   ...treeLoss,


### PR DESCRIPTION
## Overview

2018 --> 2019

Production tables need testing.