### PR TITLE
Fix/set mapRef in map ui component correctly

### DIFF
--- a/components/ui/map/component.jsx
+++ b/components/ui/map/component.jsx
@@ -84,11 +84,9 @@ class Map extends Component {
     },
   };
 
-  constructor(props) {
-    super(props);
-    this.map = createRef();
-    this.mapContainer = createRef();
-  }
+  mapRef = createRef();
+
+  mapContainer = createRef();
 
   state = {
     viewport: {
@@ -134,7 +132,7 @@ class Map extends Component {
   onLoad = () => {
     const { onLoad } = this.props;
     // Convert map reference to mapbox map instance before parsing map options
-    this.map = this.map.current.getMap();
+    this.map = this.mapRef.current.getMap();
     this.setState({ loaded: true });
     onLoad({
       map: this.map,
@@ -255,7 +253,7 @@ class Map extends Component {
         })}
       >
         <ReactMapGL
-          ref={this.map}
+          ref={this.mapRef}
           // CUSTOM PROPS FROM REACT MAPBOX API
           {...mapboxProps}
           // VIEWPORT


### PR DESCRIPTION
## Overview

Due to this.map being called as a ref and overwritten in the map ui component there was an error appearing to react ref setters. This fixes this.