### PR TITLE
Feature/simplify store

### DIFF
--- a/components/map/component.jsx
+++ b/components/map/component.jsx
@@ -136,7 +136,7 @@ class MapComponent extends Component {
         category: 'Map analysis',
         action: 'User opens analysis popup infowindow',
         label: interaction.label,
-      })
+      });
 
       if (interaction.data.cluster) {
         const { data, layer, geometry } = interaction;
@@ -199,7 +199,15 @@ class MapComponent extends Component {
     if (!drawing && e.features && e.features.length) {
       const { features, lngLat } = e;
       const { setMapInteractions } = this.props;
-      setMapInteractions({ features, lngLat });
+      setMapInteractions({
+        features: features.map((f) => ({
+          ...f,
+          // _vectorTileFeature cannot be serialized by redux
+          // so we must remove them before dispatching the action
+          _vectorTileFeature: null,
+        })),
+        lngLat,
+      });
     } else if (drawing) {
       this.setState({ drawClicks: this.state.drawClicks + 1 });
     } else {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@fullpage/react-fullpage": "^0.1.18",
     "@mapbox/mapbox-gl-draw": "^1.1.2",
     "@next/bundle-analyzer": "^9.4.4",
+    "@reduxjs/toolkit": "^1.4.0",
     "@wordpress/api-fetch": "^3.19.1",
     "@zeit/next-css": "^1.0.1",
     "@zeit/next-sass": "^1.0.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -15,7 +15,7 @@ import 'styles/styles.scss';
 finallyShim.shim();
 
 const App = ({ Component, pageProps }) => {
-  const store = useStore(pageProps.initialReduxState);
+  const store = useStore();
   const reducers = reducerRegistry.getReducers();
 
   useDeepCompareEffect(() => {

--- a/providers/datasets-provider/actions.js
+++ b/providers/datasets-provider/actions.js
@@ -152,7 +152,7 @@ export const getDatasets = createThunkAction(
                             background: customColor,
                           },
                           {
-                            background: chroma(customColor).darken(1.3),
+                            background: chroma(customColor).darken(1.3).hex(),
                           },
                         ],
                       };

--- a/redux/actions.js
+++ b/redux/actions.js
@@ -1,7 +1,4 @@
-import { handleActions, createAction } from 'redux-actions';
-
-const handleModule = ({ reducers, initialState }) =>
-  handleActions(reducers.default || reducers, initialState || {});
+import { createAction } from '@reduxjs/toolkit';
 
 const createThunkAction = (name, thunkAction, metaCreator) => {
   const action = createAction(name, null, metaCreator);
@@ -15,4 +12,4 @@ const createThunkAction = (name, thunkAction, metaCreator) => {
   return returnAction;
 };
 
-export { createAction, handleModule, createThunkAction };
+export { createAction, createThunkAction };

--- a/redux/registry.js
+++ b/redux/registry.js
@@ -1,4 +1,7 @@
-import { handleModule } from 'redux/actions';
+import { handleActions } from 'redux-actions';
+
+const handleModule = ({ reducers, initialState }) =>
+  handleActions(reducers.default || reducers, initialState || {});
 
 // As seen in http://nicolasgallagher.com/redux-modules-and-code-splitting/
 class ReducerRegistry {

--- a/redux/store.js
+++ b/redux/store.js
@@ -1,42 +1,12 @@
 import { useMemo } from 'react';
-import { createStore, applyMiddleware } from 'redux';
-import { composeWithDevTools } from 'redux-devtools-extension';
-import thunkMiddleware from 'redux-thunk';
+import { configureStore } from '@reduxjs/toolkit';
 import { rootReducer } from 'fast-redux';
 
-let store;
+const createStore = () =>
+  configureStore({
+    reducer: rootReducer,
+  });
 
-function initStore(initialState) {
-  return createStore(
-    rootReducer,
-    initialState,
-    composeWithDevTools(applyMiddleware(thunkMiddleware))
-  );
-}
+const makeStore = () => useMemo(() => createStore(), []);
 
-export const initializeStore = (preloadedState) => {
-  let _store = store ?? initStore(preloadedState);
-
-  // After navigating to a page with an initial Redux state, merge that state
-  // with the current state in the store, and create a new store
-  if (preloadedState && store) {
-    _store = initStore({
-      ...store.getState(),
-      ...preloadedState,
-    });
-    // Reset the current store
-    store = undefined;
-  }
-
-  // For SSG and SSR always create a new store
-  if (typeof window === 'undefined') return _store;
-  // Create the store once in the client
-  if (!store) store = _store;
-
-  return _store;
-};
-
-export const useStore = (initialState) =>
-  useMemo(() => initializeStore(initialState), [initialState]);
-
-export default useStore;
+export default makeStore;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2569,6 +2569,16 @@
   dependencies:
     "@babel/runtime" "^7.0.0"
 
+"@reduxjs/toolkit@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.4.0.tgz#ee2e2384cc3d1d76780d844b9c2da3580d32710d"
+  integrity sha512-hkxQwVx4BNVRsYdxjNF6cAseRmtrkpSlcgJRr3kLUcHPIAMZAmMJkXmHh/eUEGTMqPzsYpJLM7NN2w9fxQDuGw==
+  dependencies:
+    immer "^7.0.3"
+    redux "^4.0.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -8858,6 +8868,11 @@ immediate@~3.0.5:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
+immer@^7.0.3:
+  version "7.0.14"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.14.tgz#3e605f8584b15a9520d2f2f3fda9441cc9170d25"
+  integrity sha512-BxCs6pJwhgSEUEOZjywW7OA8DXVzfHjkBelSEl0A+nEu0+zS4cFVdNOONvt55N4WOm8Pu4xqSPYxhm1Lv2iBBA==
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -14137,7 +14152,7 @@ redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
 
-redux@^4.0.5:
+redux@^4.0.0, redux@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
   integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==


### PR DESCRIPTION
## Overview

Another clean up PR to start the process of simplifying our use of redux to supported libraries and tooling. The motivation for this is not only to reduce code, but also begin removing our dep on the [redux-actions](https://github.com/redux-utilities/redux-actions) lib which is no longer maintained.

The store has been reduced 😅 to a simple memoized create function, `makeStore`, which implements the [redux toolkit](https://redux-toolkit.js.org/) default store config for dev tools and middlewares. Previously we were handling to rehydration of the store from server side props which we never used, so the majority of the code was redundant. This brings some benefits:
- correctly configured dev tools and thunk out of the box
- less code
- `immutableStateInvariant` middleware for better reducer validation.

The adding of this additional middleware flagged errors in 2 actions:
1. `setMapInteractions` was passing `_vectorTileFeature` from mapbox to the store, a reference that is mutated by mapbox in view transitions and also of no use to use.
2. `getDatasets` default parsing of layer configs was generating an unfriendly rgba trackStyle color. This is now converted to a hex before returning.

## Testing

- Load the map and navigate between some locations. You should receive no redux related errors.

