### PR TITLE
Fix/HMR not loading css modules

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -14,6 +14,17 @@ import 'styles/styles.scss';
 
 finallyShim.shim();
 
+// fixes dev mode css modules not being added to the document correctly between
+// route changes due to a conflict between mini-css-extract-plugin and HMR
+// https://github.com/sheerun/extracted-loader/issues/11#issue-453094382
+if (process.env.NODE_ENV !== 'production' && module.hot) {
+  module.hot.addStatusHandler((status) => {
+    if (typeof window !== 'undefined' && status === 'ready') {
+      window.__webpack_reload_css__ = true;
+    }
+  });
+}
+
 const App = ({ Component, pageProps }) => {
   const store = useStore();
   const reducers = reducerRegistry.getReducers();


### PR DESCRIPTION
## Overview

Fixes loading of css modules between route changes in dev mode.

## Testing

- In dev mode load the app and change between pages making sure styles are correct on first transition.

