### PR TITLE
Feature/planet API proxy

### DIFF
--- a/components/map/basemaps.js
+++ b/components/map/basemaps.js
@@ -53,6 +53,6 @@ export default {
     basemapGroup: 'basemap-dark',
     labelsGroup: 'labels-dark',
     mapStyle: 'mapbox://styles/resourcewatch/ckgrx1ak30npt19o10xxkeqli',
-    url: `https://tiles.planet.com/basemaps/v1/planet-tiles/{name}/gmap/{z}/{x}/{y}.png?api_key=${process.env.NEXT_PUBLIC_PLANET_API_KEY}`,
+    url: `/api/planet-tiles/{name}/gmap/{z}/{x}/{y}/`,
   },
 };

--- a/pages/api/planet-tiles/[...params].js
+++ b/pages/api/planet-tiles/[...params].js
@@ -1,0 +1,23 @@
+const axios = require('axios');
+
+export default async function userHandler(req, res) {
+  const {
+    query: { params },
+    method,
+  } = req;
+  if (method === 'GET') {
+    const tile = await axios.get(
+      `https://tiles.planet.com/basemaps/v1/planet-tiles/${params?.join(
+        '/'
+      )}.png?api_key=${process.env.NEXT_PUBLIC_PLANET_API_KEY}`,
+      {
+        responseType: 'arraybuffer',
+      }
+    );
+    res.setHeader('content-type', 'image/png');
+    res.send(tile?.data);
+  } else {
+    res.setHeader('Allow', ['GET', 'PUT']);
+    res.status(405).end(`Method ${method} Not Allowed`);
+  }
+}


### PR DESCRIPTION
## Overview

Add api route for proxy to planet tiles to hide API key in requests.

## Testing

- Go to the map and turn on planet basemaps, make sure the tiles load.
- Check the network for planet responses and check for API key

