### PR TITLE
Fix/date picker portals

### DIFF
--- a/components/map/components/legend/components/timeline/component.jsx
+++ b/components/map/components/legend/components/timeline/component.jsx
@@ -33,7 +33,7 @@ const Timeline = (props) => {
           From
           <Datepicker
             selected={new Date(maxRange ? startDateAbsolute : startDate)}
-            onChange={(date) => handleOnDateChange(moment(date), 0, true)}
+            onChange={(date) => handleOnDateChange(moment(date), 0, !!maxRange)}
             minDate={new Date(minDate)}
             maxDate={maxRange ? new Date(maxDate) : new Date(trimEndDate)}
             isOutsideRange={(d) =>
@@ -42,10 +42,8 @@ const Timeline = (props) => {
           />
           to
           <Datepicker
-            selected={
-              new Date(moment(maxRange ? endDateAbsolute : trimEndDate))
-            }
-            onChange={(date) => handleOnDateChange(moment(date), 2, true)}
+            selected={new Date(maxRange ? endDateAbsolute : trimEndDate)}
+            onChange={(date) => handleOnDateChange(moment(date), 2, !!maxRange)}
             minDate={maxRange ? new Date(minDate) : new Date(startDate)}
             maxDate={new Date(maxDate)}
             isOutsideRange={(d) =>

--- a/components/map/components/legend/components/timeline/index.js
+++ b/components/map/components/legend/components/timeline/index.js
@@ -51,9 +51,8 @@ class TimelineContainer extends PureComponent {
       rangeInterval
     );
     if (
-      (maxRange && !diffInterval) ||
-      diffInterval >= maxRange ||
-      diffInterval < 0
+      maxRange &&
+      (!diffInterval || diffInterval >= maxRange || diffInterval < 0)
     ) {
       if (position) {
         const modDate = date.subtract(maxRange, rangeInterval);

--- a/components/ui/datepicker/component.js
+++ b/components/ui/datepicker/component.js
@@ -1,9 +1,7 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useRef, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { Portal } from 'react-portal';
 import OutsideClickHandler from 'react-outside-click-handler';
-
-import { Desktop, Mobile } from 'gfw-components';
 
 import ReactDatePicker, {
   registerLocale,
@@ -28,55 +26,28 @@ registerLocale('id', id);
 
 const Datepicker = ({ lang, ...props }) => {
   const [startDate, setStartDate] = useState(new Date());
-  const [position, setPosition] = useState(null);
   const [open, setOpen] = useState(false);
   const inputEl = useRef();
 
-  const getPosition = () => {
-    const coords = inputEl?.current?.getBoundingClientRect();
-
-    if (coords && coords.x + 290 > window.innerWidth) {
-      coords.x -= 195;
-    }
-
-    setPosition(coords);
-  };
-
-  useEffect(() => {
-    getPosition();
-  }, [open]);
-
-  const CustomInput = ({ value }) => (
-    <button className="datepicker-input" onClick={() => setOpen(!open)}>
+  const CustomInput = forwardRef(({ value }, ref) => (
+    <button
+      ref={ref}
+      className="datepicker-input"
+      onClick={() => setOpen(!open)}
+    >
       {value}
     </button>
+  ));
+
+  const CalendarWrapper = ({ className, children }) => (
+    <OutsideClickHandler onOutsideClick={() => setOpen(false)}>
+      <CalendarContainer className={className}>{children}</CalendarContainer>
+    </OutsideClickHandler>
   );
 
-  const PortalWrapper = ({ className, children }) => (
+  const PortalContainer = ({ children }) => (
     <Portal>
-      <Desktop>
-        <div
-          className="c-datepicker-portal"
-          style={{
-            transform: `translate(${position?.x}px, calc(${position?.y}px + 1.75rem))`,
-          }}
-        >
-          <OutsideClickHandler onOutsideClick={() => setOpen(false)}>
-            <CalendarContainer className={className}>
-              {children}
-            </CalendarContainer>
-          </OutsideClickHandler>
-        </div>
-      </Desktop>
-      <Mobile>
-        <div className="c-datepicker-portal">
-          <OutsideClickHandler onOutsideClick={() => setOpen(false)}>
-            <CalendarContainer className={className}>
-              {children}
-            </CalendarContainer>
-          </OutsideClickHandler>
-        </div>
-      </Mobile>
+      <div className="c-datepicker-portal">{children}</div>
     </Portal>
   );
 
@@ -95,11 +66,11 @@ const Datepicker = ({ lang, ...props }) => {
             {...headerProps}
             minDate={props?.minDate}
             maxDate={props?.maxDate}
-            open={open}
           />
         )}
+        popperContainer={PortalContainer}
         locale={lang || 'en'}
-        calendarContainer={PortalWrapper}
+        calendarContainer={CalendarWrapper}
         {...props}
       />
     </div>

--- a/components/ui/datepicker/styles.scss
+++ b/components/ui/datepicker/styles.scss
@@ -22,21 +22,25 @@
 }
 
 .c-datepicker-portal {
-  font-family: inherit;
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 10000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: rgba(17, 55, 80, 0.4);
+  .react-datepicker-popper {
+    z-index: 10000;
+  }
 
-  @media screen and (min-width: $screen-m) {
-    background-color: transparent;
-    display: block;
+  @media screen and (max-width: $screen-m) {
+    .react-datepicker-popper {
+      font-family: inherit;
+      position: fixed;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: rgba(17, 55, 80, 0.4);
+      transform: none !important;
+      margin: 0 !important;
+    }
   }
 
   > div:first-child {


### PR DESCRIPTION
## Overview

Timelines for layers that do not use absolute dates for trimming were having issues setting the dates within the timeline component. In conjunction with this, the Portal component being passed to the Datepicker component was loosing context of which active date to show inside the custom calendar header. This PR addresses both issues and removes some complexity of the portal itself.

## Testing

- Go to the map, turn on GLADs, use the datepickers and slider, check dates change.
- Go to the map, turn on VIIRS, use the datepickers and slider, check dates change.

