### PR TITLE
Fix tooltip order

### DIFF
--- a/components/widgets/forest-change/tree-loss-tsc/selectors.js
+++ b/components/widgets/forest-change/tree-loss-tsc/selectors.js
@@ -148,7 +148,7 @@ export const parseConfig = createSelector(
       },
     ];
     tooltip = tooltip.concat(
-      drivers
+      sortBy(drivers, 'position')
         .map((d) => {
           const tscCat = tscLossCategories.find((c) => c.value === d.driver);
           const label = tscCat && tscCat.label;


### PR DESCRIPTION
## Overview

Implements correct sorting of drivers in the tooltip of the Deforestation by Drivers Widget

Old:
<img width="753" alt="Screen Shot 2021-01-05 at 11 53 59" src="https://user-images.githubusercontent.com/30242314/103638492-442fee00-4f4d-11eb-9198-ce7bed22c26a.png">

New:
<img width="751" alt="Screen Shot 2021-01-05 at 11 50 25" src="https://user-images.githubusercontent.com/30242314/103638487-42662a80-4f4d-11eb-8c41-fc65d20697f8.png">
