### PR TITLE
Rename peat lands

### DIFF
--- a/data/land-categories.js
+++ b/data/land-categories.js
@@ -106,7 +106,7 @@ export default [
     ],
   },
   {
-    label: 'Indonesia peat lands',
+    label: 'Indonesia & Malaysia peat lands',
     preserveString: true,
     dataType: 'keyword',
     value: 'idn_mys_peatlands',


### PR DESCRIPTION
## Overview

Simple hotfix to rename `Indonesia peat lands` to `Indonesia & Malaysia peat lands` on the dashboard widget's Land Categories option.