### PR TITLE
Decode latest date from stats response

### DIFF
--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -186,6 +186,20 @@ const decodes = {
       alpha = 0.;
     }
   `,
+  RADDsCoverage: `
+    float red = color.r;
+    float green = color.g;
+    float blue = color.b;
+
+    if (red == 0. && green == 0. && blue == 0.) {
+      alpha = 0.;
+    } else {
+      color.r = 253. / 255.;
+      color.g = 204. / 255.;
+      color.b = 220. / 255.;
+      alpha = 1.;
+    }
+  `,
   staticRemap: `
     float red = color.r;
     float green = color.g;
@@ -635,6 +649,7 @@ export default {
   treeLossByDriver: decodes.treeLossByDriver,
   GLADs: decodes.GLADs,
   RADDs: decodes.RADDs,
+  RADDsCoverage: decodes.RADDsCoverage,
   staticRemap: decodes.staticRemap,
   forestHeight: decodes.forestHeight,
   biomassLoss: decodes.biomassLoss,

--- a/providers/latest-provider/actions.js
+++ b/providers/latest-provider/actions.js
@@ -33,9 +33,11 @@ export const getLatest = createThunkAction(
                   // Can this service return "null" or similar and then we can handle that case here
                   const days = statsLatestDecoder(bands);
                   // convert to date
-                  date = moment('2014-12-31')
-                    .add(days, 'days')
-                    .format('YYYY-MM-DD');
+                  date = days
+                    ? moment('2014-12-31')
+                        .add(days, 'days')
+                        .format('YYYY-MM-DD')
+                    : moment.now().subract(7, 'days');
                 }
                 if (!date) {
                   const data = Array.isArray(latestResponse)

--- a/providers/latest-provider/actions.js
+++ b/providers/latest-provider/actions.js
@@ -29,6 +29,8 @@ export const getLatest = createThunkAction(
                 const { bands } = latestResponse;
                 // if the response is from the stats endpoint, get bands key
                 if (bands && bands.length) {
+                  // TODO: What if we don't get dates properly formatted back?
+                  // Can this service return "null" or similar and then we can handle that case here
                   const days = statsLatestDecoder(bands);
                   // convert to date
                   date = moment('2014-12-31')

--- a/providers/latest-provider/actions.js
+++ b/providers/latest-provider/actions.js
@@ -32,10 +32,10 @@ export const getLatest = createThunkAction(
 
                   // high confidence alerts from top-level max
                   // max = abbbb where a = confidence value, bbbb = days since 2014-12-31
-                  const encodedLatestDate = max.toString(10);
-                  const daysSinceString = encodedLatestDate.substring(
+                  const encodedMax = max.toString(10);
+                  const daysSinceString = encodedMax.substring(
                     1,
-                    encodedLatestDate.length
+                    encodedMax.length
                   );
                   const daysSince = parseInt(daysSinceString, 10);
 
@@ -56,10 +56,10 @@ export const getLatest = createThunkAction(
                     histogram.min + (maxBinIndex - latestIndex) * binSize,
                     10
                   );
-                  const encodedLatestDateLowConfidence = binStart.toString(10);
-                  const daysSinceStringLowConfidence = encodedLatestDateLowConfidence.substring(
+                  const encodedMaxLowConfidence = binStart.toString(10);
+                  const daysSinceStringLowConfidence = encodedMaxLowConfidence.substring(
                     1,
-                    encodedLatestDateLowConfidence.length
+                    encodedMaxLowConfidence.length
                   );
                   const daysSinceLowConfidence = parseInt(
                     daysSinceStringLowConfidence,

--- a/providers/latest-provider/actions.js
+++ b/providers/latest-provider/actions.js
@@ -3,6 +3,7 @@ import moment from 'moment';
 import { all, spread } from 'axios';
 
 import { fetchLatestDate } from 'services/latest';
+import { statsLatestDecoder } from 'services/stats-latest-decoder';
 
 export const setLatestLoading = createAction('setLatestLoading');
 export const setLatestDates = createAction('setLatestDates');
@@ -28,50 +29,7 @@ export const getLatest = createThunkAction(
                 const { bands } = latestResponse;
                 // if the response is from the stats endpoint, get bands key
                 if (bands && bands.length) {
-                  const { max, histogram } = bands[0];
-
-                  // high confidence alerts from top-level max
-                  // max = abbbb where a = confidence value, bbbb = days since 2014-12-31
-                  const encodedMax = max.toString(10);
-                  const daysSinceString = encodedMax.substring(
-                    1,
-                    encodedMax.length
-                  );
-                  const daysSince = parseInt(daysSinceString, 10);
-
-                  // low confidence alerts from histogram
-                  // need to find the last non-zero bin where where index < 30,000 (high conf)
-                  const binSize =
-                    (histogram.max - histogram.min) / histogram.bin_count;
-                  const maxBinIndex = Math.floor(
-                    (30000 - histogram.min) / binSize
-                  );
-                  const valueBins = histogram.value_count
-                    .slice(0, maxBinIndex)
-                    .reverse();
-                  const latestIndex = valueBins.findIndex((el) => el !== 0);
-
-                  // Start of bin represents the encoded value
-                  const binStart = parseInt(
-                    histogram.min + (maxBinIndex - latestIndex) * binSize,
-                    10
-                  );
-                  const encodedMaxLowConfidence = binStart.toString(10);
-                  const daysSinceStringLowConfidence = encodedMaxLowConfidence.substring(
-                    1,
-                    encodedMaxLowConfidence.length
-                  );
-                  const daysSinceLowConfidence = parseInt(
-                    daysSinceStringLowConfidence,
-                    10
-                  );
-
-                  // whichever is latest (i.e. most days since 2014-12-31)
-                  const days =
-                    daysSinceLowConfidence > daysSince
-                      ? daysSinceLowConfidence
-                      : daysSince;
-
+                  const days = statsLatestDecoder(bands);
                   // convert to date
                   date = moment('2014-12-31')
                     .add(days, 'days')

--- a/providers/latest-provider/actions.js
+++ b/providers/latest-provider/actions.js
@@ -32,12 +32,13 @@ export const getLatest = createThunkAction(
                   // TODO: What if we don't get dates properly formatted back?
                   // Can this service return "null" or similar and then we can handle that case here
                   const days = statsLatestDecoder(bands);
+                  const endDate = moment('2014-12-31')
+                    .add(days, 'days')
+                    .format('YYYY-MM-DD');
+
+                  const defaultEndDate = moment.now().subract(7, 'days');
                   // convert to date
-                  date = days
-                    ? moment('2014-12-31')
-                        .add(days, 'days')
-                        .format('YYYY-MM-DD')
-                    : moment.now().subract(7, 'days');
+                  date = days ? endDate : defaultEndDate;
                 }
                 if (!date) {
                   const data = Array.isArray(latestResponse)

--- a/services/stats-latest-decoder.js
+++ b/services/stats-latest-decoder.js
@@ -36,12 +36,6 @@ export const statsLatestDecoder = (bands) => {
 
   const daysSinceLowConfidence = parseInt(daysSinceStringLowConfidence, 10);
 
-  // NOTE: Removed the ternary here to make it more clear what the end result of this factory is, and what its returning by default
-
-  // OLD:
-  // const days =
-  // daysSinceLowConfidence > daysSince ? daysSinceLowConfidence : daysSince;
-
   // whichever is latest (i.e. most days since 2014-12-31)
   // if both are > days since
   const daysSinceArray = [daysSince, daysSinceLowConfidence];

--- a/services/stats-latest-decoder.js
+++ b/services/stats-latest-decoder.js
@@ -1,0 +1,41 @@
+export const statsLatestDecoder = (bands) => {
+  // TODO: What if we dont have bands?
+  const { max, histogram } = bands[0];
+
+  // high confidence alerts from top-level max
+  // max = abbbb where a = confidence value, bbbb = days since 2014-12-31
+  const encodedMax = max.toString(10);
+  const daysSinceString = encodedMax.substring(1, encodedMax.length);
+
+  const daysSince = parseInt(daysSinceString, 10);
+
+  // low confidence alerts from histogram
+  // need to find the last non-zero bin where where index < 30,000 (high conf)
+  const binSize = (histogram.max - histogram.min) / histogram.bin_count;
+
+  const maxBinIndex = Math.floor((30000 - histogram.min) / binSize);
+
+  const valueBins = histogram.value_count.slice(0, maxBinIndex).reverse();
+
+  const latestIndex = valueBins.findIndex((el) => el !== 0);
+
+  // Start of bin represents the encoded value
+  const binStart = parseInt(
+    histogram.min + (maxBinIndex - latestIndex) * binSize,
+    10
+  );
+
+  const encodedMaxLowConfidence = binStart.toString(10);
+  const daysSinceStringLowConfidence = encodedMaxLowConfidence.substring(
+    1,
+    encodedMaxLowConfidence.length
+  );
+
+  const daysSinceLowConfidence = parseInt(daysSinceStringLowConfidence, 10);
+
+  // whichever is latest (i.e. most days since 2014-12-31)
+  const days =
+    daysSinceLowConfidence > daysSince ? daysSinceLowConfidence : daysSince;
+
+  return days;
+};

--- a/services/stats-latest-decoder.js
+++ b/services/stats-latest-decoder.js
@@ -8,6 +8,7 @@ export const statsLatestDecoder = (bands) => {
   const encodedMax = max.toString(10);
   const daysSinceString = encodedMax.substring(1, encodedMax.length);
 
+  // This is always a confirmed alert
   const daysSince = parseInt(daysSinceString, 10);
 
   // low confidence alerts from histogram
@@ -42,9 +43,8 @@ export const statsLatestDecoder = (bands) => {
   // daysSinceLowConfidence > daysSince ? daysSinceLowConfidence : daysSince;
 
   // whichever is latest (i.e. most days since 2014-12-31)
-  if (daysSinceLowConfidence > daysSince) {
-    return daysSinceLowConfidence;
-  }
+  // if both are > days since
+  const daysSinceArray = [daysSince, daysSinceLowConfidence];
 
-  return daysSince;
+  return Math.max(...daysSinceArray);
 };

--- a/services/stats-latest-decoder.js
+++ b/services/stats-latest-decoder.js
@@ -1,5 +1,6 @@
 export const statsLatestDecoder = (bands) => {
-  // TODO: What if we dont have bands?
+  // TODO: What if we don't have bands? or max / histogram is not present?
+  // i would recommend this service to simply return "null" if something is not formatted as we expect it to be
   const { max, histogram } = bands[0];
 
   // high confidence alerts from top-level max
@@ -17,6 +18,7 @@ export const statsLatestDecoder = (bands) => {
 
   const valueBins = histogram.value_count.slice(0, maxBinIndex).reverse();
 
+  // TODO: make sure we get a index here, and not -1, if we get -1 we should exit with "null"
   const latestIndex = valueBins.findIndex((el) => el !== 0);
 
   // Start of bin represents the encoded value
@@ -33,9 +35,16 @@ export const statsLatestDecoder = (bands) => {
 
   const daysSinceLowConfidence = parseInt(daysSinceStringLowConfidence, 10);
 
-  // whichever is latest (i.e. most days since 2014-12-31)
-  const days =
-    daysSinceLowConfidence > daysSince ? daysSinceLowConfidence : daysSince;
+  // NOTE: Removed the ternary here to make it more clear what the end result of this factory is, and what its returning by default
 
-  return days;
+  // OLD:
+  // const days =
+  // daysSinceLowConfidence > daysSince ? daysSinceLowConfidence : daysSince;
+
+  // whichever is latest (i.e. most days since 2014-12-31)
+  if (daysSinceLowConfidence > daysSince) {
+    return daysSinceLowConfidence;
+  }
+
+  return daysSince;
 };


### PR DESCRIPTION
## Overview

Adds RADD Alerts specific `latestDate` parsing for the `endDate` param as well as the raster decode function `RADDsCoverage` to parse the RADD Alerts geographic coverage layer.

### Details

The `stats` endpoint for the RADD alerts dataset returns statistics (`min`, `max`, `histogram`) for the _encoded_ alert dates. Example response:

```
"data": {
    "bands": [
        {
            "min": 21462,
            "max": 32199,
            "mean": 31221.31386,
            "histogram": {
                "bin_count": 8638,
                "min": 21440.947059,
                "max": 32220.052941,
                "value_count": [ 1166, 89, 0 , 1455, ...
```

Statistics are returned in the format `abbbb` with:

- `a` = _Confidence level_ where: 3 is 'high confidence', 2 is 'nominal', 1 is 'low'
- `bbbb` = number of days since 2014-12-31.

### Calculations

Since stats are returned in their encoded form, the `max` value is **always high confidence** (since 3XXXX > 2XXXX or 1XXXX), therefore we need to do further parsing to extract the latest alert date _regardless of confidence level_.

To do this we need to look at the `value_count` array inside the `histogram_key`, which is a binned frequency histogram of all alerts that occurred inside that encoded bin. Since this is filled sequentially, in order to get the latest _encoded_ date, we need to find the index of the last non-zero element and multiply that by the bin size.

`bin_size = histogram.max - histogram.min / histogram.bin_count`

The latest encoded date is then: `histogram.min + lastNonZeroIndex*bin_size`.

Finally, the latest encoded date _that is not high confidence_ is the same as the above with the condition that the encoded date is < 30,000.

We then convert the larger of the two _decoded_ `bbbb` numbers into a latests date.

## RADD Extent Layer

Simple raster coverage decode added to config:

<img width="986" alt="Screen Shot 2021-01-14 at 15 29 50" src="https://user-images.githubusercontent.com/30242314/104604530-be631f80-567d-11eb-9701-be8bb0da6157.png">

 

