### PR TITLE
fixing primary forest loss widget

### DIFF
--- a/components/widgets/forest-change/tree-loss-pct/selectors.js
+++ b/components/widgets/forest-change/tree-loss-pct/selectors.js
@@ -156,7 +156,7 @@ export const parseTitle = createSelector(
 
 const parseSentence = createSelector(
   [
-    // parseData,
+    parseData,
     filterData,
     getExtent,
     getSettings,
@@ -164,7 +164,15 @@ const parseSentence = createSelector(
     getIndicator,
     getSentence,
   ],
-  (data, extent, settings, locationLabel, indicator, sentences) => {
+  (
+    data,
+    filteredData,
+    extent,
+    settings,
+    locationLabel,
+    indicator,
+    sentences
+  ) => {
     if (!data) return null;
     const {
       initial,
@@ -178,9 +186,10 @@ const parseSentence = createSelector(
 
     // const data =
     //  data && data.length ? data.filter((y) => y.year > 2001) : [];
-    const totalLossPrimary = data && data.length ? sumBy(data, 'area') : 0;
-    console.log(data, totalLossPrimary);
-    const totalLoss = data.length ? data[0].totalLoss : 0;
+    const totalLossPrimary =
+      filteredData && filteredData.length ? sumBy(filteredData, 'area') : 0;
+
+    const totalLoss = data && data.length ? data[0].totalLoss : 0;
     const percentageLoss =
       (totalLoss && extent && (totalLossPrimary / totalLoss) * 100) || 0;
 

--- a/components/widgets/forest-change/tree-loss-pct/selectors.js
+++ b/components/widgets/forest-change/tree-loss-pct/selectors.js
@@ -184,8 +184,6 @@ const parseSentence = createSelector(
     } = sentences;
     const { startYear, endYear } = settings;
 
-    // const data =
-    //  data && data.length ? data.filter((y) => y.year > 2001) : [];
     const totalLossPrimary =
       filteredData && filteredData.length ? sumBy(filteredData, 'area') : 0;
 

--- a/components/widgets/forest-change/tree-loss-pct/selectors.js
+++ b/components/widgets/forest-change/tree-loss-pct/selectors.js
@@ -156,7 +156,8 @@ export const parseTitle = createSelector(
 
 const parseSentence = createSelector(
   [
-    parseData,
+    // parseData,
+    filterData,
     getExtent,
     getSettings,
     getLocationLabel,
@@ -175,22 +176,19 @@ const parseSentence = createSelector(
     } = sentences;
     const { startYear, endYear } = settings;
 
-    const filteredData =
-      data && data.length ? data.filter((y) => y.year > 2001) : [];
-    const totalLossPrimary = filteredData.length
-      ? sumBy(filteredData, 'area')
-      : 0;
-    const totalLoss = filteredData.length ? filteredData[0].totalLoss : 0;
+    // const data =
+    //  data && data.length ? data.filter((y) => y.year > 2001) : [];
+    const totalLossPrimary = data && data.length ? sumBy(data, 'area') : 0;
+    console.log(data, totalLossPrimary);
+    const totalLoss = data.length ? data[0].totalLoss : 0;
     const percentageLoss =
       (totalLoss && extent && (totalLossPrimary / totalLoss) * 100) || 0;
 
-    const initialExtentData = filteredData.find(
-      (d) => d.year === startYear - 1
-    );
+    const initialExtentData = data.find((d) => d.year === startYear - 1);
     const initialExtent =
       (initialExtentData && initialExtentData.extentRemaining) || 100;
 
-    const finalExtentData = filteredData.find((d) => d.year === endYear);
+    const finalExtentData = data.find((d) => d.year === endYear);
     const finalExtent =
       (finalExtentData && finalExtentData.extentRemaining) || 0;
 

--- a/components/widgets/manifest.js
+++ b/components/widgets/manifest.js
@@ -39,12 +39,9 @@ import treeCoverLocated from 'components/widgets/land-cover/tree-cover-located';
 import USLandCover from 'components/widgets/land-cover/us-land-cover';
 
 // Climate
-import emissions from 'components/widgets/climate/emissions';
 import woodyBiomass from 'components/widgets/climate/whrc-biomass/';
 import soilBiomass from 'components/widgets/climate/soil-organic';
 import emissionsDeforestation from 'components/widgets/climate/emissions-deforestation';
-import emissionsPlantations from 'components/widgets/climate/emissions-plantations';
-import cumulativeEmissions from 'components/widgets/climate/cumulative-emissions';
 import carbonStock from 'components/widgets/climate/carbon-stock';
 
 // Land Use
@@ -94,12 +91,10 @@ export default {
   treeCoverLocated,
 
   // climate
-  emissions,
+  // emissions,
   emissionsDeforestation,
-  emissionsPlantations,
   woodyBiomass,
   soilBiomass,
-  cumulativeEmissions,
   carbonStock,
 
   // land use


### PR DESCRIPTION
## Overview

Fixing primary forest loss widget.
Three climate widgets removed;
- Delete New York Declaration on Forests disturbance tracker widget 2 comments AJ Pain
- Delete Biomass loss emissions in natural forest vs. plantations widget 3 comments AJ Pain
- Delete historical emissions widget 2 comments AJ Pain

## Notes

Data isn't filtering, but fix has cascading effects that need to be addressed

## Testing

- Go to widget [url](globalforestwatch.org/embed/widget/treeLossPct/country/BRA?treeLossPct=eyJ0aHJlc2hvbGQiOjUwLCJzdGFydFllYXIiOjIwMDMsImhpZ2hsaWdodGVkIjpmYWxzZX0=), select date range, check loss and percentage and parameters change

