### PR TITLE
fix planet basemap date/image type serialisation

### DIFF
--- a/components/basemaps/index.js
+++ b/components/basemaps/index.js
@@ -19,6 +19,7 @@ class BasemapsContainer extends React.Component {
   static propTypes = {
     activeLabels: PropTypes.object,
     basemaps: PropTypes.object,
+    defaultPlanetBasemapsByCategory: PropTypes.object,
     defaultPlanetBasemap: PropTypes.string,
     labels: PropTypes.array,
     activeDatasets: PropTypes.array,
@@ -26,15 +27,25 @@ class BasemapsContainer extends React.Component {
     setMapSettings: PropTypes.func.isRequired,
   };
 
+  handlePlanetName = (name, color) => {
+    const { defaultPlanetBasemapsByCategory } = this.props;
+    const { visual, cir } = defaultPlanetBasemapsByCategory;
+    if (!name) {
+      // User selects image category
+      return color === 'cir' ? cir : visual;
+    }
+    return name;
+  };
+
   selectBasemap = ({ value, year, defaultYear, name, color } = {}) => {
-    const { setMapSettings, defaultPlanetBasemap } = this.props;
+    const { setMapSettings } = this.props;
     const basemapOptions = {
       value,
       ...(value === 'landsat' && {
         year: year || defaultYear,
       }),
       ...(value === 'planet' && {
-        name: name || defaultPlanetBasemap,
+        name: this.handlePlanetName(name, color),
         color: color || 'rgb',
       }),
     };

--- a/components/basemaps/planet-menu/component.jsx
+++ b/components/basemaps/planet-menu/component.jsx
@@ -7,7 +7,6 @@ import Dropdown from 'components/ui/dropdown';
 import './styles.scss';
 
 export const PlanetMenu = ({
-  name,
   periodOptions,
   periodSelected,
   onSelectBasemap,
@@ -42,7 +41,6 @@ export const PlanetMenu = ({
           onChange={(value) =>
             onSelectBasemap({
               value: 'planet',
-              name,
               color: value,
             })}
           native
@@ -53,7 +51,6 @@ export const PlanetMenu = ({
 );
 
 PlanetMenu.propTypes = {
-  name: PropTypes.string,
   periodOptions: PropTypes.array,
   periodSelected: PropTypes.object,
   colorOptions: PropTypes.array,

--- a/components/basemaps/planet-menu/selectors.js
+++ b/components/basemaps/planet-menu/selectors.js
@@ -10,7 +10,7 @@ const COLOR_OPTIONS = [
   },
   {
     label: 'False color (NIR)',
-    value: 'nir',
+    value: 'cir',
   },
 ];
 

--- a/components/basemaps/planet-menu/selectors.js
+++ b/components/basemaps/planet-menu/selectors.js
@@ -18,20 +18,14 @@ const selectBasemapSelected = (state) => state?.map?.settings?.basemap?.name;
 const selectBasemapColorSelected = (state) =>
   state?.map?.settings?.basemap?.color;
 
-const getPeriodsByImageType = (basemaps, basemapImageType) => {
-  const imageType = basemapImageType === 'rgb' ? 'visual' : 'analytic';
-  return basemaps.filter((b) => b.value.includes(imageType));
-};
-
 export const getPeriodOptions = createSelector(
-  [getPlanetBasemaps, selectBasemapColorSelected],
-  (planetBasemaps, basemapImageType) => {
+  [getPlanetBasemaps],
+  (planetBasemaps) => {
     if (isEmpty(planetBasemaps)) return null;
-    const serialize = planetBasemaps?.map(({ period, name } = {}) => ({
+    return planetBasemaps?.map(({ period, name } = {}) => ({
       label: period,
       value: name,
     }));
-    return serialize ? getPeriodsByImageType(serialize, basemapImageType) : [];
   }
 );
 

--- a/components/basemaps/planet-menu/selectors.js
+++ b/components/basemaps/planet-menu/selectors.js
@@ -18,15 +18,20 @@ const selectBasemapSelected = (state) => state?.map?.settings?.basemap?.name;
 const selectBasemapColorSelected = (state) =>
   state?.map?.settings?.basemap?.color;
 
-export const getPeriodOptions = createSelector(
-  [getPlanetBasemaps],
-  (planetBasemaps) => {
-    if (isEmpty(planetBasemaps)) return null;
+const getPeriodsByImageType = (basemaps, selected) => {
+  const imageType = selected === 'rgb' ? 'visual' : 'analytic';
+  return basemaps.filter((b) => b.value.includes(imageType));
+};
 
-    return planetBasemaps?.map(({ period, name } = {}) => ({
+export const getPeriodOptions = createSelector(
+  [getPlanetBasemaps, selectBasemapColorSelected],
+  (planetBasemaps, selected) => {
+    if (isEmpty(planetBasemaps)) return null;
+    const serialize = planetBasemaps?.map(({ period, name } = {}) => ({
       label: period,
       value: name,
     }));
+    return serialize ? getPeriodsByImageType(serialize, selected) : [];
   }
 );
 

--- a/components/basemaps/planet-menu/selectors.js
+++ b/components/basemaps/planet-menu/selectors.js
@@ -10,7 +10,7 @@ const COLOR_OPTIONS = [
   },
   {
     label: 'False color (NIR)',
-    value: 'cir',
+    value: 'nir',
   },
 ];
 

--- a/components/basemaps/planet-menu/selectors.js
+++ b/components/basemaps/planet-menu/selectors.js
@@ -18,20 +18,20 @@ const selectBasemapSelected = (state) => state?.map?.settings?.basemap?.name;
 const selectBasemapColorSelected = (state) =>
   state?.map?.settings?.basemap?.color;
 
-const getPeriodsByImageType = (basemaps, selected) => {
-  const imageType = selected === 'rgb' ? 'visual' : 'analytic';
+const getPeriodsByImageType = (basemaps, basemapImageType) => {
+  const imageType = basemapImageType === 'rgb' ? 'visual' : 'analytic';
   return basemaps.filter((b) => b.value.includes(imageType));
 };
 
 export const getPeriodOptions = createSelector(
   [getPlanetBasemaps, selectBasemapColorSelected],
-  (planetBasemaps, selected) => {
+  (planetBasemaps, basemapImageType) => {
     if (isEmpty(planetBasemaps)) return null;
     const serialize = planetBasemaps?.map(({ period, name } = {}) => ({
       label: period,
       value: name,
     }));
-    return serialize ? getPeriodsByImageType(serialize, selected) : [];
+    return serialize ? getPeriodsByImageType(serialize, basemapImageType) : [];
   }
 );
 

--- a/components/basemaps/selectors.js
+++ b/components/basemaps/selectors.js
@@ -18,7 +18,8 @@ import {
 
 const selectPlanetBasemaps = (state) => {
   const activeType = state?.map?.settings?.basemap?.color;
-  const imageType = activeType !== 'cir' ? 'visual' : 'analytic';
+  // This can be either rgb<string> hex value <#xxx> or nir<string>
+  const imageType = activeType !== 'nir' ? 'visual' : 'analytic';
   const planetBasemaps = state.planet?.data;
   if (activeType && planetBasemaps) {
     // XXX: Filter planet basemaps based on active image type

--- a/components/basemaps/selectors.js
+++ b/components/basemaps/selectors.js
@@ -25,6 +25,17 @@ const selectPlanetBasemaps = (state) => {
   return planetBasemaps?.filter((bm) => bm.name.includes(imageType));
 };
 
+const getGroupedPlanetBasemaps = (state) => {
+  const planetBasemaps = state.planet?.data;
+  const visual = planetBasemaps
+    ?.filter((bm) => bm.name.includes('visual'))
+    .reverse();
+  const cir = planetBasemaps
+    ?.filter((bm) => bm.name.includes('analytic'))
+    .reverse();
+  return [visual, cir];
+};
+
 export const getPlanetBasemaps = createSelector(
   [selectPlanetBasemaps],
   (planetBasemaps) => {
@@ -55,6 +66,17 @@ export const getPlanetBasemaps = createSelector(
 export const getDefaultPlanetBasemap = createSelector(
   [getPlanetBasemaps],
   (planetBasemaps) => planetBasemaps?.[0]?.name
+);
+
+export const getDefaultPlanetBasemaps = createSelector(
+  [getGroupedPlanetBasemaps],
+  (grouped) => {
+    const [visual, cir] = grouped;
+    return {
+      visual: visual?.[0]?.name,
+      cir: cir?.[0]?.name,
+    };
+  }
 );
 
 export const getLandsatYears = createSelector([getBasemaps], (basemaps) =>
@@ -99,6 +121,7 @@ export const getRoadsSelected = createSelector(
 export const getBasemapsProps = createStructuredSelector({
   activeDatasets: getActiveDatasetsFromState,
   mapZoom: getMapZoom,
+  defaultPlanetBasemapsByCategory: getDefaultPlanetBasemaps,
   activeBasemap: getBasemap,
   boundaries: getAllBoundaries,
   activeBoundaries: getActiveBoundaryDatasets,

--- a/components/basemaps/selectors.js
+++ b/components/basemaps/selectors.js
@@ -57,7 +57,6 @@ export const getPlanetBasemaps = createSelector(
 export const getDefaultPlanetBasemap = createSelector(
   [getPlanetBasemaps],
   (planetBasemaps) => {
-    console.log('planet basemaps', planetBasemaps);
     return planetBasemaps?.[0]?.name;
   }
 );

--- a/components/basemaps/selectors.js
+++ b/components/basemaps/selectors.js
@@ -16,7 +16,16 @@ import {
   getAllBoundaries,
 } from 'components/analysis/selectors';
 
-const selectPlanetBasemaps = (state) => state.planet?.data;
+const selectPlanetBasemaps = (state) => {
+  const activeType = state?.map?.settings?.basemap?.color;
+  const imageType = activeType !== 'cir' ? 'visual' : 'analytic';
+  const planetBasemaps = state.planet?.data;
+  if (activeType && planetBasemaps) {
+    // XXX: Filter planet basemaps based on active image type
+    return planetBasemaps.filter((bm) => bm.name.includes(imageType));
+  }
+  return [];
+};
 
 export const getPlanetBasemaps = createSelector(
   [selectPlanetBasemaps],
@@ -27,7 +36,6 @@ export const getPlanetBasemaps = createSelector(
         const startDate = new Date(first_acquired);
         const endDate = new Date(last_acquired);
         const monthDiff = differenceInMonths(endDate, startDate);
-
         const period =
           monthDiff === 1
             ? `${format(startDate, 'MMM yyyy')}`
@@ -35,7 +43,6 @@ export const getPlanetBasemaps = createSelector(
                 endDate,
                 'MMM yyyy'
               )}`;
-
         return {
           name,
           period,
@@ -49,7 +56,10 @@ export const getPlanetBasemaps = createSelector(
 
 export const getDefaultPlanetBasemap = createSelector(
   [getPlanetBasemaps],
-  (planetBasemaps) => planetBasemaps?.[0]?.name
+  (planetBasemaps) => {
+    console.log('planet basemaps', planetBasemaps);
+    return planetBasemaps?.[0]?.name;
+  }
 );
 
 export const getLandsatYears = createSelector([getBasemaps], (basemaps) =>

--- a/components/basemaps/selectors.js
+++ b/components/basemaps/selectors.js
@@ -1,7 +1,7 @@
 import { createStructuredSelector, createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import sortBy from 'lodash/sortBy';
-import { format, isValid, endOfMonth } from 'date-fns';
+import { format, differenceInMonths } from 'date-fns';
 
 import {
   getBasemaps,
@@ -23,17 +23,18 @@ export const getPlanetBasemaps = createSelector(
   (planetBasemaps) => {
     if (isEmpty(planetBasemaps)) return null;
     return sortBy(
-      planetBasemaps.map(({ name } = {}) => {
-        const splitName = name?.split('_');
-        const startDate = new Date(`${splitName?.[4]}-02`);
-        const endDate =
-          splitName?.[5] === 'mosaic'
-            ? null
-            : endOfMonth(new Date(`${splitName?.[5]}-02`));
+      planetBasemaps.map(({ name, first_acquired, last_acquired } = {}) => {
+        const startDate = new Date(first_acquired);
+        const endDate = new Date(last_acquired);
+        const monthDiff = differenceInMonths(endDate, startDate);
 
-        const period = isValid(endDate)
-          ? `${format(startDate, 'MMM yyyy')} - ${format(endDate, 'MMM yyyy')}`
-          : `${format(startDate, 'MMM yyyy')}`;
+        const period =
+          monthDiff === 1
+            ? `${format(startDate, 'MMM yyyy')}`
+            : `${format(startDate, 'MMM yyyy')} - ${format(
+                endDate,
+                'MMM yyyy'
+              )}`;
 
         return {
           name,

--- a/components/basemaps/selectors.js
+++ b/components/basemaps/selectors.js
@@ -19,13 +19,10 @@ import {
 const selectPlanetBasemaps = (state) => {
   const activeType = state?.map?.settings?.basemap?.color;
   // This can be either rgb<string> hex value <#xxx> or nir<string>
-  const imageType = activeType !== 'nir' ? 'visual' : 'analytic';
+  const imageType = activeType !== 'cir' ? 'visual' : 'analytic';
   const planetBasemaps = state.planet?.data;
-  if (activeType && planetBasemaps) {
-    // XXX: Filter planet basemaps based on active image type
-    return planetBasemaps.filter((bm) => bm.name.includes(imageType));
-  }
-  return [];
+  // XXX: Filter planet basemaps based on active image type
+  return planetBasemaps?.filter((bm) => bm.name.includes(imageType));
 };
 
 export const getPlanetBasemaps = createSelector(
@@ -57,9 +54,7 @@ export const getPlanetBasemaps = createSelector(
 
 export const getDefaultPlanetBasemap = createSelector(
   [getPlanetBasemaps],
-  (planetBasemaps) => {
-    return planetBasemaps?.[0]?.name;
-  }
+  (planetBasemaps) => planetBasemaps?.[0]?.name
 );
 
 export const getLandsatYears = createSelector([getBasemaps], (basemaps) =>

--- a/components/map/selectors.js
+++ b/components/map/selectors.js
@@ -78,7 +78,6 @@ export const getBasemap = createSelector(
         }
       });
     }
-
     return { ...basemap, url };
   }
 );


### PR DESCRIPTION
## Overview

Fix multiple issue with planet basemaps. 

1. Use dates from basemap response instead of parsing title
2. Filter basemaps based on selected image type

## Notes

BC: https://basecamp.com/3063126/projects/10728552/todos/433532321

## Testing

- Ensure dates + basemap corresponds to the correct image type
- Ensure basemaps render, or make sure this is not an issue on our side 
- Check interactivity and lets make sure we are updating the basemaps dynamically correct
- Make sure that when you land on planet basemap selected you get results 
- Make sure that when you toggle between image types that basemap renders correctly
- Ensure date ranges within the basemap options are correct and all of them works as expected (for both image types)
