### PR TITLE
Fix seasonStartDate issue

### DIFF
--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -387,19 +387,12 @@ export const parseSentence = createSelector(
     const minMean = min(data.map((d) => d.mean));
     const halfMax = (maxMean - minMean) * 0.5;
 
-    const minWeeks = orderBy(
-      data.filter((d) => d.mean <= minMean),
-      'date'
-    );
+    const sortedWeeks = orderBy(data, 'date');
+
+    const minWeeks = sortedWeeks.filter((d) => d.mean <= minMean);
     const lastMinDate =
       minWeeks && minWeeks.length ? minWeeks[minWeeks.length - 1].date : 0;
-
-    const peakWeeks = data.filter((d) => d.mean > halfMax);
-    const sortedPeakWeeks = orderBy(
-      peakWeeks,
-      ['year', 'week'],
-      ['asc', 'asc']
-    );
+    const sortedPeakWeeks = sortedWeeks.filter((d) => d.mean > halfMax);
     const seasonStartDate =
       sortedPeakWeeks.length &&
       sortedPeakWeeks.filter((d) => d.date > lastMinDate)[0].date;

--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -390,8 +390,7 @@ export const parseSentence = createSelector(
     const sortedWeeks = orderBy(data, 'date');
 
     const minWeeks = sortedWeeks.filter((d) => d.mean <= minMean);
-    const lastMinDate =
-      minWeeks && minWeeks.length ? minWeeks[minWeeks.length - 1].date : 0;
+    const lastMinDate = minWeeks[minWeeks.length - 1].date;
     const sortedPeakWeeks = sortedWeeks.filter((d) => d.mean > halfMax);
     const seasonStartDate =
       sortedPeakWeeks.length &&

--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -387,14 +387,22 @@ export const parseSentence = createSelector(
     const minMean = min(data.map((d) => d.mean));
     const halfMax = (maxMean - minMean) * 0.5;
 
+    const minWeeks = orderBy(
+      data.filter((d) => d.mean <= minMean),
+      'date'
+    );
+    const lastMinDate =
+      minWeeks && minWeeks.length ? minWeeks[minWeeks.length - 1].date : 0;
+
     const peakWeeks = data.filter((d) => d.mean > halfMax);
     const sortedPeakWeeks = orderBy(
       peakWeeks,
       ['year', 'week'],
-      ['desc', 'asc']
+      ['asc', 'asc']
     );
-    const seasonStartDate = sortedPeakWeeks.length && sortedPeakWeeks[0].date;
-
+    const seasonStartDate =
+      sortedPeakWeeks.length &&
+      sortedPeakWeeks.filter((d) => d.date > lastMinDate)[0].date;
     const seasonMonth = moment(seasonStartDate).format('MMMM');
     const seasonDay = parseInt(moment(seasonStartDate).format('D'), 10);
 


### PR DESCRIPTION
## Overview

Fixes issue detecting fire season start date (date at which the mean line passes full-width-half-maximum) in locations with southern hemisphere-like seasonality.

<img width="931" alt="Screen Shot 2021-02-08 at 10 18 02" src="https://user-images.githubusercontent.com/30242314/107199602-f2b8ca00-69f6-11eb-9866-77d674b1beaf.png">


## Demo

If applicable: screenshots, gifs, etc.

## Testing

- Go to Benin, Australia, Indonesia, Brazil
- Check that the dynamic sentence states that the fire season begins in the appropriate month.

