### PR TITLE
Fall back to default date if latest is in the future

### DIFF
--- a/providers/latest-provider/actions.js
+++ b/providers/latest-provider/actions.js
@@ -33,7 +33,11 @@ export const getLatest = createThunkAction(
                   // TODO: What if we don't get dates properly formatted back?
                   // Can this service return "null" or similar and then we can handle that case here
                   const days = statsLatestDecoder(bands);
-                  const endDate = moment('2014-12-31')
+                  const raddStartDate = moment('2014-12-31');
+                  const today = moment();
+                  const todayDays = today.diff(raddStartDate, 'days');
+                  const isPast = todayDays - days >= 0;
+                  const endDate = raddStartDate
                     .add(days, 'days')
                     .format('YYYY-MM-DD');
                   const defaultEndDate = moment()
@@ -41,7 +45,7 @@ export const getLatest = createThunkAction(
                     .format('YYYY-MM-DD');
 
                   // convert to date
-                  date = days && days > 0 ? endDate : defaultEndDate;
+                  date = days && days > 0 && isPast ? endDate : defaultEndDate;
                 }
                 if (!date) {
                   const data = Array.isArray(latestResponse)
@@ -51,6 +55,7 @@ export const getLatest = createThunkAction(
                     data && (data.date || data.latestResponse || data.latest);
                 }
                 let latestDate = moment(date).utc();
+
                 if (newEndpoints[index].resolution) {
                   latestDate = latestDate.endOf(newEndpoints[index].resolution);
                 }

--- a/providers/latest-provider/actions.js
+++ b/providers/latest-provider/actions.js
@@ -40,7 +40,7 @@ export const getLatest = createThunkAction(
                   const endDate = raddStartDate
                     .add(days, 'days')
                     .format('YYYY-MM-DD');
-                  const defaultEndDate = moment()
+                  const defaultEndDate = today
                     .add(-7, 'days')
                     .format('YYYY-MM-DD');
 

--- a/providers/latest-provider/actions.js
+++ b/providers/latest-provider/actions.js
@@ -27,9 +27,13 @@ export const getLatest = createThunkAction(
                 const latestResponse = response.data.data || response.data;
                 let date = latestResponse.date || latestResponse.max_date;
 
-                const { bands } = latestResponse;
+                const { bands, metadata } = latestResponse;
+                // if response is from the meta endpoint (prioritise this)
+                if (metadata && metadata.content_date) {
+                  date = metadata.content_date;
+                }
                 // if the response is from the stats endpoint, get bands key
-                if (bands && bands.length) {
+                else if (bands && bands.length) {
                   // TODO: What if we don't get dates properly formatted back?
                   // Can this service return "null" or similar and then we can handle that case here
                   const days = statsLatestDecoder(bands);
@@ -43,7 +47,6 @@ export const getLatest = createThunkAction(
                   const defaultEndDate = today
                     .add(-7, 'days')
                     .format('YYYY-MM-DD');
-
                   // convert to date
                   date = days && days > 0 && isPast ? endDate : defaultEndDate;
                 }
@@ -54,8 +57,7 @@ export const getLatest = createThunkAction(
                   date =
                     data && (data.date || data.latestResponse || data.latest);
                 }
-                let latestDate = moment(date).utc();
-
+                let latestDate = moment(date); // .utc();
                 if (newEndpoints[index].resolution) {
                   latestDate = latestDate.endOf(newEndpoints[index].resolution);
                 }


### PR DESCRIPTION
## Overview

Adds a check for radd latest date. If in the future, falls back to `defaultDate`.

BONUS - implements new code that prioritises using the `content_date` key from the metadata in `https://data-api.globalforestwatch.org/dataset/gfw_radd_alerts/latest` 

## Notes

- go to prod
- activate radd
- end date is currently in the future.
- with this fix it should default to today - 7 days