### PR TITLE
Hotfix/fires dates

### DIFF
--- a/components/widgets/fires/fires-alerts/index.js
+++ b/components/widgets/fires/fires-alerts/index.js
@@ -88,14 +88,17 @@ export default {
     confidence: 'h',
   },
   sentences: {
+    defaultSentence: 'In {location} there ',
+    seasonSentence:
+      'In {location} the peak fire season typically begins in {fires_season_start} and lasts around {fire_season_length} weeks. There ',
     allAlerts:
-      'In {location} the peak fire season typically begins in {fires_season_start} and lasts around {fire_season_length} weeks. There were {count} {dataset} fire alerts reported between {start_date} and {end_date}. This is {status} compared to previous years going back to {dataset_start_year}.',
+      'were {count} {dataset} fire alerts reported between {start_date} and {end_date}. This is {status} compared to previous years going back to {dataset_start_year}.',
     highConfidence:
-      'In {location} the peak fire season typically begins in {fires_season_start} and lasts around {fire_season_length} weeks. There were {count} {dataset} fire alerts reported between {start_date} and {end_date} considering <b>high confidence alerts</b> only. This is {status} compared to previous years going back to {dataset_start_year}.',
+      'were {count} {dataset} fire alerts reported between {start_date} and {end_date} considering <b>high confidence alerts</b> only. This is {status} compared to previous years going back to {dataset_start_year}.',
     allAlertsWithInd:
-      'In {location} the peak fire season typically begins in {fires_season_start} and lasts around {fire_season_length} weeks. There were {count} {dataset} fire alerts reported within {indicator} between {start_date} and {end_date}. This is {status} compared to previous years going back to {dataset_start_year}.',
+      'were {count} {dataset} fire alerts reported within {indicator} between {start_date} and {end_date}. This is {status} compared to previous years going back to {dataset_start_year}.',
     highConfidenceWithInd:
-      'In {location} the peak fire season typically begins in {fires_season_start} and lasts around {fire_season_length} weeks. There were {count} {dataset} fire alerts reported within {indicator} between {start_date} and {end_date} considering <b>high confidence alerts</b> only. This is {status} compared to previous years going back to {dataset_start_year}.',
+      'were {count} {dataset} fire alerts reported within {indicator} between {start_date} and {end_date} considering <b>high confidence alerts</b> only. This is {status} compared to previous years going back to {dataset_start_year}.',
   },
   whitelists: {
     adm0: [

--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -393,13 +393,13 @@ export const parseSentence = createSelector(
 
     const minWeeks = sortedWeeks.filter((d) => d.mean <= minMean);
 
-    const earliestMinDate = minWeeks[0].date;
+    const earliestMinDate = minWeeks[0]?.date;
     const sortedPeakWeeks = sortedWeeks.filter(
       (d) => d.mean > halfMax && d.date && d.date > earliestMinDate
     );
 
     const seasonStartDate =
-      sortedPeakWeeks.length > 0 && sortedPeakWeeks[0].date;
+      sortedPeakWeeks.length > 0 && sortedPeakWeeks[0]?.date;
 
     const seasonMonth = moment(seasonStartDate).format('MMMM');
     const seasonDay = parseInt(moment(seasonStartDate).format('D'), 10);

--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -390,11 +390,17 @@ export const parseSentence = createSelector(
     const sortedWeeks = orderBy(data, 'date');
 
     const minWeeks = sortedWeeks.filter((d) => d.mean <= minMean);
-    const lastMinDate = minWeeks[minWeeks.length - 1].date;
-    const sortedPeakWeeks = sortedWeeks.filter((d) => d.mean > halfMax);
+
+    const earliestMinDate =
+      minWeeks.length > 0
+        ? minWeeks[0].date
+        : moment().add(-1, 'years').format('YYYY-MM-DD');
+    const sortedPeakWeeks = sortedWeeks.filter(
+      (d) => d.mean > halfMax && d.date && d.date > earliestMinDate
+    );
+
     const seasonStartDate =
-      sortedPeakWeeks.length &&
-      sortedPeakWeeks.filter((d) => d.date > lastMinDate)[0].date;
+      sortedPeakWeeks.length > 0 ? sortedPeakWeeks[0].date : null; // TODO: add fallback to fail gracefully
     const seasonMonth = moment(seasonStartDate).format('MMMM');
     const seasonDay = parseInt(moment(seasonStartDate).format('D'), 10);
 

--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -363,6 +363,8 @@ export const parseSentence = createSelector(
   ) => {
     if (!data) return null;
     const {
+      defaultSentence,
+      seasonSentence,
       highConfidence,
       allAlerts,
       highConfidenceWithInd,
@@ -391,16 +393,14 @@ export const parseSentence = createSelector(
 
     const minWeeks = sortedWeeks.filter((d) => d.mean <= minMean);
 
-    const earliestMinDate =
-      minWeeks.length > 0
-        ? minWeeks[0].date
-        : moment().add(-1, 'years').format('YYYY-MM-DD');
+    const earliestMinDate = minWeeks[0].date;
     const sortedPeakWeeks = sortedWeeks.filter(
       (d) => d.mean > halfMax && d.date && d.date > earliestMinDate
     );
 
     const seasonStartDate =
-      sortedPeakWeeks.length > 0 ? sortedPeakWeeks[0].date : null; // TODO: add fallback to fail gracefully
+      sortedPeakWeeks.length > 0 && sortedPeakWeeks[0].date;
+
     const seasonMonth = moment(seasonStartDate).format('MMMM');
     const seasonDay = parseInt(moment(seasonStartDate).format('D'), 10);
 
@@ -431,8 +431,11 @@ export const parseSentence = createSelector(
       statusColor = colorRange[6];
     }
 
+    const initialSentence = seasonStartDate ? seasonSentence : defaultSentence;
     let sentence =
-      confidence && confidence.value === 'h' ? highConfidence : allAlerts;
+      confidence && confidence.value === 'h'
+        ? initialSentence + highConfidence
+        : initialSentence + allAlerts;
     if (indicator) {
       sentence =
         confidence && confidence.value === 'h'


### PR DESCRIPTION
## Overview

Catches edgecase with fire seasons in the Fire Stats widget (see: BRA/1/1) and makes the widget fail gracefully where no fire season can be detected.

To test go to 

`embed/widget/firesAlertsStats/country/BRA/1/1`