### PR TITLE
fix datepickers timezone issue

### DIFF
--- a/components/ui/datepicker/datepicker-header/component.jsx
+++ b/components/ui/datepicker/datepicker-header/component.jsx
@@ -29,9 +29,9 @@ const DatepickerHeader = ({
   const currentYear = getYear(date);
 
   const startDate =
-    currentYear === minYear ? minDate : new Date(`${currentYear}-01-01`);
+    currentYear === minYear ? minDate : new Date(`${currentYear}/01/01`);
   const endDate =
-    currentYear === maxYear ? maxDate : new Date(`${currentYear}-12-31`);
+    currentYear === maxYear ? maxDate : new Date(`${currentYear}/12/31`);
 
   const monthsInYear = eachMonthOfInterval({
     start: startDate,


### PR DESCRIPTION
## Overview

Datepickers when for example a US user uses GFW, we get out-of-bounds months, December twice. This is fixed by formating UTC in a normalized format so it gets parsed as local time, not UTC.
 
https://basecamp.com/3063126/projects/10728552/todos/434995459

## Testing

- Change your timezone to Americas on your computer
- go to: /map/?map=eyJkYXRhc2V0cyI6W3siZGF0YXNldCI6ImRlZm9yZXN0YXRpb24tYWxlcnRzLXRlcnJhLWkiLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlLCJsYXllcnMiOlsiZGVmb3Jlc3RhdGlvbi1hbGVydHMtdGVycmEtaSJdfSx7ImRhdGFzZXQiOiJwb2xpdGljYWwtYm91bmRhcmllcyIsImxheWVycyI6WyJkaXNwdXRlZC1wb2xpdGljYWwtYm91bmRhcmllcyIsInBvbGl0aWNhbC1ib3VuZGFyaWVzIl0sIm9wYWNpdHkiOjEsInZpc2liaWxpdHkiOnRydWV9XX0%3D and switch year, make sure you don't get December twice. Test on production the same URL to re produce the issue solved here

