### PR TITLE
Make overflow visible for trase widget

### DIFF
--- a/layouts/embed/widget/trase-embed-styles.scss
+++ b/layouts/embed/widget/trase-embed-styles.scss
@@ -50,6 +50,10 @@ $trase-font-family-2: 'Merriweather';
 // READ COMMENT FROM TOP
 .l-embed-widget-page {
   &.-trase {
+    .embed-widget {
+      overflow: visible;
+    }
+
     .c-widget-header {
       .options {
         display: none;


### PR DESCRIPTION
## Overview

On the [Trase integration](https://trase.earth/profiles) we had a problem with two scrollbars on the widget. It could only be solved by changing these styles inside the GFW application.
![image](https://user-images.githubusercontent.com/9701591/109787715-d0d5f000-7c0e-11eb-9b23-be5341880b6b.png)

## Testing

We will need this to be deployed to staging/production to test it 😕 

