### PR TITLE
Tree cover to land cover

### DIFF
--- a/components/charts/lollipop-chart/component.jsx
+++ b/components/charts/lollipop-chart/component.jsx
@@ -74,6 +74,7 @@ class LollipopChart extends PureComponent {
       unitsConfig &&
       unitsConfig.options &&
       unitsConfig.options.find((opt) => opt.value === unit);
+
     let formatUnit = unit;
     if (selectedUnitConfig) {
       formatUnit =
@@ -100,7 +101,7 @@ class LollipopChart extends PureComponent {
       <div className={cx('c-lollipop-chart', className)}>
         {!simple && legend && <Legend config={legend} simple={simple} />}
         <div className="unit-legend">
-          {`${unit.charAt(0).toUpperCase()}${unit.slice(1)} ${
+          {`${selectedUnitConfig.label || ''} ${
             formatUnit !== '' ? `(${formatUnit.trim()})` : ''
           }`}
         </div>

--- a/components/widgets/fires/fires-alerts-cumulative/index.js
+++ b/components/widgets/fires/fires-alerts-cumulative/index.js
@@ -15,7 +15,7 @@ export default {
       key: 'forestType',
       label: 'Forest Type',
       type: 'select',
-      placeholder: 'All tree cover',
+      placeholder: 'All land cover',
       clearable: true,
     },
     {

--- a/components/widgets/fires/fires-alerts-historical-old/index.js
+++ b/components/widgets/fires/fires-alerts-historical-old/index.js
@@ -12,7 +12,7 @@ export default {
       key: 'forestType',
       label: 'Forest Type',
       type: 'select',
-      placeholder: 'All tree cover',
+      placeholder: 'All land cover',
       clearable: true,
     },
     {

--- a/components/widgets/fires/fires-alerts-historical/index.js
+++ b/components/widgets/fires/fires-alerts-historical/index.js
@@ -26,7 +26,7 @@ export default {
       key: 'forestType',
       label: 'Forest Type',
       type: 'select',
-      placeholder: 'All tree cover',
+      placeholder: 'All land cover',
       clearable: true,
     },
     {

--- a/components/widgets/fires/fires-alerts/index.js
+++ b/components/widgets/fires/fires-alerts/index.js
@@ -26,7 +26,7 @@ export default {
       key: 'forestType',
       label: 'Forest Type',
       type: 'select',
-      placeholder: 'All tree cover',
+      placeholder: 'All land cover',
       clearable: true,
     },
     {

--- a/components/widgets/fires/fires-ranked/index.js
+++ b/components/widgets/fires/fires-ranked/index.js
@@ -22,7 +22,7 @@ export default {
       key: 'forestType',
       label: 'Forest Type',
       type: 'select',
-      placeholder: 'All tree cover',
+      placeholder: 'All land cover',
       clearable: true,
     },
     {

--- a/components/widgets/fires/fires-ranked/selectors.js
+++ b/components/widgets/fires/fires-ranked/selectors.js
@@ -113,7 +113,7 @@ export const parseList = createSelector(
 
       const counts = adm.currentYearCounts;
       const locationAreaData =
-        areas.find((el) => el[matchKey] === adm.id) || {};
+        areas.find((el) => el[matchKey] === locationId) || {};
 
       const locationArea = locationAreaData.area__ha || null;
       // Density in counts per Mha

--- a/components/widgets/fires/fires-within/index.js
+++ b/components/widgets/fires/fires-within/index.js
@@ -27,7 +27,7 @@ export default {
       key: 'forestType',
       label: 'Forest Type',
       type: 'select',
-      placeholder: 'All categories',
+      placeholder: 'All land cover',
       clearable: true,
       border: false,
     },

--- a/components/widgets/fires/fires-within/index.js
+++ b/components/widgets/fires/fires-within/index.js
@@ -125,12 +125,16 @@ export default {
     ),
   getDataURL: (params) => [
     fetchFiresWithin({ ...params, download: true }),
-    fetchFiresWithin({
-      ...params,
-      forestType: '',
-      landCategory: '',
-      download: true,
-    }),
+    ...(params.forestType || params.landCategory
+      ? [
+          fetchFiresWithin({
+            ...params,
+            forestType: '',
+            landCategory: '',
+            download: true,
+          }),
+        ]
+      : []),
   ],
   getWidgetProps,
 };

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -30,19 +30,19 @@ const SQL_QUERIES = {
     'SELECT {location}, alert__year, alert__week, SUM(alert__count) AS alert__count, SUM(alert_area__ha) AS alert_area__ha FROM data {WHERE} GROUP BY {location}, alert__year, alert__week',
   gladDaily: `SELECT {location}, alert__date, SUM(alert__count) AS alert__count, SUM(alert_area__ha) AS alert_area__ha FROM data {WHERE} AND alert__date >= '{startDate}' AND alert__date <= '{endDate}' GROUP BY {location}, alert__date ORDER BY alert__date DESC`,
   fires:
-    'SELECT {location}, alert__year, alert__week, SUM(alert__count) AS alert__count, confidence__cat FROM data {WHERE} GROUP BY {location}, alert__year, alert__week',
+    'SELECT {location}, alert__year, alert__week, SUM(alert__count) AS alert__count, confidence__cat FROM data {WHERE} GROUP BY {location}, alert__year, alert__week, confidence__cat',
   firesGrouped:
-    'SELECT {location}, alert__year, alert__week, SUM(alert__count) AS alert__count, confidence__cat FROM data {WHERE} AND ({dateFilter}) GROUP BY {location}, alert__year, alert__week',
+    'SELECT {location}, alert__year, alert__week, SUM(alert__count) AS alert__count, confidence__cat FROM data {WHERE} AND ({dateFilter}) GROUP BY {location}, alert__year, alert__week, confidence__cat',
   firesWithin:
-    'SELECT {location}, alert__week, alert__year, SUM(alert__count) AS alert__count, confidence__cat FROM data {WHERE} AND alert__year >= {alert__year} AND alert__week >= 1 GROUP BY alert__year, alert__week ORDER BY alert__week DESC, alert__year DESC',
+    'SELECT {location}, alert__week, alert__year, SUM(alert__count) AS alert__count, confidence__cat FROM data {WHERE} AND alert__year >= {alert__year} AND alert__week >= 1 GROUP BY alert__year, alert__week, confidence__cat ORDER BY alert__week DESC, alert__year DESC',
   nonGlobalDatasets:
     'SELECT {polynames} FROM polyname_whitelist WHERE iso is null AND adm1 is null AND adm2 is null',
   getLocationPolynameWhitelist:
     'SELECT {location}, {polynames} FROM data {WHERE}',
   alertsWeekly:
-    'SELECT alert__week, alert__year, SUM(alert__count) AS alert__count FROM data {WHERE} AND ({dateFilter}) GROUP BY alert__week, alert__year ORDER BY alert__year DESC, alert__week DESC',
+    'SELECT alert__week, alert__year, SUM(alert__count) AS alert__count, confidence__cat FROM data {WHERE} AND ({dateFilter}) GROUP BY alert__week, alert__year, confidence__cat ORDER BY alert__year DESC, alert__week DESC',
   alertsDaily:
-    "SELECT alert__date, SUM(alert__count) AS alert__count FROM data {WHERE} AND alert__date >= '{startDate}' AND alert__date <= '{endDate}' GROUP BY alert__date ORDER BY alert__date DESC",
+    "SELECT alert__date, SUM(alert__count) AS alert__count, confidence__cat FROM data {WHERE} AND alert__date >= '{startDate}' AND alert__date <= '{endDate}' GROUP BY alert__date, confidence__cat ORDER BY alert__date DESC",
   biomassStock:
     'SELECT SUM(whrc_aboveground_biomass_stock_2000__Mg) AS whrc_aboveground_biomass_stock_2000__Mg, SUM(whrc_aboveground_co2_stock_2000__Mg) AS whrc_aboveground_co2_stock_2000__Mg, SUM(umd_tree_cover_extent_2000__ha) AS umd_tree_cover_extent_2000__ha FROM data {WHERE}',
   biomassStockGrouped:

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -34,7 +34,7 @@ const SQL_QUERIES = {
   firesGrouped:
     'SELECT {location}, alert__year, alert__week, SUM(alert__count) AS alert__count, confidence__cat FROM data {WHERE} AND ({dateFilter}) GROUP BY {location}, alert__year, alert__week, confidence__cat',
   firesWithin:
-    'SELECT {location}, alert__week, alert__year, SUM(alert__count) AS alert__count, confidence__cat FROM data {WHERE} AND alert__year >= {alert__year} AND alert__week >= 1 GROUP BY alert__year, alert__week, confidence__cat ORDER BY alert__week DESC, alert__year DESC',
+    'SELECT {location}, alert__week, alert__year, SUM(alert__count) AS alert__count, confidence__cat FROM data {WHERE} AND alert__year >= {alert__year} AND alert__week >= 1 GROUP BY {location}, alert__year, alert__week, confidence__cat ORDER BY alert__week DESC, alert__year DESC',
   nonGlobalDatasets:
     'SELECT {polynames} FROM polyname_whitelist WHERE iso is null AND adm1 is null AND adm2 is null',
   getLocationPolynameWhitelist:


### PR DESCRIPTION
## Overview

For fires widgets, changes default forest type label to `All land cover` (since fires needn't be _within_ forest)
<img width="677" alt="Screen Shot 2021-03-08 at 13 37 25" src="https://user-images.githubusercontent.com/30242314/110322629-b6878200-8013-11eb-948d-b5c170f3e969.png">
