### PR TITLE
Planet Basemaps Test

### DIFF
--- a/components/basemaps/index.js
+++ b/components/basemaps/index.js
@@ -31,10 +31,12 @@ class BasemapsContainer extends React.Component {
 
   handlePlanetName = (name, color) => {
     const { defaultPlanetBasemapsByCategory } = this.props;
-    const { visual, cir } = defaultPlanetBasemapsByCategory;
+    const { visual, cir, rgb } = defaultPlanetBasemapsByCategory;
     if (!name) {
       // User selects image category
-      return color === 'cir' ? cir : visual;
+      if (color === 'rgb') return rgb;
+      if (color === 'cir') return cir;
+      return visual;
     }
     return name;
   };
@@ -51,7 +53,7 @@ class BasemapsContainer extends React.Component {
       }),
       ...(value === 'planet' && {
         name: this.handlePlanetName(name, color),
-        color: color || 'rgb',
+        color: color || '',
       }),
     };
 

--- a/components/basemaps/planet-menu/selectors.js
+++ b/components/basemaps/planet-menu/selectors.js
@@ -6,11 +6,15 @@ import { getPlanetBasemaps } from '../selectors';
 const COLOR_OPTIONS = [
   {
     label: 'Natural color',
-    value: 'rgb',
+    value: '',
   },
   {
     label: 'False color (NIR)',
     value: 'cir',
+  },
+  {
+    label: 'False color (RGB)',
+    value: 'rgb',
   },
 ];
 

--- a/components/basemaps/planet-menu/selectors.js
+++ b/components/basemaps/planet-menu/selectors.js
@@ -3,20 +3,11 @@ import isEmpty from 'lodash/isEmpty';
 
 import { getPlanetBasemaps } from '../selectors';
 
-const COLOR_OPTIONS = [
-  {
-    label: 'Natural color',
-    value: '',
-  },
-  {
-    label: 'False color (NIR)',
-    value: 'cir',
-  },
-];
-
 const selectBasemapSelected = (state) => state?.map?.settings?.basemap?.name;
 const selectBasemapColorSelected = (state) =>
   state?.map?.settings?.basemap?.color;
+
+const getBasemapOptions = (state) => state?.planet?.options;
 
 export const getPeriodOptions = createSelector(
   [getPlanetBasemaps],
@@ -37,11 +28,27 @@ export const getPeriodSelected = createSelector(
   }
 );
 
-export const getColorOptions = createSelector([], () => COLOR_OPTIONS);
+export const getColorOptions = createSelector(
+  [getBasemapOptions],
+  (options) => {
+    if (!options) return null;
+    try {
+      return Object.values(options);
+    } catch (_) {
+      return null;
+    }
+  }
+);
 
 export const getColorSelected = createSelector(
   [getColorOptions, selectBasemapColorSelected],
-  (options, selected) => options.find((o) => o.value === selected)?.value
+  (options, selected) => {
+    if (!options) return null;
+    if (selected === 'cir') {
+      return options.find((opt) => opt.id === 'analytical').value;
+    }
+    return options.find((opt) => opt.id === 'visual').value;
+  }
 );
 
 export default createStructuredSelector({

--- a/components/basemaps/planet-menu/selectors.js
+++ b/components/basemaps/planet-menu/selectors.js
@@ -12,10 +12,6 @@ const COLOR_OPTIONS = [
     label: 'False color (NIR)',
     value: 'cir',
   },
-  {
-    label: 'False color (RGB)',
-    value: 'rgb',
-  },
 ];
 
 const selectBasemapSelected = (state) => state?.map?.settings?.basemap?.name;

--- a/components/basemaps/selectors.js
+++ b/components/basemaps/selectors.js
@@ -28,7 +28,6 @@ const selectPlanetBasemaps = (state) => {
 
 const getGroupedPlanetBasemaps = (state) => {
   const planetBasemaps = state.planet?.data;
-  console.log('planetBasemaps', planetBasemaps);
 
   const visual = planetBasemaps
     ?.filter((bm) => bm.name.includes('visual'))
@@ -36,7 +35,8 @@ const getGroupedPlanetBasemaps = (state) => {
   const cir = planetBasemaps
     ?.filter((bm) => bm.name.includes('analytic'))
     .reverse();
-  return [visual, cir];
+
+  return [visual, cir, cir];
 };
 
 // ES6 provision, replace the hyphens with slashes forces UTC to be calculated from timestamp
@@ -85,6 +85,7 @@ export const getDefaultPlanetBasemaps = createSelector(
     return {
       visual: visual?.[0]?.name,
       cir: cir?.[0]?.name,
+      rgb: cir?.[0]?.name,
     };
   }
 );

--- a/components/basemaps/selectors.js
+++ b/components/basemaps/selectors.js
@@ -28,14 +28,15 @@ const selectPlanetBasemaps = (state) => {
 
 const getGroupedPlanetBasemaps = (state) => {
   const planetBasemaps = state.planet?.data;
-  // Visual is broken for now
-  // const visual = planetBasemaps
-  //   ?.filter((bm) => bm.name.includes('visual'))
-  //   .reverse();
+  console.log('planetBasemaps', planetBasemaps);
+
+  const visual = planetBasemaps
+    ?.filter((bm) => bm.name.includes('visual'))
+    .reverse();
   const cir = planetBasemaps
     ?.filter((bm) => bm.name.includes('analytic'))
     .reverse();
-  return [cir, cir];
+  return [visual, cir];
 };
 
 // ES6 provision, replace the hyphens with slashes forces UTC to be calculated from timestamp

--- a/components/map/selectors.js
+++ b/components/map/selectors.js
@@ -27,6 +27,8 @@ const selectLatest = (state) => state.latest && state.latest.data;
 export const selectGeostore = (state) => state.geostore && state.geostore.data;
 const selectLocation = (state) => state.location && state.location.payload;
 
+const getPlanetSettings = (state) => state.planet;
+
 // CONSTS
 export const getBasemaps = () => basemaps;
 
@@ -60,7 +62,21 @@ export const getMapMaxZoom = createSelector(
 
 export const getBasemapFromState = createSelector(
   getMapSettings,
-  (settings) => settings.basemap
+  getPlanetSettings,
+  ({ basemap }, planet) => {
+    if (basemap.value === 'planet') {
+      return {
+        ...basemap,
+        ...(basemap.color === 'cir' && {
+          color: planet?.options?.analytical?.value || 'cir',
+        }),
+        ...(basemap.color !== 'cir' && {
+          color: planet?.options?.visual?.value || '',
+        }),
+      };
+    }
+    return basemap;
+  }
 );
 
 export const getBasemap = createSelector(

--- a/data/basemaps.js
+++ b/data/basemaps.js
@@ -20,7 +20,7 @@ function sortPlanetBasemaps(items) {
     return {
       name,
       period,
-      date: startDate,
+      date: Date(startDate),
     };
   });
 

--- a/data/basemaps.js
+++ b/data/basemaps.js
@@ -1,0 +1,61 @@
+import sortBy from 'lodash/sortBy';
+import { format, differenceInMonths } from 'date-fns';
+
+// ES6 provision, replace the hyphens with slashes forces UTC to be calculated from timestamp
+// instead of local time
+// interesting article: https://codeofmatt.com/javascript-date-parsing-changes-in-es6/
+const cleanPlanetDate = (dateStr) =>
+  new Date(dateStr.substring(0, 10).replace(/-/g, '/'));
+
+function sortPlanetBasemaps(items) {
+  const init = items.map(({ name, first_acquired, last_acquired } = {}) => {
+    const startDate = cleanPlanetDate(first_acquired);
+    const endDate = cleanPlanetDate(last_acquired);
+    const monthDiff = differenceInMonths(endDate, startDate);
+    const period =
+      monthDiff === 1
+        ? `${format(startDate, 'MMM yyyy')}`
+        : `${format(startDate, 'MMM yyyy')} - ${format(endDate, 'MMM yyyy')}`;
+
+    return {
+      name,
+      period,
+      date: startDate,
+    };
+  });
+
+  return sortBy(init, (i) => {
+    return new Date(i.date);
+  }).reverse();
+}
+
+export default {
+  planet: (data) => {
+    const visual = data?.filter((bm) => bm.name.includes('visual'));
+    const analytical = data?.filter((bm) => bm.name.includes('analytic'));
+
+    const treatVisualAsAnalytical = !visual || visual.length === 0;
+
+    const options = {
+      visual: { label: 'Natural color', value: '', id: 'visual' },
+      analytical: {
+        label: 'False color (NIR)',
+        value: 'cir',
+        id: 'analytical',
+      },
+    };
+
+    if (treatVisualAsAnalytical) {
+      options.visual.value = 'rgb';
+    }
+
+    const sortAnalytical = sortPlanetBasemaps(analytical);
+    const sortVisual = sortPlanetBasemaps(visual);
+
+    return {
+      analytical: sortAnalytical,
+      visual: treatVisualAsAnalytical ? sortAnalytical : sortVisual,
+      options,
+    };
+  },
+};

--- a/pages/api/planet-tiles/[...params].js
+++ b/pages/api/planet-tiles/[...params].js
@@ -6,11 +6,7 @@ export default async function userHandler(req, res) {
     method,
   } = req;
   if (method === 'GET') {
-    const ENV = process.env.NEXT_PUBLIC_FEATURE_ENV;
-    const PLANET_KEY =
-      ENV === 'staging'
-        ? process.env.NEXT_PUBLIC_STAGING_PLANET_API_KEY
-        : process.env.NEXT_PUBLIC_PLANET_API_KEY;
+    const PLANET_KEY = process.env.NEXT_PUBLIC_PLANET_API_KEY;
     try {
       const tile = await axios.get(
         `https://tiles.planet.com/basemaps/v1/planet-tiles/${params?.join(

--- a/pages/api/planet-tiles/[...params].js
+++ b/pages/api/planet-tiles/[...params].js
@@ -6,13 +6,16 @@ export default async function userHandler(req, res) {
     method,
   } = req;
   if (method === 'GET') {
+    const ENV = process.env.NEXT_PUBLIC_FEATURE_ENV;
+    const PLANET_KEY =
+      ENV === 'staging'
+        ? process.env.NEXT_PUBLIC_STAGING_PLANET_API_KEY
+        : process.env.NEXT_PUBLIC_PLANET_API_KEY;
     try {
       const tile = await axios.get(
         `https://tiles.planet.com/basemaps/v1/planet-tiles/${params?.join(
           '/'
-        )}.png?proc=${proc || 'rgb'}&api_key=${
-          process.env.NEXT_PUBLIC_PLANET_API_KEY
-        }`,
+        )}.png?proc=${proc || ''}&api_key=${PLANET_KEY}`,
         {
           responseType: 'arraybuffer',
         }

--- a/providers/planet-provider/reducers.js
+++ b/providers/planet-provider/reducers.js
@@ -1,21 +1,29 @@
+import basemapParser from 'data/basemaps';
 import * as actions from './actions';
 
 export const initialState = {
   loading: false,
-  data: []
+  data: [],
+  analytical: null,
+  visual: null,
+  options: null,
 };
 
-const setPlanetBasemaps = (state, { payload }) => ({
-  ...state,
-  data: payload
-});
+const setPlanetBasemaps = (state, { payload }) => {
+  const additionalParsing = basemapParser.planet(payload);
+  return {
+    ...state,
+    data: payload,
+    ...additionalParsing,
+  };
+};
 
 const setPlanetBasemapsLoading = (state, { payload }) => ({
   ...state,
-  loading: payload
+  loading: payload,
 });
 
 export default {
   [actions.setPlanetBasemaps]: setPlanetBasemaps,
-  [actions.setPlanetBasemapsLoading]: setPlanetBasemapsLoading
+  [actions.setPlanetBasemapsLoading]: setPlanetBasemapsLoading,
 };

--- a/services/planet.js
+++ b/services/planet.js
@@ -2,11 +2,7 @@ import request from 'utils/request';
 
 const REQUEST_URL = 'https://api.planet.com/basemaps/v1/mosaics';
 
-const ENV = process.env.NEXT_PUBLIC_FEATURE_ENV;
-const PLANET_KEY =
-  ENV === 'staging'
-    ? process.env.NEXT_PUBLIC_STAGING_PLANET_API_KEY
-    : process.env.NEXT_PUBLIC_PLANET_API_KEY;
+const PLANET_KEY = process.env.NEXT_PUBLIC_PLANET_API_KEY;
 
 export const fetchPlanetBasemaps = () =>
   request.get(`${REQUEST_URL}?api_key=${PLANET_KEY}&_page_size=1000`);

--- a/services/planet.js
+++ b/services/planet.js
@@ -2,7 +2,11 @@ import request from 'utils/request';
 
 const REQUEST_URL = 'https://api.planet.com/basemaps/v1/mosaics';
 
+const ENV = process.env.NEXT_PUBLIC_FEATURE_ENV;
+const PLANET_KEY =
+  ENV === 'staging'
+    ? process.env.NEXT_PUBLIC_STAGING_PLANET_API_KEY
+    : process.env.NEXT_PUBLIC_PLANET_API_KEY;
+
 export const fetchPlanetBasemaps = () =>
-  request.get(
-    `${REQUEST_URL}?api_key=${process.env.NEXT_PUBLIC_PLANET_API_KEY}&_page_size=1000`
-  );
+  request.get(`${REQUEST_URL}?api_key=${PLANET_KEY}&_page_size=1000`);


### PR DESCRIPTION
## Update

We need to implement this in a way that allows it to work when there are Visual basemaps (using the staging key) and when there are not (using the current production key).

The user should always see2 options:

1. Natural Colour (`proc=''` if visual basemaps are available, else `proc='rgb'` and analytic basemap if not)
2. False Colour (NIR) (always `proc='cir' and analytic basemap`)

## Overview

Adds new code to test new visual basemaps for Planet. Note that is should fix a previous issue where visual basemaps were not returning correctly.

New basemaps have the the following nomenclature:

- `planet_medres_visual_20YY-MM_20YY-MM_mosaic` for 6-monthly mosaics
- `planet_medres_visual_20YY-MM_mosaic` for monthly mosaics

Here 'visual' basemaps need to be sent with the query param `proc=''`, whereas analytic mosaics can be sent with `proc='rgb'` or `proc='cir'` for 'false colour'.

This means that we have 3 options for each time range:

- Visual with `proc=''` (True colour)
- Analytic with `proc='rgb'` (False colour)
- Analytic with `proc='cir'` (False colour NIR)

## Note

Requires a new Planet API key in `.env`: `NEXT_PUBLIC_STAGING_PLANET_API_KEY` which is used when `NEXT_PUBLIC_FEATURE_ENV === 'staging'`.

