### PR TITLE
FIX GFW-92

### DIFF
--- a/.github/workflows/ci-deployment.yml
+++ b/.github/workflows/ci-deployment.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Production
 
 on:
   push:

--- a/.github/workflows/ci-deployment.yml
+++ b/.github/workflows/ci-deployment.yml
@@ -6,7 +6,7 @@ on:
       - master
 jobs:
   cypress-run:
-    name: e2e tests
+    name: e2e tests - production
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-deployment.yml
+++ b/.github/workflows/ci-deployment.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
 jobs:
-  cypress-run:
+  cypress-run-production:
     name: e2e tests - production
     runs-on: ubuntu-latest
     strategy:

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -150,7 +150,6 @@ const getLocationSelect = ({ type, adm0, adm1, adm2, grouped }) => {
 
 // build {where} statement for query
 export const getWHEREQuery = (params) => {
-  console.log('get Where query', params);
   const allPolynames = forestTypes.concat(landCategories);
   const paramKeys = params && Object.keys(params);
   const allowedParams = ALLOWED_PARAMS[params.dataset || 'annual'];

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -150,6 +150,7 @@ const getLocationSelect = ({ type, adm0, adm1, adm2, grouped }) => {
 
 // build {where} statement for query
 export const getWHEREQuery = (params) => {
+  console.log('get Where query', params);
   const allPolynames = forestTypes.concat(landCategories);
   const paramKeys = params && Object.keys(params);
   const allowedParams = ALLOWED_PARAMS[params.dataset || 'annual'];
@@ -178,7 +179,8 @@ export const getWHEREQuery = (params) => {
 
       const zeroString = polynameMeta?.dataType === 'keyword' ? "'0'" : '0';
       const isNumericValue = !!(
-        typeof value === 'number' && !['adm0', 'confidence'].includes(p)
+        typeof value === 'number' ||
+        (!isNaN(value) && !['adm0', 'confidence'].includes(p))
       );
 
       const polynameString = `


### PR DESCRIPTION
This pr fixes the issue reported [here](https://vizzuality.atlassian.net/secure/RapidBoard.jspa?rapidView=11&projectKey=GFW&modal=detail&selectedIssue=GFW-92)

The problem was that our "isNumber" check within the `where` query selection was not accurate enough, as some query parameters passed from external sources will be parsed as `strings` so the previous check `typeof` will not work. What I'm doing now is checking if the string does not return `NaN`. Then we can assume that a current parameter is a number. 

In this case, `adm1` was returned as a string, so when performing the query in the API we get this error: `Operator [=] cannot work with [INTEGER, STRING].`. This fix will ensure that any comparison we sent to the API should be parsed as a number is. 

## Testing instructions

Check the link you posted within the deployed environment, you should have data returned on the dashboard.