### PR TITLE
fix/GFW-161

### DIFF
--- a/components/analysis/components/show-analysis/component.jsx
+++ b/components/analysis/components/show-analysis/component.jsx
@@ -57,7 +57,6 @@ class ShowAnalysis extends PureComponent {
     endDate,
     dateFormat,
     threshold,
-    thresh,
   }) => (
     <li className="draw-stat" key={label}>
       <div className="title">
@@ -68,8 +67,7 @@ class ShowAnalysis extends PureComponent {
             ` (${moment(startDate).format(
               dateFormat || 'YYYY-MM-DD'
             )} to ${moment(endDate).format(dateFormat || 'YYYY-MM-DD')})`}
-          {(thresh || threshold) &&
-            ` with >${threshold || thresh}% canopy density`}
+          {threshold && ` with >${threshold}% canopy density`}
         </span>
       </div>
       <div className="value" style={{ color }}>
@@ -169,7 +167,7 @@ class ShowAnalysis extends PureComponent {
                         downloadUrls &&
                         downloadUrls.length &&
                         downloadUrls.map((d) => d?.label).join(', '),
-                    })
+                    });
                   }}
                   tooltip={{ text: 'Download data' }}
                 >

--- a/components/map/components/legend/index.js
+++ b/components/map/components/legend/index.js
@@ -135,13 +135,21 @@ class Legend extends PureComponent {
 
   onChangeParam = (currentLayer, newParam) => {
     const { setMapSettings, activeDatasets } = this.props;
+
     setMapSettings({
       datasets: activeDatasets.map((l) => {
         const dataset = { ...l };
         if (l.layers.includes(currentLayer.id)) {
           dataset.params = {
             ...dataset.params,
-            ...newParam,
+            ...(newParam.thresh
+              ? {
+                  ...newParam,
+                  threshold: parseInt(newParam.thresh, 10),
+                }
+              : {
+                  ...newParam,
+                }),
           };
         }
         return dataset;

--- a/components/widgets/utils/config.js
+++ b/components/widgets/utils/config.js
@@ -234,7 +234,7 @@ export const getWidgetDatasets = ({
         }),
         ...(threshold && {
           params: {
-            thresh: threshold,
+            threshold,
             visibility: true,
           },
         }),

--- a/services/analysis.js
+++ b/services/analysis.js
@@ -34,15 +34,14 @@ const buildAnalysisUrl = ({
       .format('YYYY-MM-DD')},${moment().format('YYYY-MM-DD')}`;
   }
 
-  const thresh = params.thresh || threshold ? params.thresh || threshold : '';
   const geostore = type === 'geostore' ? adm0 : '';
 
   const queryParams = qs.stringify({
     ...(period && {
       period,
     }),
-    ...(thresh && {
-      thresh,
+    ...(threshold && {
+      threshold: parseInt(threshold, 10),
     }),
     ...(geostore && {
       geostore,

--- a/services/otf-analysis.js
+++ b/services/otf-analysis.js
@@ -67,10 +67,9 @@ class OTFAnalysis {
     // simply replace threshold with it so we can perform user defined analysis
     return {
       ...params,
-      ...(params.thresh &&
-        params.thresh.length > 0 && {
-          threshold: parseInt(params.thresh, 10),
-        }),
+      ...(params.threshold && {
+        threshold: parseInt(params.threshold, 10),
+      }),
     };
   }
 


### PR DESCRIPTION
this pr fixes an issue where thresholds were not applied to widgets.

Cleaned up so we only care about `threshhold` now. We have to verify shaders where we use "thresh" [example](https://github.com/Vizzuality/gfw/blob/develop/providers/datasets-provider/config.js#L494). The previous behaviour was that `thresh` was the dynamic value, when user updates threshold in the UI and threshold was kept the original value at all times. Now I modiy threshold on runtime. If in the shaders we need to compare original `threshhold` i can store another key on fetch `originalThreshhold` or similar.