### PR TITLE
Ci/fix

### DIFF
--- a/.github/workflows/ci-deployment.yml
+++ b/.github/workflows/ci-deployment.yml
@@ -31,3 +31,5 @@ jobs:
           parallel: true
           wait-on-timeout: 120
           wait-on: 'http://localhost:3000'
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.GFW_CYPRESS_KEY }}

--- a/.github/workflows/ci-deployment.yml
+++ b/.github/workflows/ci-deployment.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-
 jobs:
   cypress-run:
     name: e2e tests
@@ -25,7 +24,6 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           build: yarn build
-          build_wait_on: yarn add --save wait-on
           start: yarn start 3000
           group: 'Integration tests'
           parallel: true

--- a/.github/workflows/ci-deployment.yml
+++ b/.github/workflows/ci-deployment.yml
@@ -2,23 +2,10 @@ name: CI
 
 on:
   push:
-    branches-ignore:
+    branches:
       - master
 
 jobs:
-  lint:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.16.2'
-      - name: Install modules
-        run: yarn
-      - name: Run ESLint
-        run: yarn lint
   cypress-run:
     name: e2e tests
     runs-on: ubuntu-latest
@@ -37,9 +24,9 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
-          build: yarn install
+          build: yarn build
           build_wait_on: yarn add --save wait-on
-          start: yarn dev
+          start: yarn start 3000
           group: 'Integration tests'
           parallel: true
           wait-on-timeout: 120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
   cypress-run:
     name: e2e tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - name: Setup Node
         uses: actions/setup-node@v1
@@ -32,4 +36,7 @@ jobs:
         with:
           build: yarn build
           start: yarn start 3000
+          group: 'Integration tests'
+          parallel: true
+          wait-on-timeout: 120
           wait-on: 'http://localhost:3000'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,9 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           build: yarn install
-          build_wait_on: yarn add --save wait-on
           start: yarn dev
           group: 'Integration tests'
+          record: true
           parallel: true
           wait-on-timeout: 120
           wait-on: 'http://localhost:3000'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,5 @@ jobs:
           parallel: true
           wait-on-timeout: 120
           wait-on: 'http://localhost:3000'
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.GFW_CYPRESS_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,7 @@
 name: CI
 
 on:
-  push:
-    branches-ignore:
-      - master
-
+  pull_request:
 jobs:
   lint:
     name: lint

--- a/cypress.json
+++ b/cypress.json
@@ -13,5 +13,6 @@
     "best-practices": 85,
     "seo": 85,
     "pwa": 0
-  }
+  },
+  "projectId": "ga4xsh"
 }


### PR DESCRIPTION
Improve CI duration

1. We have separate actions for production + dev, on dev, we don't run on the build, we simply run on a dev server to speed things up.
2. On production we run the build, it will take a bit longer as we have tons of assets to compile. But I don't see a need to do these asset builds on development.
3. Now we run the jobs only on pr + pr sync.
4. We now run the tasks in parallel for cypres to speed things up even more.