### PR TITLE
fix/GFW-121

### DIFF
--- a/components/widget/component.jsx
+++ b/components/widget/component.jsx
@@ -18,7 +18,7 @@ class Widget extends PureComponent {
     large: PropTypes.bool,
     colors: PropTypes.object,
     simple: PropTypes.bool,
-    caution: PropTypes.string,
+    caution: PropTypes.object,
     datasets: PropTypes.array,
     settings: PropTypes.object,
     settingsConfig: PropTypes.array,

--- a/components/widget/components/widget-caution/component.js
+++ b/components/widget/components/widget-caution/component.js
@@ -5,7 +5,7 @@ import './styles.scss';
 
 class WidgetCaution extends PureComponent {
   static propTypes = {
-    caution: PropTypes.string,
+    caution: PropTypes.object,
     locationType: PropTypes.string,
   };
 

--- a/components/widget/components/widget-footer/component.jsx
+++ b/components/widget/components/widget-footer/component.jsx
@@ -11,7 +11,7 @@ class WidgetFooter extends PureComponent {
   static propTypes = {
     type: PropTypes.string,
     simple: PropTypes.bool,
-    caution: PropTypes.string,
+    caution: PropTypes.object,
     statements: PropTypes.array,
     locationType: PropTypes.string,
     showAttributionLink: PropTypes.bool,
@@ -30,7 +30,11 @@ class WidgetFooter extends PureComponent {
     return (
       <div className={cx('c-widget-footer', { simple })}>
         {caution && (
-          <WidgetCaution type={type} caution={caution} locationType={locationType} />
+          <WidgetCaution
+            type={type}
+            caution={caution}
+            locationType={locationType}
+          />
         )}
         {statementsMapped && !!statementsMapped.length && (
           <div className="notranslate">{ReactHtmlParser(statementsMapped)}</div>

--- a/pages/embed/widget/[widget]/[[...location]].js
+++ b/pages/embed/widget/[widget]/[[...location]].js
@@ -23,7 +23,7 @@ const errorProps = {
   errorTitle: 'Widget Not Found',
 };
 
-const ALLOWED_TYPES = ['global', 'country', 'aoi'];
+const ALLOWED_TYPES = ['geostore', 'global', 'country', 'aoi'];
 
 export const getStaticProps = async ({ params }) => {
   const { location, widget } = params || {};


### PR DESCRIPTION
## Overview

This pr resolves [this](https://vizzuality.atlassian.net/secure/RapidBoard.jspa?rapidView=11&projectKey=GFW&modal=detail&selectedIssue=GFW-121) reported issue. The passed widget is of type `geostore` that was not allowed in `allowed_types`. That's why the widget was not showing.

## Testing

Enter this: http://localhost:3000/embed/widget/treeLossPct/geostore/c738e2286859db9de89a487981337d4e/?location=WyJnZW9zdG9yZSIsImM3MzhlMjI4Njg1OWRiOWRlODlhNDg3OTgxMzM3ZDRlIl0%3D&treeLossPct=eyJoaWdobGlnaHRlZCI6ZmFsc2V9&widget=treeLossPct URL and make sure widget shows for you.


