### PR TITLE
Set wdpa_protected_area__id isNumeric to false

### DIFF
--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -169,18 +169,22 @@ export const getWHEREQuery = (params) => {
       const tableKey =
         polynameMeta &&
         (polynameMeta.tableKey || polynameMeta.tableKeys[dataset || 'annual']);
+
+      const zeroString = polynameMeta?.dataType === 'keyword' ? "'0'" : '0';
+      let isNumericValue = !!(
+        typeof value === 'number' ||
+        (!isNaN(value) && !['adm0', 'confidence'].includes(p))
+      );
+
       let paramKey = p;
       if (p === 'confidence') paramKey = 'confidence__cat';
       if (p === 'threshold') paramKey = 'umd_tree_cover_density__threshold';
       if (p === 'adm0' && type === 'country') paramKey = 'iso';
       if (p === 'adm0' && type === 'geostore') paramKey = 'geostore__id';
-      if (p === 'adm0' && type === 'wdpa') paramKey = 'wdpa_protected_area__id';
-
-      const zeroString = polynameMeta?.dataType === 'keyword' ? "'0'" : '0';
-      const isNumericValue = !!(
-        typeof value === 'number' ||
-        (!isNaN(value) && !['adm0', 'confidence'].includes(p))
-      );
+      if (p === 'adm0' && type === 'wdpa') {
+        paramKey = 'wdpa_protected_area__id';
+        isNumericValue = false;
+      }
 
       const polynameString = `
         ${

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -170,6 +170,12 @@ export const getWHEREQuery = (params) => {
         polynameMeta &&
         (polynameMeta.tableKey || polynameMeta.tableKeys[dataset || 'annual']);
 
+      /* TODO
+       perform better casting / allow to configure types:
+       as for example wdpa_protected_area__id needs to be a string,
+       even that it evaluates as a number.
+       Note that the postgres tables will allow us to cast at the query level.
+      */
       const zeroString = polynameMeta?.dataType === 'keyword' ? "'0'" : '0';
       let isNumericValue = !!(
         typeof value === 'number' ||


### PR DESCRIPTION
## Overview

WDPA ID values are strings in the new tables - ensures sql wraps them in `'`.

## Test

MAP:  Go to map, activate wdpa, select and analyse... Should return an analysis for loss, gain, extent.

DASHBOARD: Go to `localhost.../dashboards/aoi/5ede8debd970e4001bbef545`, widgets should return for loss gain and extent

## NOTE

This section of `analysis-cached.js` where this logic is applied should by config based and not have complex logic when we know the type based on the table keys already. Tests can then verify that these keys are as expected.