### PR TITLE
Remove second nav bar from chart

### DIFF
--- a/layouts/embed/widget/trase-embed-styles.scss
+++ b/layouts/embed/widget/trase-embed-styles.scss
@@ -52,6 +52,10 @@ $trase-font-family-2: 'Merriweather';
   &.-trase {
     .embed-widget {
       overflow: visible;
+
+      .c-composed-chart {
+        overflow: visible;
+      }
     }
 
     .c-widget-header {


### PR DESCRIPTION
## Overview

This is a little PR to remove the internal scrollbar on the embedded chart only on Trase. We removed the outer scroll but the internal one also needed to go

## Demo

Before:

![image](https://user-images.githubusercontent.com/9701591/114042460-be8e4800-9885-11eb-8ff4-aa92e8e0c1d9.png)

After:

![image](https://user-images.githubusercontent.com/9701591/114042400-b1715900-9885-11eb-9e5e-63e52b1347ed.png)

## Notes

This is not urgent. Just notify me when its deployed

## Testing

- It should be tested on Trase Profiles country pages after deploy
