### PR TITLE
Update biomass loss widget, add biomass loss by driver

### DIFF
--- a/components/widget/components/widget-header/components/widget-download-button/component.jsx
+++ b/components/widget/components/widget-header/components/widget-download-button/component.jsx
@@ -72,8 +72,9 @@ class WidgetDownloadButton extends PureComponent {
               'page',
               'page_size',
               'ifl',
+              'yearsRange',
             ].includes(key) && {
-              [snakeCase(key)]: settings[key],
+              [snakeCase(key)]: snakeCase(settings[key]),
             }),
           }),
           {}

--- a/components/widgets/climate/emissions-deforestation-drivers/index.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/index.js
@@ -66,7 +66,7 @@ export default {
     climate: 3,
   },
   settings: {
-    emissionType: 'emissionsAll',
+    gasesIncluded: 'emissionsAll',
     tscDriverGroup: 'all',
     highlighted: false,
     threshold: 30,

--- a/components/widgets/climate/emissions-deforestation-drivers/index.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/index.js
@@ -16,7 +16,7 @@ import { getEmissions } from 'services/analysis-cached';
 import getWidgetProps from './selectors';
 
 const MIN_YEAR = 2001;
-const MAX_YEAR = 2019;
+const MAX_YEAR = 2020;
 
 export default {
   ...treeLoss,
@@ -35,24 +35,13 @@ export default {
       key: 'emissionType',
       label: 'Emissions Type',
       type: 'select',
-    },
-    {
-      key: 'years',
-      label: 'years',
-      endKey: 'endYear',
-      startKey: 'startYear',
-      type: 'range-select',
       border: true,
     },
-    {
-      key: 'threshold',
-      label: 'canopy density',
-      type: 'mini-select',
-      metaKey: 'widget_canopy_density',
-    },
+    ...treeLoss.settingsConfig,
   ],
   chartType: 'composedChart',
   datasets: [
+    // TODO BIOMASS LOSS LAYER
     {
       dataset: POLITICAL_BOUNDARIES_DATASET,
       layers: [DISPUTED_POLITICAL_BOUNDARIES, POLITICAL_BOUNDARIES],
@@ -83,11 +72,11 @@ export default {
   },
   sentences: {
     initial:
-      'In {location} from {startYear} to {endYear}, {totalEmissions} emissions occurred in areas where the dominant drivers of loss resulted in {deforestation}',
+      'In {location} from {startYear} to {endYear}, {totalEmissions} occurred in areas where the dominant drivers of loss resulted in {deforestation}',
     noLoss:
-      'In {location} from {startYear} to {endYear}, <b>no emissions</b> emissions occurred in areas where the dominant drivers of loss resulted in {deforestation}',
+      'In {location} from {startYear} to {endYear}, <b>no emissions</b> in areas where the dominant drivers of loss resulted in {deforestation}',
     globalInitial:
-      'In {location} from {startYear} to {endYear}, {totalEmissions} emissions occurred in areas where the dominant drivers of loss resulted in {deforestation}',
+      'In {location} from {startYear} to {endYear}, {totalEmissions} in areas where the dominant drivers of loss resulted in {deforestation}',
     co2Only: ', considering emissions from CO2 gases only.',
     nonCo2Only: ', considering only emissions from non-CO2 gases only.',
   },

--- a/components/widgets/climate/emissions-deforestation-drivers/index.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/index.js
@@ -1,0 +1,127 @@
+import { all, spread } from 'axios';
+import { getYearsRangeFromMinMax } from 'components/widgets/utils/data';
+
+import {
+  POLITICAL_BOUNDARIES_DATASET,
+  TREE_COVER_LOSS_BY_DOMINANT_DRIVER_DATASET,
+} from 'data/datasets';
+import {
+  DISPUTED_POLITICAL_BOUNDARIES,
+  POLITICAL_BOUNDARIES,
+  TREE_COVER_LOSS_BY_DOMINANT_DRIVER,
+} from 'data/layers';
+
+import treeLoss from 'components/widgets/forest-change/tree-loss';
+import { getExtent, getLoss } from 'services/analysis-cached';
+
+import getWidgetProps from './selectors';
+
+const MIN_YEAR = 2001;
+const MAX_YEAR = 2019;
+
+export default {
+  ...treeLoss,
+  widget: 'emissionsDeforestationDrivers',
+  title: 'Emissions from biomass loss in {location} by driver',
+  types: ['country', 'geostore', 'aoi', 'use', 'wdpa'],
+  admins: ['adm0', 'adm1', 'adm2'],
+  settingsConfig: [
+    {
+      key: 'tscDriverGroup',
+      label: 'drivers',
+      type: 'select',
+    },
+    {
+      key: 'years',
+      label: 'years',
+      endKey: 'endYear',
+      startKey: 'startYear',
+      type: 'range-select',
+      border: true,
+    },
+    {
+      key: 'threshold',
+      label: 'canopy density',
+      type: 'mini-select',
+      metaKey: 'widget_canopy_density',
+    },
+  ],
+  chartType: 'composedChart',
+  datasets: [
+    {
+      dataset: POLITICAL_BOUNDARIES_DATASET,
+      layers: [DISPUTED_POLITICAL_BOUNDARIES, POLITICAL_BOUNDARIES],
+      boundary: true,
+    },
+    {
+      dataset: POLITICAL_BOUNDARIES_DATASET,
+      layers: [DISPUTED_POLITICAL_BOUNDARIES, POLITICAL_BOUNDARIES],
+      boundary: true,
+    },
+    // loss tsc
+    {
+      dataset: TREE_COVER_LOSS_BY_DOMINANT_DRIVER_DATASET,
+      layers: [TREE_COVER_LOSS_BY_DOMINANT_DRIVER],
+    },
+  ],
+  metaKey: '',
+  colors: 'climate',
+  sortOrder: {
+    climate: 2,
+  },
+  settings: {
+    tscDriverGroup: 'all',
+    highlighted: false,
+    extentYear: 2000,
+    threshold: 30,
+  },
+  sentences: {
+    initial:
+      'In {location} from {startYear} to {endYear}, {permPercent} of tree cover loss occurred in areas where the dominant drivers of loss resulted in {deforestation}.',
+    noLoss:
+      'In {location} from {startYear} to {endYear}, <b>no</b> tree cover loss occurred in areas where the dominant drivers of loss resulted in {deforestation}.',
+    globalInitial:
+      '{location} from {startYear} to {endYear}, {permPercent} of tree cover loss occurred in areas where the dominant drivers of loss resulted in {deforestation}.',
+  },
+  whitelists: {
+    checkStatus: true,
+  },
+  getData: (params) =>
+    all([
+      getLoss({ ...params, landCategory: 'tsc', lossTsc: true }),
+      getExtent({ ...params }),
+    ]).then(
+      spread((loss, extent) => {
+        let data = {};
+        if (loss && loss.data && extent && extent.data) {
+          data = {
+            loss: loss.data.data.filter(
+              (d) => d.tsc_tree_cover_loss_drivers__type !== 'Unknown'
+            ),
+            extent: (loss.data.data && extent.data.data[0].value) || 0,
+          };
+        }
+
+        const { startYear, endYear, range } = getYearsRangeFromMinMax(
+          MIN_YEAR,
+          MAX_YEAR
+        );
+        return {
+          ...data,
+          settings: {
+            startYear,
+            endYear,
+            yearsRange: range,
+          },
+          options: {
+            years: range,
+          },
+        };
+      })
+    ),
+  getDataURL: (params) => [
+    getLoss({ ...params, landCategory: 'tsc', lossTsc: true, download: true }),
+    getExtent({ ...params, download: true }),
+  ],
+  getWidgetProps,
+};

--- a/components/widgets/climate/emissions-deforestation-drivers/index.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/index.js
@@ -66,7 +66,7 @@ export default {
     climate: 3,
   },
   settings: {
-    gasesIncluded: 'emissionsAll',
+    gasesIncluded: 'allGases',
     tscDriverGroup: 'all',
     highlighted: false,
     threshold: 30,

--- a/components/widgets/climate/emissions-deforestation-drivers/index.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/index.js
@@ -24,9 +24,7 @@ const MAX_YEAR = 2019;
 export default {
   ...emissionsDeforestation,
   widget: 'emissionsDeforestationDrivers',
-  title: 'Emissions from biomass loss in {location} by driver',
-  categories: ['climate'],
-  types: ['country', 'geostore', 'aoi', 'use', 'wdpa'],
+  title: 'Forest-related greenhouse gas emissions in {location} by driver',
   admins: ['adm0', 'adm1'],
   settingsConfig: [
     {
@@ -36,7 +34,6 @@ export default {
     },
     ...emissionsDeforestation.settingsConfig,
   ],
-  chartType: 'composedChart',
   datasets: [
     // TODO BIOMASS LOSS LAYER
     {
@@ -72,7 +69,7 @@ export default {
   },
   sentences: {
     initial:
-      'In {location} from {startYear} to {endYear}, {totalEmissions} occurred in areas where the dominant drivers of loss resulted in {deforestation}',
+      'In {location} from {startYear} to {endYear}, an average of {totalEmissions} occurred in areas where the dominant drivers of loss resulted in {deforestation}',
     noLoss:
       'In {location} from {startYear} to {endYear}, <b>no emissions</b> in areas where the dominant drivers of loss resulted in {deforestation}',
     globalInitial:

--- a/components/widgets/climate/emissions-deforestation-drivers/index.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/index.js
@@ -26,6 +26,10 @@ export default {
   widget: 'emissionsDeforestationDrivers',
   title: 'Forest-related greenhouse gas emissions in {location} by driver',
   admins: ['adm0', 'adm1'],
+  caution: {
+    visible: ['wdpa', 'country', 'aoi'],
+    text: '2020 data coming soon.',
+  },
   settingsConfig: [
     {
       key: 'tscDriverGroup',
@@ -59,7 +63,7 @@ export default {
   metaKey: '',
   colors: 'climate',
   sortOrder: {
-    climate: 2,
+    climate: 3,
   },
   settings: {
     emissionType: 'emissionsAll',
@@ -74,7 +78,7 @@ export default {
       'In {location} from {startYear} to {endYear}, <b>no emissions</b> in areas where the dominant drivers of loss resulted in {deforestation}',
     globalInitial:
       'In {location} from {startYear} to {endYear}, {totalEmissions} in areas where the dominant drivers of loss resulted in {deforestation}',
-    co2Only: ', considering emissions from CO\u2082 gases only.',
+    co2Only: ', considering emissions from CO\u2082 only.',
     nonCo2Only: ', considering only emissions from non-CO\u2082 gases only.',
   },
   whitelists: {

--- a/components/widgets/climate/emissions-deforestation-drivers/index.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/index.js
@@ -83,11 +83,11 @@ export default {
   },
   sentences: {
     initial:
-      'In {location} from {startYear} to {endYear}, {totalEmissions} occurred in areas where the dominant drivers of loss resulted in {deforestation}',
+      'In {location} from {startYear} to {endYear}, {totalEmissions} emissions occurred in areas where the dominant drivers of loss resulted in {deforestation}',
     noLoss:
-      'In {location} from {startYear} to {endYear}, <b>no</b> occurred in areas where the dominant drivers of loss resulted in {deforestation}',
+      'In {location} from {startYear} to {endYear}, <b>no emissions</b> emissions occurred in areas where the dominant drivers of loss resulted in {deforestation}',
     globalInitial:
-      'In {location} from {startYear} to {endYear}, {totalEmissions} occurred in areas where the dominant drivers of loss resulted in {deforestation}',
+      'In {location} from {startYear} to {endYear}, {totalEmissions} emissions occurred in areas where the dominant drivers of loss resulted in {deforestation}',
     co2Only: ', considering emissions from CO2 gases only.',
     nonCo2Only: ', considering only emissions from non-CO2 gases only.',
   },

--- a/components/widgets/climate/emissions-deforestation-drivers/index.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/index.js
@@ -1,4 +1,5 @@
 import { getYearsRangeFromMinMax } from 'components/widgets/utils/data';
+import biomassLossIsos from 'data/biomass-isos.json';
 
 import {
   POLITICAL_BOUNDARIES_DATASET,
@@ -80,6 +81,7 @@ export default {
     nonCo2Only: ', considering only emissions from non-CO\u2082 gases only.',
   },
   whitelists: {
+    adm0: biomassLossIsos,
     checkStatus: true,
   },
   getData: (params) =>

--- a/components/widgets/climate/emissions-deforestation-drivers/index.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/index.js
@@ -39,7 +39,7 @@ export default {
       type: 'select',
       border: true,
     },
-    ...treeLoss.settingsConfig,
+    ...treeLoss.settingsConfig.filter((el) => el.key !== 'extentYear'),
   ],
   chartType: 'composedChart',
   datasets: [
@@ -82,8 +82,8 @@ export default {
       'In {location} from {startYear} to {endYear}, <b>no emissions</b> in areas where the dominant drivers of loss resulted in {deforestation}',
     globalInitial:
       'In {location} from {startYear} to {endYear}, {totalEmissions} in areas where the dominant drivers of loss resulted in {deforestation}',
-    co2Only: ', considering emissions from CO2 gases only.',
-    nonCo2Only: ', considering only emissions from non-CO2 gases only.',
+    co2Only: ', considering emissions from CO\u2082 gases only.',
+    nonCo2Only: ', considering only emissions from non-CO\u2082 gases only.',
   },
   whitelists: {
     checkStatus: true,

--- a/components/widgets/climate/emissions-deforestation-drivers/index.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/index.js
@@ -23,6 +23,7 @@ export default {
   ...treeLoss,
   widget: 'emissionsDeforestationDrivers',
   title: 'Emissions from biomass loss in {location} by driver',
+  categories: ['climate'],
   types: ['country', 'geostore', 'aoi', 'use', 'wdpa'],
   admins: ['adm0', 'adm1', 'adm2'],
   settingsConfig: [

--- a/components/widgets/climate/emissions-deforestation-drivers/index.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/index.js
@@ -2,11 +2,13 @@ import { getYearsRangeFromMinMax } from 'components/widgets/utils/data';
 
 import {
   POLITICAL_BOUNDARIES_DATASET,
+  CARBON_EMISSIONS_DATASET,
   TREE_COVER_LOSS_BY_DOMINANT_DRIVER_DATASET,
 } from 'data/datasets';
 import {
   DISPUTED_POLITICAL_BOUNDARIES,
   POLITICAL_BOUNDARIES,
+  CARBON_EMISSIONS,
   TREE_COVER_LOSS_BY_DOMINANT_DRIVER,
 } from 'data/layers';
 
@@ -16,7 +18,7 @@ import { getEmissions } from 'services/analysis-cached';
 import getWidgetProps from './selectors';
 
 const MIN_YEAR = 2001;
-const MAX_YEAR = 2020;
+const MAX_YEAR = 2019;
 
 export default {
   ...treeLoss,
@@ -24,7 +26,7 @@ export default {
   title: 'Emissions from biomass loss in {location} by driver',
   categories: ['climate'],
   types: ['country', 'geostore', 'aoi', 'use', 'wdpa'],
-  admins: ['adm0', 'adm1', 'adm2'],
+  admins: ['adm0', 'adm1'],
   settingsConfig: [
     {
       key: 'tscDriverGroup',
@@ -52,6 +54,10 @@ export default {
       layers: [DISPUTED_POLITICAL_BOUNDARIES, POLITICAL_BOUNDARIES],
       boundary: true,
     },
+    {
+      dataset: CARBON_EMISSIONS_DATASET,
+      layers: [CARBON_EMISSIONS],
+    },
     // loss tsc
     {
       dataset: TREE_COVER_LOSS_BY_DOMINANT_DRIVER_DATASET,
@@ -67,7 +73,6 @@ export default {
     emissionType: 'emissionsAll',
     tscDriverGroup: 'all',
     highlighted: false,
-    extentYear: 2000,
     threshold: 30,
   },
   sentences: {

--- a/components/widgets/climate/emissions-deforestation-drivers/index.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/index.js
@@ -12,7 +12,7 @@ import {
   TREE_COVER_LOSS_BY_DOMINANT_DRIVER,
 } from 'data/layers';
 
-import treeLoss from 'components/widgets/forest-change/tree-loss';
+import emissionsDeforestation from 'components/widgets/climate/emissions-deforestation';
 import { getEmissions } from 'services/analysis-cached';
 
 import getWidgetProps from './selectors';
@@ -21,7 +21,7 @@ const MIN_YEAR = 2001;
 const MAX_YEAR = 2019;
 
 export default {
-  ...treeLoss,
+  ...emissionsDeforestation,
   widget: 'emissionsDeforestationDrivers',
   title: 'Emissions from biomass loss in {location} by driver',
   categories: ['climate'],
@@ -33,13 +33,7 @@ export default {
       label: 'drivers',
       type: 'select',
     },
-    {
-      key: 'emissionType',
-      label: 'Emissions Type',
-      type: 'select',
-      border: true,
-    },
-    ...treeLoss.settingsConfig.filter((el) => el.key !== 'extentYear'),
+    ...emissionsDeforestation.settingsConfig,
   ],
   chartType: 'composedChart',
   datasets: [

--- a/components/widgets/climate/emissions-deforestation-drivers/selectors.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/selectors.js
@@ -38,13 +38,13 @@ export const getFilteredData = createSelector(
   [mergeDataWithCetagories, getSettings, getPermCats],
   (data, settings, permCats) => {
     if (isEmpty(data)) return null;
-    const { startYear, endYear, emissionType } = settings;
+    const { startYear, endYear, gasesIncluded } = settings;
     const filteredByYear = data.filter(
       (d) => d.year >= startYear && d.year <= endYear
     );
     const emissionsData = filteredByYear.map((d) => ({
       ...d,
-      selectedEmissions: d[emissionType],
+      selectedEmissions: d[gasesIncluded],
     }));
     const permanentData = emissionsData.filter((d) =>
       permCats.includes(d.bound1)
@@ -188,7 +188,7 @@ export const parseSentence = createSelector(
   (data, settings, locationName, sentences, permCats) => {
     if (isEmpty(data)) return null;
     const { initial, globalInitial, noLoss, co2Only, nonCo2Only } = sentences;
-    const { startYear, endYear, emissionType } = settings;
+    const { startYear, endYear, gasesIncluded } = settings;
     const filteredEmissions =
       data && data.filter((x) => permCats.includes(x.bound1));
 
@@ -202,8 +202,8 @@ export const parseSentence = createSelector(
     if (!totalEmissions) sentence = noLoss;
 
     let emissionString = '.';
-    if (emissionType !== 'emissionsAll') {
-      emissionString = emissionType === 'emissionsCo2' ? co2Only : nonCo2Only;
+    if (gasesIncluded !== 'allGases') {
+      emissionString = gasesIncluded === 'co2Only' ? co2Only : nonCo2Only;
     }
     sentence += emissionString;
 

--- a/components/widgets/climate/emissions-deforestation-drivers/selectors.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/selectors.js
@@ -211,7 +211,7 @@ export const parseSentence = createSelector(
       location: locationName === 'global' ? 'Globally' : locationName,
       startYear,
       endYear,
-      totalEmissions: `${format('.3s')(totalEmissions)}t CO2e`,
+      totalEmissions: `${format('.3s')(totalEmissions)}t of CO\u2082e`,
       component: {
         key: 'deforestation',
         tooltip:

--- a/components/widgets/climate/emissions-deforestation-drivers/selectors.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/selectors.js
@@ -1,0 +1,252 @@
+import { createSelector, createStructuredSelector } from 'reselect';
+import isEmpty from 'lodash/isEmpty';
+import sum from 'lodash/sum';
+import sumBy from 'lodash/sumBy';
+import entries from 'lodash/entries';
+import groupBy from 'lodash/groupBy';
+import findIndex from 'lodash/findIndex';
+import { format } from 'd3-format';
+import sortBy from 'lodash/sortBy';
+import { yearTicksFormatter } from 'components/widgets/utils/data';
+
+import tscLossCategories from 'data/tsc-loss-categories.json';
+
+// get list data
+const getLoss = (state) => state.data && state.data.loss;
+const getSettings = (state) => state.settings;
+const getLocationName = (state) => state.locationLabel;
+const getColors = (state) => state.colors;
+const getSentences = (state) => state.sentences;
+const getTitle = (state) => state.title;
+
+export const getPermCats = createSelector([], () =>
+  tscLossCategories.filter((x) => x.permanent).map((el) => el.value.toString())
+);
+
+export const mergeDataWithCetagories = createSelector(
+  [getLoss, getPermCats],
+  (data, permCats) => {
+    if (isEmpty(data)) return null;
+
+    return data.map((d) => ({
+      ...d,
+      permanent: permCats.includes(d.bound1),
+    }));
+  }
+);
+
+export const getFilteredData = createSelector(
+  [mergeDataWithCetagories, getSettings, getPermCats],
+  (data, settings, permCats) => {
+    if (isEmpty(data)) return null;
+    const { startYear, endYear } = settings;
+    const filteredByYear = data.filter(
+      (d) => d.year >= startYear && d.year <= endYear
+    );
+    const permanentData = filteredByYear.filter((d) =>
+      permCats.includes(d.bound1)
+    );
+    return settings.tscDriverGroup === 'permanent'
+      ? permanentData
+      : filteredByYear;
+  }
+);
+
+export const getAllLoss = createSelector(
+  [mergeDataWithCetagories, getSettings],
+  (data, settings) => {
+    if (isEmpty(data)) return null;
+    const { startYear, endYear } = settings;
+    return data.filter((d) => d.year >= startYear && d.year <= endYear);
+  }
+);
+
+export const getDrivers = createSelector(
+  [getFilteredData, getSettings, getPermCats],
+  (data, settings, permCats) => {
+    if (isEmpty(data)) return null;
+    const groupedData = groupBy(sortBy(data, 'area').reverse(), 'bound1');
+    const filteredData = Object.keys(groupedData)
+      .filter((key) => permCats.includes(key))
+      .reduce(
+        (obj, key) => ({
+          ...obj,
+          [key]: groupedData[key],
+        }),
+        {}
+      );
+
+    const groupedLoss =
+      settings.tscDriverGroup === 'permanent' ? filteredData : groupedData;
+    const sortedLoss = !isEmpty(groupedLoss)
+      ? sortBy(
+          Object.keys(groupedLoss).map((k) => {
+            const cat = tscLossCategories.find((c) => c.value.toString() === k);
+            return {
+              driver: k,
+              position: cat && cat.position,
+              area: sumBy(groupedLoss[k], 'area'),
+              permanent: permCats.includes(k),
+            };
+          }),
+          'area'
+        )
+      : permCats.map((x) => ({
+          driver: x.toString(),
+          area: 0.0,
+        }));
+    return sortedLoss;
+  }
+);
+
+// get lists selected
+export const parseData = createSelector([getFilteredData], (data) => {
+  if (isEmpty(data)) return null;
+  const groupedData = groupBy(data, 'year');
+  const x = Object.keys(groupedData).map((y) => {
+    const groupedByBound = groupBy(groupedData[y], 'bound1');
+    const datakeys = entries(groupedByBound).reduce((acc, [key, value]) => {
+      const areaSum = sumBy(value, 'area');
+      return {
+        ...acc,
+        [`class_${key}`]: areaSum < 1000 ? Math.round(areaSum) : areaSum,
+      };
+    }, {});
+    return {
+      year: y,
+      total: sum(Object.values(datakeys)),
+      ...datakeys,
+    };
+  });
+  return x;
+});
+
+export const parseConfig = createSelector(
+  [getColors, getFilteredData, getDrivers, getSettings],
+  (colors, data, drivers, settings) => {
+    if (isEmpty(data)) return null;
+    const { highlighted } = settings || {};
+    const yKeys = {};
+    const categoryColors = colors.lossDrivers;
+    sortBy(drivers, 'position').forEach((k) => {
+      yKeys[`class_${k.driver}`] = {
+        fill: categoryColors[k.driver],
+        stackId: 1,
+        opacity: !highlighted || (highlighted && k.permanent) ? 1 : 0.3,
+      };
+    });
+    let tooltip = [
+      {
+        key: 'year',
+      },
+      {
+        key: 'total',
+        label: 'Total',
+        unit: 'ha',
+        unitFormat: (value) =>
+          value < 1000 ? Math.round(value) : format('.3s')(value),
+      },
+    ];
+    tooltip = tooltip.concat(
+      sortBy(drivers, 'position')
+        .map((d) => {
+          const tscCat = tscLossCategories.find((c) => c.value === d.driver);
+          const label = tscCat && tscCat.label;
+          return {
+            key: `class_${d.driver}`,
+            label,
+            unit: 'ha',
+            color: categoryColors[d.driver],
+            unitFormat: (value) =>
+              value < 1000 ? Math.round(value) : format('.3s')(value),
+          };
+        })
+        .reverse()
+    );
+    const insertIndex = findIndex(tooltip, { key: 'class_Urbanization' });
+    if (insertIndex > -1) {
+      tooltip.splice(insertIndex, 0, {
+        key: 'break',
+        label: 'Drivers of permanent deforestation:',
+      });
+    }
+    return {
+      height: 250,
+      xKey: 'year',
+      yKeys: {
+        bars: yKeys,
+      },
+      xAxis: {
+        tickFormatter: yearTicksFormatter,
+      },
+      unit: 'ha',
+      tooltip,
+    };
+  }
+);
+
+export const parseSentence = createSelector(
+  [
+    getFilteredData,
+    getAllLoss,
+    getSettings,
+    getLocationName,
+    getSentences,
+    getPermCats,
+  ],
+  (data, allLoss, settings, locationName, sentences, permCats) => {
+    if (isEmpty(data)) return null;
+    const { initial, globalInitial, noLoss } = sentences;
+    const { startYear, endYear } = settings;
+
+    const filteredLoss =
+      data && data.filter((x) => permCats.includes(x.bound1));
+
+    const permLoss =
+      (filteredLoss && filteredLoss.length && sumBy(filteredLoss, 'area')) || 0;
+    const totalLoss =
+      (allLoss && allLoss.length && sumBy(allLoss, 'area')) || 0;
+    const permPercent = (permLoss && (permLoss / totalLoss) * 100) || 0;
+
+    let sentence = locationName === 'global' ? globalInitial : initial;
+    if (!permLoss) sentence = noLoss;
+
+    const params = {
+      location: locationName === 'global' ? 'Globally' : locationName,
+      startYear,
+      endYear,
+      permPercent:
+        permPercent && permPercent < 0.1
+          ? '< 0.1%'
+          : `${format('.2r')(permPercent)}%`,
+      component: {
+        key: 'deforestation',
+        tooltip:
+          'The drivers of permanent deforestation are mainly urbanization and commodity-driven deforestation. Shifting agriculture may or may not lead to deforestation, depending upon the impact and permanence of agricultural activities.',
+      },
+    };
+
+    return {
+      sentence,
+      params,
+    };
+  }
+);
+
+export const parseTitle = createSelector(
+  [getTitle, getLocationName],
+  (title, name) => {
+    let selectedTitle = title.initial;
+    if (name === 'global') {
+      selectedTitle = title.global;
+    }
+    return selectedTitle;
+  }
+);
+
+export default createStructuredSelector({
+  data: parseData,
+  config: parseConfig,
+  sentence: parseSentence,
+  title: parseTitle,
+});

--- a/components/widgets/climate/emissions-deforestation/index.js
+++ b/components/widgets/climate/emissions-deforestation/index.js
@@ -4,8 +4,6 @@ import { getEmissions } from 'services/analysis-cached';
 
 import OTFAnalysis from 'services/otf-analysis';
 
-import biomassLossIsos from 'data/biomass-isos.json';
-
 import {
   POLITICAL_BOUNDARIES_DATASET,
   CARBON_EMISSIONS_DATASET,
@@ -147,9 +145,6 @@ export default {
     threshold: 30,
     startYear: 2001,
     endYear: 2018,
-  },
-  whitelists: {
-    adm0: biomassLossIsos,
   },
   getData: (params) => {
     if (shouldQueryPrecomputedTables(params)) {

--- a/components/widgets/climate/emissions-deforestation/index.js
+++ b/components/widgets/climate/emissions-deforestation/index.js
@@ -73,7 +73,7 @@ const getOTFAnalysis = async (params) => {
 export default {
   ...treeLoss,
   widget: 'emissionsDeforestation',
-  title: 'Emissions from biomass loss in {location}',
+  title: 'Forest-related greenhouse gas emissions in {location}',
   large: true,
   categories: ['climate'],
   types: ['country', 'geostore', 'aoi', 'use', 'wdpa'],
@@ -82,7 +82,7 @@ export default {
   settingsConfig: [
     {
       key: 'emissionType',
-      label: 'Emissions Type',
+      label: 'Greenhouse gases included',
       type: 'select',
       border: true,
     },
@@ -113,6 +113,7 @@ export default {
       key: 'threshold',
       label: 'canopy density',
       type: 'mini-select',
+      whitelist: [30, 50, 75],
       metaKey: 'widget_canopy_density',
     },
   ],
@@ -128,7 +129,7 @@ export default {
     },
   ],
   pendingKeys: ['threshold'],
-  refetchKeys: ['threshold'],
+  refetchKeys: ['threshold', 'landCategory', 'forestType'],
   visible: ['dashboard', 'analysis'],
   metaKey: 'widget_carbon_emissions_tree_cover_loss',
   dataType: 'loss',
@@ -138,9 +139,9 @@ export default {
   },
   sentences: {
     initial:
-      'Between {startYear} and {endYear}, a total of {value} was released into the atmosphere as a result of tree cover loss in {location}. This is equivalent to {annualAvg} per year',
-    co2Only: ', considering emissions from CO\u2082 gases only.',
-    nonCo2Only: ', considering only emissions from non-CO\u2082 gases only.',
+      'Between {startYear} and {endYear}, an average of {annualAvg} per year was released into the atmosphere as a result of tree cover loss in {location}. In total, {value} was emitted in this period',
+    co2Only: ', considering emissions from CO\u2082 only.',
+    nonCo2Only: ', considering emissions from non-CO\u2082 gases only.',
   },
   settings: {
     emissionType: 'emissionsAll',

--- a/components/widgets/climate/emissions-deforestation/index.js
+++ b/components/widgets/climate/emissions-deforestation/index.js
@@ -4,6 +4,8 @@ import { getEmissions } from 'services/analysis-cached';
 
 import OTFAnalysis from 'services/otf-analysis';
 
+import biomassLossIsos from 'data/biomass-isos.json';
+
 import {
   POLITICAL_BOUNDARIES_DATASET,
   CARBON_EMISSIONS_DATASET,
@@ -145,6 +147,9 @@ export default {
     threshold: 30,
     startYear: 2001,
     endYear: 2018,
+  },
+  whitelists: {
+    adm0: biomassLossIsos,
   },
   getData: (params) => {
     if (shouldQueryPrecomputedTables(params)) {

--- a/components/widgets/climate/emissions-deforestation/index.js
+++ b/components/widgets/climate/emissions-deforestation/index.js
@@ -71,6 +71,7 @@ const getOTFAnalysis = async (params) => {
 export default {
   widget: 'emissionsDeforestation',
   title: 'Emissions from biomass loss in {location}',
+  large: true,
   categories: ['climate'],
   types: ['country', 'geostore', 'aoi', 'use', 'wdpa'],
   admins: ['adm0', 'adm1', 'adm2'],
@@ -115,7 +116,7 @@ export default {
   dataType: 'loss',
   colors: 'climate',
   sortOrder: {
-    climate: 2,
+    climate: 1,
   },
   sentences:
     'Between {startYear} and {endYear}, a total of {value} of {type} was released into the atmosphere as a result of tree cover loss in {location}. This is equivalent to {annualAvg} per year.',

--- a/components/widgets/climate/emissions-deforestation/index.js
+++ b/components/widgets/climate/emissions-deforestation/index.js
@@ -85,7 +85,35 @@ export default {
       type: 'select',
       border: true,
     },
-    ...treeLoss.settingsConfig.filter((el) => el.key !== 'extentYear'),
+    {
+      key: 'forestType',
+      label: 'Forest Type',
+      type: 'select',
+      placeholder: 'All tree cover',
+      clearable: true,
+    },
+    {
+      key: 'landCategory',
+      label: 'Land Category',
+      type: 'select',
+      placeholder: 'All categories',
+      clearable: true,
+      border: true,
+    },
+    {
+      key: 'years',
+      label: 'years',
+      endKey: 'endYear',
+      startKey: 'startYear',
+      type: 'range-select',
+      border: true,
+    },
+    {
+      key: 'threshold',
+      label: 'canopy density',
+      type: 'mini-select',
+      metaKey: 'widget_canopy_density',
+    },
   ],
   datasets: [
     {

--- a/components/widgets/climate/emissions-deforestation/index.js
+++ b/components/widgets/climate/emissions-deforestation/index.js
@@ -97,7 +97,7 @@ export default {
     nonCo2Only: ', considering emissions from non-CO\u2082 gases only.',
   },
   settings: {
-    gasesIncluded: 'emissionsAll',
+    gasesIncluded: 'allGases',
     threshold: 30,
     startYear: 2001,
     endYear: 2018,

--- a/components/widgets/climate/emissions-deforestation/index.js
+++ b/components/widgets/climate/emissions-deforestation/index.js
@@ -81,7 +81,7 @@ export default {
   chartType: 'composedChart',
   settingsConfig: [
     {
-      key: 'emissionType',
+      key: 'gasesIncluded',
       label: 'Greenhouse gases included',
       type: 'select',
       border: true,
@@ -144,7 +144,7 @@ export default {
     nonCo2Only: ', considering emissions from non-CO\u2082 gases only.',
   },
   settings: {
-    emissionType: 'emissionsAll',
+    gasesIncluded: 'emissionsAll',
     threshold: 30,
     startYear: 2001,
     endYear: 2018,

--- a/components/widgets/climate/emissions-deforestation/index.js
+++ b/components/widgets/climate/emissions-deforestation/index.js
@@ -31,6 +31,7 @@ import getWidgetProps from './selectors';
 const MIN_YEAR = 2001;
 const MAX_YEAR = 2020;
 
+// To do
 const getOTFAnalysis = async (params) => {
   const analysis = new OTFAnalysis(params.geostore.id);
   analysis.setData(['emissionsDeforestation', 'biomassLoss'], {

--- a/components/widgets/climate/emissions-deforestation/index.js
+++ b/components/widgets/climate/emissions-deforestation/index.js
@@ -130,12 +130,12 @@ export default {
   ],
   pendingKeys: ['threshold'],
   refetchKeys: ['threshold', 'landCategory', 'forestType'],
-  visible: ['dashboard', 'analysis'],
+  visible: ['dashboard', 'analysis', 'aoi'],
   metaKey: 'widget_carbon_emissions_tree_cover_loss',
   dataType: 'loss',
   colors: 'climate',
   sortOrder: {
-    climate: 1,
+    climate: 2,
   },
   sentences: {
     initial:

--- a/components/widgets/climate/emissions-deforestation/selectors.js
+++ b/components/widgets/climate/emissions-deforestation/selectors.js
@@ -5,29 +5,29 @@ import isEmpty from 'lodash/isEmpty';
 import { formatNumber } from 'utils/format';
 import {
   yearTicksFormatter,
-  zeroFillYears
+  zeroFillYears,
 } from 'components/widgets/utils/data';
 
 // get list data
-const getData = state => state.data && state.data.loss;
-const getSettings = state => state.settings;
-const getColors = state => state.colors;
-const getIndicator = state => state.indicator;
-const getLocationName = state => state.locationLabel;
-const getSentences = state => state.sentences;
+const getData = (state) => state.data && state.data.loss;
+const getSettings = (state) => state.settings;
+const getColors = (state) => state.colors;
+const getIndicator = (state) => state.indicator;
+const getLocationName = (state) => state.locationLabel;
+const getSentences = (state) => state.sentences;
 
 export const parseData = createSelector(
   [getData, getSettings],
   (data, settings) => {
     if (isEmpty(data)) return null;
-    const { startYear, endYear, yearsRange } = settings;
-    const years = yearsRange && yearsRange.map(yearObj => yearObj.value);
+    const { startYear, endYear, yearsRange, emissionType } = settings;
+    const years = yearsRange && yearsRange.map((yearObj) => yearObj.value);
     const fillObj = {
       area: 0,
       biomassLoss: 0,
       bound1: null,
       emissions: 0,
-      percentage: 0
+      percentage: 0,
     };
     const zeroFilledData = zeroFillYears(
       data,
@@ -39,61 +39,57 @@ export const parseData = createSelector(
     return (
       zeroFilledData &&
       zeroFilledData
-        .filter(d => d.year >= startYear && d.year <= endYear)
-        .map(d => ({
+        .filter((d) => d.year >= startYear && d.year <= endYear)
+        .map((d) => ({
           ...d,
-          co2LossByYear: d.emissions,
-          biomassLoss: d.biomassLoss
+          emissions: d[emissionType],
         }))
     );
   }
 );
 
-export const parseConfig = createSelector(
-  [getSettings, getColors],
-  (settings, colors) => {
-    const { unit } = settings;
-    const { loss } = colors;
-    return {
-      height: 250,
-      xKey: 'year',
-      yKeys: {
-        bars: {
-          [unit]: {
-            fill: loss.main,
-            background: false
-          }
-        }
-      },
-      xAxis: {
-        tickFormatter: yearTicksFormatter
-      },
-      tooltip: [
-        {
-          key: 'year'
+export const parseConfig = createSelector([getColors], (colors) => {
+  const { loss } = colors;
+  return {
+    height: 250,
+    xKey: 'year',
+    yKeys: {
+      bars: {
+        emissions: {
+          fill: loss.main,
+          background: false,
         },
-        {
-          key: [unit],
-          unit: 't',
-          unitFormat: value => format('.3s')(value)
-        }
-      ],
-      unit: 't',
-      unitFormat: value => format('.2s')(value)
-    };
-  }
-);
+      },
+    },
+    xAxis: {
+      tickFormatter: yearTicksFormatter,
+    },
+    tooltip: [
+      {
+        key: 'year',
+      },
+      {
+        key: 'emissions',
+        unit: 't',
+        unitFormat: (value) => format('.3s')(value),
+        color: loss.main,
+      },
+    ],
+    unit: 't',
+    unitFormat: (value) => format('.2s')(value),
+  };
+});
 
 export const parseSentence = createSelector(
   [parseData, getSettings, getIndicator, getSentences, getLocationName],
-  (data, settings, indicator, sentence, locationName) => {
+  (data, settings, indicator, sentences, locationName) => {
     if (!data || isEmpty(data)) return null;
-    const { startYear, endYear, unit } = settings;
+    const { initial, co2Only, nonCo2Only } = sentences;
+    const { startYear, endYear, emissionType } = settings;
     const totalBiomass = data
-      .map(d => d[unit])
+      .map((d) => d.emissions)
       .reduce((sum, d) => (d ? sum + d : sum));
-    const emissionType =
-      unit === 'biomassLoss' ? 'aboveground biomass' : 'CO\u2082';
+
     let indicatorText = '';
     if (indicator && indicator.value === 'mining') {
       indicatorText = ` ${indicator.label} regions`;
@@ -101,14 +97,19 @@ export const parseSentence = createSelector(
       indicatorText = ` ${indicator.label}`;
     }
 
+    let emissionString = '.';
+    if (emissionType !== 'emissionsAll') {
+      emissionString = emissionType === 'emissionsCo2' ? co2Only : nonCo2Only;
+    }
+    const sentence = initial + emissionString;
+
     const params = {
-      type: emissionType,
-      value: formatNumber({ num: totalBiomass, unit: 't' }),
+      value: `${formatNumber({ num: totalBiomass, unit: 't' })} of CO\u2082e`,
       location: locationName,
       annualAvg: formatNumber({ num: totalBiomass / data.length, unit: 't' }),
       startYear,
       endYear,
-      indicatorText
+      indicatorText,
     };
     return { sentence, params };
   }
@@ -117,5 +118,5 @@ export const parseSentence = createSelector(
 export default createStructuredSelector({
   data: parseData,
   config: parseConfig,
-  sentence: parseSentence
+  sentence: parseSentence,
 });

--- a/components/widgets/climate/emissions-deforestation/selectors.js
+++ b/components/widgets/climate/emissions-deforestation/selectors.js
@@ -70,12 +70,12 @@ export const parseConfig = createSelector([getColors], (colors) => {
       },
       {
         key: 'emissions',
-        unit: 't',
+        unit: 't CO2e',
         unitFormat: (value) => format('.3s')(value),
         color: loss.main,
       },
     ],
-    unit: 't',
+    unit: 't CO2e',
     unitFormat: (value) => format('.2s')(value),
   };
 });

--- a/components/widgets/climate/emissions-deforestation/selectors.js
+++ b/components/widgets/climate/emissions-deforestation/selectors.js
@@ -48,37 +48,47 @@ export const parseData = createSelector(
   }
 );
 
-export const parseConfig = createSelector([getColors], (colors) => {
-  const { loss } = colors;
-  return {
-    height: 250,
-    xKey: 'year',
-    yKeys: {
-      bars: {
-        emissions: {
-          fill: loss.main,
-          background: false,
+export const parseConfig = createSelector(
+  [getColors, getSettings],
+  (colors, settings) => {
+    const { loss } = colors;
+    const { emissionType } = settings;
+    let emissionLabel = 'Emissions';
+    if (emissionType !== 'emissionsAll') {
+      emissionLabel +=
+        emissionType === 'emissionsCo2' ? ' (CO\u2082)' : '(non-CO\u2082)';
+    }
+    return {
+      height: 250,
+      xKey: 'year',
+      yKeys: {
+        bars: {
+          emissions: {
+            fill: loss.main,
+            background: false,
+          },
         },
       },
-    },
-    xAxis: {
-      tickFormatter: yearTicksFormatter,
-    },
-    tooltip: [
-      {
-        key: 'year',
+      xAxis: {
+        tickFormatter: yearTicksFormatter,
       },
-      {
-        key: 'emissions',
-        unit: 't CO2e',
-        unitFormat: (value) => format('.3s')(value),
-        color: loss.main,
-      },
-    ],
-    unit: 't CO2e',
-    unitFormat: (value) => format('.2s')(value),
-  };
-});
+      tooltip: [
+        {
+          key: 'year',
+        },
+        {
+          key: 'emissions',
+          label: emissionLabel,
+          unit: 't CO2e',
+          unitFormat: (value) => format('.3s')(value),
+          color: loss.main,
+        },
+      ],
+      unit: 't CO2e',
+      unitFormat: (value) => format('.2s')(value),
+    };
+  }
+);
 
 export const parseSentence = createSelector(
   [parseData, getSettings, getIndicator, getSentences, getLocationName],

--- a/components/widgets/climate/emissions-deforestation/selectors.js
+++ b/components/widgets/climate/emissions-deforestation/selectors.js
@@ -20,7 +20,7 @@ export const parseData = createSelector(
   [getData, getSettings],
   (data, settings) => {
     if (isEmpty(data)) return null;
-    const { startYear, endYear, yearsRange, emissionType } = settings;
+    const { startYear, endYear, yearsRange, gasesIncluded } = settings;
     const years = yearsRange && yearsRange.map((yearObj) => yearObj.value);
     const fillObj = {
       area: 0,
@@ -42,7 +42,7 @@ export const parseData = createSelector(
         .filter((d) => d.year >= startYear && d.year <= endYear)
         .map((d) => ({
           ...d,
-          emissions: d[emissionType],
+          emissions: d[gasesIncluded],
         }))
     );
   }
@@ -52,11 +52,11 @@ export const parseConfig = createSelector(
   [getColors, getSettings],
   (colors, settings) => {
     const { loss } = colors;
-    const { emissionType } = settings;
+    const { gasesIncluded } = settings;
     let emissionLabel = 'Emissions';
-    if (emissionType !== 'emissionsAll') {
+    if (gasesIncluded !== 'allGases') {
       emissionLabel +=
-        emissionType === 'emissionsCo2' ? ' (CO\u2082)' : '(non-CO\u2082)';
+        gasesIncluded === 'co2Only' ? ' (CO\u2082)' : ' (non-CO\u2082)';
     }
     return {
       height: 250,
@@ -95,7 +95,7 @@ export const parseSentence = createSelector(
   (data, settings, indicator, sentences, locationName) => {
     if (!data || isEmpty(data)) return null;
     const { initial, co2Only, nonCo2Only } = sentences;
-    const { startYear, endYear, emissionType } = settings;
+    const { startYear, endYear, gasesIncluded } = settings;
     const totalBiomass = data
       .map((d) => d.emissions)
       .reduce((sum, d) => (d ? sum + d : sum));
@@ -108,8 +108,8 @@ export const parseSentence = createSelector(
     }
 
     let emissionString = '.';
-    if (emissionType !== 'emissionsAll') {
-      emissionString = emissionType === 'emissionsCo2' ? co2Only : nonCo2Only;
+    if (gasesIncluded !== 'allGases') {
+      emissionString = gasesIncluded === 'co2Only' ? co2Only : nonCo2Only;
     }
     const sentence = initial + emissionString;
 

--- a/components/widgets/forest-change/tree-loss-plantations/index.js
+++ b/components/widgets/forest-change/tree-loss-plantations/index.js
@@ -67,7 +67,7 @@ export default {
     forestChange: 2,
   },
   sentence:
-    'From {startYear} to {endYear}, {percentage} of tree cover loss in {location} occurred within {lossPhrase}. The total loss within natural forest was equivalent to {value} of CO<sub>2</sub> emissions.',
+    'From {startYear} to {endYear}, {percentage} of tree cover loss in {location} occurred within {lossPhrase}. The total loss within natural forest was equivalent to {value} of CO\u2082e emissions.',
   whitelists: {
     indicators: ['plantations'],
     checkStatus: true,

--- a/components/widgets/forest-change/tree-loss/index.js
+++ b/components/widgets/forest-change/tree-loss/index.js
@@ -142,7 +142,7 @@ export default {
       'From {startYear} to {endYear}, {location} lost {loss} of tree cover',
     noLossWithIndicator:
       'From {startYear} to {endYear}, {location} lost {loss} of tree cover in {indicator}',
-    co2Emissions: 'and {emissions} of CO\u2082 emissions',
+    co2Emissions: 'and {emissions} of CO\u2082e emissions',
   },
   settings: {
     threshold: 30,

--- a/components/widgets/forest-change/tree-loss/selectors.js
+++ b/components/widgets/forest-change/tree-loss/selectors.js
@@ -5,35 +5,37 @@ import { format } from 'd3-format';
 import { formatNumber } from 'utils/format';
 import {
   yearTicksFormatter,
-  zeroFillYears
+  zeroFillYears,
 } from 'components/widgets/utils/data';
 
 // get list data
-const getLoss = state => state.data && state.data.loss;
-const getExtent = state => state.data && state.data.extent;
-const getSettings = state => state.settings;
-const getIsTropical = state => state.isTropical;
-const getLocationLabel = state => state.locationLabel;
-const getIndicator = state => state.indicator;
-const getColors = state => state.colors;
-const getSentence = state => state && state.sentence;
+const getLoss = (state) => state.data && state.data.loss;
+const getExtent = (state) => state.data && state.data.extent;
+const getSettings = (state) => state.settings;
+const getIsTropical = (state) => state.isTropical;
+const getLocationLabel = (state) => state.locationLabel;
+const getIndicator = (state) => state.indicator;
+const getColors = (state) => state.colors;
+const getSentence = (state) => state && state.sentence;
 
 const parseData = createSelector(
   [getLoss, getExtent, getSettings],
   (data, extent, settings) => {
     if (!data || isEmpty(data)) return null;
     const { startYear, endYear } = settings;
-    return data.filter(d => d.year >= startYear && d.year <= endYear).map(d => {
-      const percentageLoss = (d.area && d.area && d.area / extent * 100) || 0;
+    return data
+      .filter((d) => d.year >= startYear && d.year <= endYear)
+      .map((d) => {
+        const percentageLoss =
+          (d.area && d.area && (d.area / extent) * 100) || 0;
 
-      return {
-        ...d,
-        area: d.area || 0,
-        emissions: d.emissions || 0,
-        percentage: percentageLoss > 100 ? 100 : percentageLoss
-      };
-
-    });
+        return {
+          ...d,
+          area: d.area || 0,
+          emissions: d.emissions || 0,
+          percentage: percentageLoss > 100 ? 100 : percentageLoss,
+        };
+      });
   }
 );
 
@@ -42,50 +44,49 @@ const zeroFillData = createSelector(
   (data, settings) => {
     if (!data || isEmpty(data)) return null;
     const { startYear, endYear, yearsRange } = settings;
-    const years = yearsRange && yearsRange.map(yearObj => yearObj.value);
+    const years = yearsRange && yearsRange.map((yearObj) => yearObj.value);
     const fillObj = {
       area: 0,
-      biomassLoss: 0,
       bound1: null,
       emissions: 0,
-      percentage: 0
+      percentage: 0,
     };
     return zeroFillYears(data, startYear, endYear, years, fillObj);
   }
 );
 
-const parseConfig = createSelector([getColors], colors => ({
+const parseConfig = createSelector([getColors], (colors) => ({
   height: 250,
   xKey: 'year',
   yKeys: {
     bars: {
       area: {
         fill: colors.main,
-        background: false
-      }
-    }
+        background: false,
+      },
+    },
   },
   xAxis: {
-    tickFormatter: yearTicksFormatter
+    tickFormatter: yearTicksFormatter,
   },
   unit: 'ha',
   tooltip: [
     {
-      key: 'year'
+      key: 'year',
     },
     {
       key: 'area',
       label: 'Tree cover loss',
-      unitFormat: value => formatNumber({ num: value, unit: 'ha' }),
-      color: colors.main
+      unitFormat: (value) => formatNumber({ num: value, unit: 'ha' }),
+      color: colors.main,
     },
     {
       key: 'percentage',
-      unitFormat: value => formatNumber({ num: value, unit: '%' }),
+      unitFormat: (value) => formatNumber({ num: value, unit: '%' }),
       label: 'Percentage of tree cover',
-      color: 'transparent'
-    }
-  ]
+      color: 'transparent',
+    },
+  ],
 }));
 
 const parseSentence = createSelector(
@@ -96,7 +97,7 @@ const parseSentence = createSelector(
     getIsTropical,
     getLocationLabel,
     getIndicator,
-    getSentence
+    getSentence,
   ],
   (data, extent, settings, tropical, locationLabel, indicator, sentences) => {
     if (!data) return null;
@@ -105,14 +106,14 @@ const parseSentence = createSelector(
       withIndicator,
       noLoss,
       noLossWithIndicator,
-      co2Emissions
+      co2Emissions,
     } = sentences;
     const { startYear, endYear, extentYear } = settings;
     const totalLoss = (data && data.length && sumBy(data, 'area')) || 0;
     const totalEmissions =
       (data && data.length && sumBy(data, 'emissions')) || 0;
     const percentageLoss =
-      (totalLoss && extent && totalLoss / extent * 100) || 0;
+      (totalLoss && extent && (totalLoss / extent) * 100) || 0;
     let sentence = indicator ? withIndicator : initial;
     if (totalLoss === 0) {
       sentence = indicator ? noLossWithIndicator : noLoss;
@@ -130,12 +131,12 @@ const parseSentence = createSelector(
       loss: formatNumber({ num: totalLoss, unit: 'ha' }),
       percent: `${format('.2r')(percentageLoss)}%`,
       emissions: `${format('.3s')(totalEmissions)}t`,
-      extentYear
+      extentYear,
     };
 
     return {
       sentence,
-      params
+      params,
     };
   }
 );
@@ -143,5 +144,5 @@ const parseSentence = createSelector(
 export default createStructuredSelector({
   data: zeroFillData,
   config: parseConfig,
-  sentence: parseSentence
+  sentence: parseSentence,
 });

--- a/components/widgets/manifest.js
+++ b/components/widgets/manifest.js
@@ -41,6 +41,7 @@ import USLandCover from 'components/widgets/land-cover/us-land-cover';
 import woodyBiomass from 'components/widgets/climate/whrc-biomass/';
 import soilBiomass from 'components/widgets/climate/soil-organic';
 import emissionsDeforestation from 'components/widgets/climate/emissions-deforestation';
+import emissionsDeforestationDrivers from 'components/widgets/climate/emissions-deforestation-drivers';
 import carbonStock from 'components/widgets/climate/carbon-stock';
 
 // Land Use
@@ -91,6 +92,7 @@ export default {
   // climate
   // emissions,
   emissionsDeforestation,
+  emissionsDeforestationDrivers,
   woodyBiomass,
   soilBiomass,
   carbonStock,

--- a/components/widgets/options.js
+++ b/components/widgets/options.js
@@ -2,6 +2,7 @@ import forestType from 'data/forest-types';
 import landCategory from 'data/land-categories';
 import threshold from 'data/thresholds.json';
 import unit from 'data/units.json';
+import emissionType from 'data/emission-types.json';
 import variable from 'data/variables.json';
 import period from 'data/periods.json';
 import extentYear from 'data/extent-years.json';
@@ -19,6 +20,7 @@ export default {
   landCategory: landCategory.filter((l) => !l.hidden),
   threshold,
   unit,
+  emissionType,
   period,
   extentYear,
   tscDriverGroup,

--- a/components/widgets/options.js
+++ b/components/widgets/options.js
@@ -2,7 +2,7 @@ import forestType from 'data/forest-types';
 import landCategory from 'data/land-categories';
 import threshold from 'data/thresholds.json';
 import unit from 'data/units.json';
-import emissionType from 'data/emission-types.json';
+import gasesIncluded from 'data/emission-gases.json';
 import variable from 'data/variables.json';
 import period from 'data/periods.json';
 import extentYear from 'data/extent-years.json';
@@ -20,7 +20,7 @@ export default {
   landCategory: landCategory.filter((l) => !l.hidden),
   threshold,
   unit,
-  emissionType,
+  gasesIncluded,
   period,
   extentYear,
   tscDriverGroup,

--- a/cypress/integration/widget.js
+++ b/cypress/integration/widget.js
@@ -21,7 +21,7 @@ const testConfig = [
         visit: '/dashboards/country/IDN',
         test: 'dashboard-header-sentence',
         sentence:
-          'In 2001, {location} had {primaryForest} of primary forest*, extending over {percentagePrimaryForest} of its land area. In {year}, it lost {primaryLoss} of primary forest*, equivalent to {emissionsPrimary} of CO₂ of emissions.',
+          'In 2001, {location} had {primaryForest} of primary forest*, extending over {percentagePrimaryForest} of its land area. In {year}, it lost {primaryLoss} of primary forest*, equivalent to {emissionsPrimary} of CO\u2082e of emissions.',
       },
       {
         slug: 'indonesiaAdm1',
@@ -30,7 +30,7 @@ const testConfig = [
         visit: '/dashboards/country/IDN/1',
         test: 'dashboard-header-sentence',
         sentence:
-          'In 2001, {location} had {primaryForest} of primary forest*, extending over {percentagePrimaryForest} of its land area. In {year}, it lost {primaryLoss} of primary forest*, equivalent to {emissionsPrimary} of CO₂ of emissions.',
+          'In 2001, {location} had {primaryForest} of primary forest*, extending over {percentagePrimaryForest} of its land area. In {year}, it lost {primaryLoss} of primary forest*, equivalent to {emissionsPrimary} of CO\u2082e of emissions.',
       },
       {
         slug: 'indonesiaAdm2',
@@ -39,7 +39,7 @@ const testConfig = [
         visit: '/dashboards/country/IDN/1/1',
         test: 'dashboard-header-sentence',
         sentence:
-          'In 2001, {location} had {primaryForest} of primary forest*, extending over {percentagePrimaryForest} of its land area. In {year}, it lost {primaryLoss} of primary forest*, equivalent to {emissionsPrimary} of CO₂ of emissions.',
+          'In 2001, {location} had {primaryForest} of primary forest*, extending over {percentagePrimaryForest} of its land area. In {year}, it lost {primaryLoss} of primary forest*, equivalent to {emissionsPrimary} of CO\u2082e of emissions.',
       },
       {
         slug: 'plantationsIso',
@@ -48,7 +48,7 @@ const testConfig = [
         visit: '/dashboards/country/ESP',
         test: 'dashboard-header-sentence',
         sentence:
-          'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {naturalLoss} of natural forest, equivalent to {naturalEmissions} of CO₂ of emissions.',
+          'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {naturalLoss} of natural forest, equivalent to {naturalEmissions} of CO\u2082e of emissions.',
       },
       {
         slug: 'plantationsAdm1',
@@ -57,7 +57,7 @@ const testConfig = [
         visit: '/dashboards/country/ESP/12',
         test: 'dashboard-header-sentence',
         sentence:
-          'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {naturalLoss} of natural forest, equivalent to {naturalEmissions} of CO₂ of emissions.',
+          'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {naturalLoss} of natural forest, equivalent to {naturalEmissions} of CO\u2082e of emissions.',
       },
       {
         slug: 'plantationsAdm2',
@@ -66,7 +66,7 @@ const testConfig = [
         visit: '/dashboards/country/ESP/12/1',
         test: 'dashboard-header-sentence',
         sentence:
-          'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {naturalLoss} of natural forest, equivalent to {naturalEmissions} of CO₂ of emissions.',
+          'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {naturalLoss} of natural forest, equivalent to {naturalEmissions} of CO\u2082e of emissions.',
       },
       {
         slug: 'plantationsTropicalIso',
@@ -75,7 +75,7 @@ const testConfig = [
         visit: '/dashboards/country/MYS',
         test: 'dashboard-header-sentence',
         sentence:
-          'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {naturalLoss} of natural forest, equivalent to {emissions} of CO\u2082 of emissions.',
+          'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {naturalLoss} of natural forest, equivalent to {emissions} of CO\u2082e of emissions.',
       },
       {
         slug: 'plantationsTropicalAdm1',
@@ -84,7 +84,7 @@ const testConfig = [
         visit: '/dashboards/country/MYS/14',
         test: 'dashboard-header-sentence',
         sentence:
-          'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {naturalLoss} of natural forest, equivalent to {emissions} of CO\u2082 of emissions.',
+          'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {naturalLoss} of natural forest, equivalent to {emissions} of CO\u2082e of emissions.',
       },
       {
         slug: 'plantationsTropicalAdm2',
@@ -93,7 +93,7 @@ const testConfig = [
         visit: '/dashboards/country/MYS/14/31',
         test: 'dashboard-header-sentence',
         sentence:
-          'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {naturalLoss} of natural forest, equivalent to {emissions} of CO\u2082 of emissions.',
+          'In 2010, {location} had {naturalForest} of natural forest, extending over {percentage} of its land area. In {year}, it lost {naturalLoss} of natural forest, equivalent to {emissions} of CO\u2082e of emissions.',
       },
       {
         slug: 'lossIso',

--- a/data/colors.json
+++ b/data/colors.json
@@ -36,6 +36,13 @@
     "loss": {
       "main": "#DF511E",
       "secondary": "#F9A000"
+    },
+    "lossDrivers": {
+      "Commodity driven deforestation": "#F41D36",
+      "Shifting agriculture": "#efd31a",
+      "Forestry": "#2FBF71",
+      "Wildfire": "#ad6824",
+      "Urbanization": "#B235CC"
     }
   },
   "plantations": {

--- a/data/colors.json
+++ b/data/colors.json
@@ -38,11 +38,11 @@
       "secondary": "#F9A000"
     },
     "lossDrivers": {
-      "Commodity driven deforestation": "#F41D36",
-      "Shifting agriculture": "#efd31a",
-      "Forestry": "#2FBF71",
-      "Wildfire": "#ad6824",
-      "Urbanization": "#B235CC"
+      "Commodity driven deforestation": "#DF511E",
+      "Shifting agriculture": "#F9A000",
+      "Forestry": "#898522",
+      "Wildfire": "#895122",
+      "Urbanization": "#892227"
     }
   },
   "plantations": {

--- a/data/datasets.js
+++ b/data/datasets.js
@@ -7,6 +7,8 @@ export const FOREST_GAIN_DATASET = 'tree-cover-gain';
 export const FOREST_EXTENT_DATASET = 'tree-cover';
 export const BIOMASS_LOSS_DATASET =
   'carbon-dioxide-emissions-from-tree-cover-loss';
+export const CARBON_EMISSIONS_DATASET = 'carbon-emissions';
+
 export const SOIL_CARBON_DENSITY_DATASET = 'soil-carbon-density';
 export const TREE_BIOMASS_DENSITY_DATASET = 'tree-biomass-density';
 export const PROJECTED_CARBON_STORAGE_FOREST_REGROWTH_DATASET =

--- a/data/emission-gases.json
+++ b/data/emission-gases.json
@@ -9,6 +9,7 @@
   },
   {
     "label": "Non-CO\u2082 emissions",
-    "value": "nonCo2Gases"
+    "value": "nonCo2Gases",
+    "infoText": "Includes methane (CH\u2084) and nitrous oxide (N\u2082O)"
   }
 ]

--- a/data/emission-gases.json
+++ b/data/emission-gases.json
@@ -1,14 +1,14 @@
 [
   {
     "label": "All gases",
-    "value": "emissionsAll"
+    "value": "allGases"
   },
   {
     "label": "CO\u2082 emissions only",
-    "value": "emissionsCo2"
+    "value": "co2Only"
   },
   {
     "label": "Non-CO\u2082 emissions",
-    "value": "emissionsNonCo2"
+    "value": "nonCo2Gases"
   }
 ]

--- a/data/emission-types.json
+++ b/data/emission-types.json
@@ -1,0 +1,14 @@
+[
+  {
+    "label": "All emissions gases",
+    "value": "emissionsAll"
+  },
+  {
+    "label": "CO2 emissions only",
+    "value": "emissionsCo2"
+  },
+  {
+    "label": "Non-CO2 emissions",
+    "value": "emissionsNonCo2"
+  }
+]

--- a/data/emission-types.json
+++ b/data/emission-types.json
@@ -1,14 +1,14 @@
 [
   {
-    "label": "All emissions gases",
+    "label": "All gases",
     "value": "emissionsAll"
   },
   {
-    "label": "CO2 emissions only",
+    "label": "CO\u2082 emissions only",
     "value": "emissionsCo2"
   },
   {
-    "label": "Non-CO2 emissions",
+    "label": "Non-CO\u2082 emissions",
     "value": "emissionsNonCo2"
   }
 ]

--- a/data/layers.js
+++ b/data/layers.js
@@ -8,6 +8,7 @@ export const TREE_COVER_LOSS_BY_DOMINANT_DRIVER =
   'tree-cover-loss-by-dominant-driver';
 export const RIVER_BASINS_BOUNDARIES = 'river-basin-boundaries';
 export const BIOMASS_LOSS = 'carbon-dioxide-emissions-from-tree-cover-loss';
+export const CARBON_EMISSIONS = 'carbon-emissions-2001-2020';
 export const SOIL_CARBON_DENSITY = 'soil-carbon-density';
 export const TREE_BIOMASS_DENSITY = 'tree-biomass-density';
 export const BIODIVERSITY_HOTSPOTS_2016 = 'biodiversity-hot-spots-2016';

--- a/providers/geodescriber-provider/selectors.js
+++ b/providers/geodescriber-provider/selectors.js
@@ -22,7 +22,7 @@ const adminSentences = {
     IDN:
       'In 2001, {location} had {primaryForest} of primary forest*, extending over {percentagePrimaryForest} of its land area. In {year}, it lost {primaryLoss} of primary forest*, equivalent to {emissionsPrimary} of CO₂ of emissions.',
   },
-  co2Emissions: ', equivalent to {emissions} of CO\u2082 of emissions.',
+  co2Emissions: ', equivalent to {emissions} of CO\u2082e of emissions.',
   end: '.',
 };
 

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -365,7 +365,7 @@ export const getLoss = (params) => {
 
 // summed loss for single location
 export const getEmissions = (params) => {
-  const { forestType, landCategory, ifl, download } = params || {};
+  // const { forestType, landCategory, ifl, download } = params || {};
   const { emissions, emissionsByDriver } = SQL_QUERIES;
   const query = params.byDriver ? emissionsByDriver : emissions;
   const url = encodeURI(
@@ -402,7 +402,7 @@ export const getEmissions = (params) => {
         year: d.umd_tree_cover_loss__year,
         emissionsAll: d.gfw_gross_emissions_co2e_all_gases__Mg,
         emissionsCo2: d.gfw_gross_emissions_co2e_co2_only__Mg,
-        emissionsNonCo2: d.gfw_gross_emissions_co2e_non_co2__Mg
+        emissionsNonCo2: d.gfw_gross_emissions_co2e_non_co2__Mg,
       })),
     },
   }));

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -399,9 +399,9 @@ export const getEmissions = (params) => {
         ...d,
         bound1: d.tsc_tree_cover_loss_drivers__type,
         year: d.umd_tree_cover_loss__year,
-        emissionsAll: d.gfw_gross_emissions_co2e_all_gases__Mg,
-        emissionsCo2: d.gfw_gross_emissions_co2e_co2_only__Mg,
-        emissionsNonCo2: d.gfw_gross_emissions_co2e_non_co2__Mg,
+        allGases: d.gfw_gross_emissions_co2e_all_gases__Mg,
+        co2Only: d.gfw_gross_emissions_co2e_co2_only__Mg,
+        nonCo2Gases: d.gfw_gross_emissions_co2e_non_co2__Mg,
       })),
     },
   }));

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -14,9 +14,9 @@ const VIIRS_START_YEAR = 2012;
 
 const SQL_QUERIES = {
   lossTsc:
-    'SELECT tsc_tree_cover_loss_drivers__type, umd_tree_cover_loss__year, SUM(umd_tree_cover_loss__ha) AS umd_tree_cover_loss__ha, SUM("whrc_aboveground_biomass_loss__Mg") AS "whrc_aboveground_biomass_loss__Mg", SUM("whrc_aboveground_co2_emissions__Mg") AS "whrc_aboveground_co2_emissions__Mg" FROM data {WHERE} GROUP BY tsc_tree_cover_loss_drivers__type, umd_tree_cover_loss__year',
+    'SELECT tsc_tree_cover_loss_drivers__type, umd_tree_cover_loss__year, SUM(umd_tree_cover_loss__ha) AS umd_tree_cover_loss__ha, SUM("gfw_gross_emissions_co2e_all_gases__Mg") AS "gfw_gross_emissions_co2e_all_gases__Mg" FROM data {WHERE} GROUP BY tsc_tree_cover_loss_drivers__type, umd_tree_cover_loss__year',
   loss:
-    'SELECT {select_location}, umd_tree_cover_loss__year, SUM("whrc_aboveground_biomass_loss__Mg") AS "whrc_aboveground_biomass_loss__Mg", SUM("whrc_aboveground_co2_emissions__Mg") AS "whrc_aboveground_co2_emissions__Mg", SUM(umd_tree_cover_loss__ha) AS umd_tree_cover_loss__ha FROM data {WHERE} GROUP BY umd_tree_cover_loss__year, {location} ORDER BY umd_tree_cover_loss__year, {location}',
+    'SELECT {select_location}, umd_tree_cover_loss__year, SUM(umd_tree_cover_loss__ha) AS umd_tree_cover_loss__ha, SUM("gfw_gross_emissions_co2e_all_gases__Mg") AS "gfw_gross_emissions_co2e_all_gases__Mg" FROM data {WHERE} GROUP BY umd_tree_cover_loss__year, {location} ORDER BY umd_tree_cover_loss__year, {location}',
   emissions:
     'SELECT {select_location}, umd_tree_cover_loss__year, SUM("gfw_gross_emissions_co2e_all_gases__Mg") AS "gfw_gross_emissions_co2e_all_gases__Mg", SUM("gfw_gross_emissions_co2e_non_co2__Mg") AS "gfw_gross_emissions_co2e_non_co2__Mg", SUM("gfw_gross_emissions_co2e_co2_only__Mg") AS "gfw_gross_emissions_co2e_co2_only__Mg" FROM data {WHERE} GROUP BY umd_tree_cover_loss__year, {location} ORDER BY umd_tree_cover_loss__year, {location}',
   emissionsByDriver:
@@ -357,8 +357,7 @@ export const getLoss = (params) => {
         bound1: d.tsc_tree_cover_loss_drivers__type,
         year: d.umd_tree_cover_loss__year,
         area: d.umd_tree_cover_loss__ha,
-        emissions: d.whrc_aboveground_co2_emissions__Mg,
-        biomassLoss: d.whrc_aboveground_biomass_loss__Mg,
+        emissions: d.gfw_gross_emissions_co2e_all_gases__Mg,
       })),
     },
   }));
@@ -442,8 +441,7 @@ export const getLossGrouped = (params) => {
         ...d,
         year: d.umd_tree_cover_loss__year,
         area: d.umd_tree_cover_loss__ha,
-        emissions: d.whrc_aboveground_co2_emissions__Mg,
-        biomassLoss: d.whrc_aboveground_biomass_loss__Mg,
+        emissions: d.gfw_gross_emissions_co2e_all_gases__Mg,
       })),
     },
   }));

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -386,9 +386,9 @@ export const getEmissions = (params) => {
   if (download) {
     const indicator = getIndicator(forestType, landCategory, ifl);
     return {
-      name: `biomass_emissions${byDriver ? '_by_driver' : ''}${
+      name: `Forest_related_GHG_emissions__${byDriver ? '_by_driver' : ''}${
         indicator ? `_in_${snakeCase(indicator.label)}` : ''
-      }__Mt`,
+      }`,
       url: getDownloadUrl(url),
     };
   }

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -365,7 +365,7 @@ export const getLoss = (params) => {
 
 // summed loss for single location
 export const getEmissions = (params) => {
-  // const { forestType, landCategory, ifl, download } = params || {};
+  const { forestType, landCategory, ifl, download } = params || {};
   const { emissions, emissionsByDriver } = SQL_QUERIES;
   const query = params.byDriver ? emissionsByDriver : emissions;
   const url = encodeURI(
@@ -382,17 +382,16 @@ export const getEmissions = (params) => {
       .replace('{WHERE}', getWHEREQuery({ ...params, dataset: 'annual' }))
   );
 
-  // TODO
-  // if (download) {
-  //   const indicator = getIndicator(forestType, landCategory, ifl);
-  //   return {
-  //     name: `treecover_loss${
-  //       indicator ? `_in_${snakeCase(indicator.label)}` : ''
-  //     }__ha`,
-  //     url: getDownloadUrl(url),
-  //   };
-  // }
-
+  if (download) {
+    const indicator = getIndicator(forestType, landCategory, ifl);
+    return {
+      name: `biomass_emissions${
+        indicator ? `_in_${snakeCase(indicator.label)}` : ''
+      }__Mt`,
+      url: getDownloadUrl(url),
+    };
+  }
+  console.log('url', url);
   return apiRequest.get(url).then((response) => ({
     ...response,
     data: {

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -385,9 +385,9 @@ export const getEmissions = (params) => {
   if (download) {
     const indicator = getIndicator(forestType, landCategory, ifl);
     return {
-      name: `Forest_related_GHG_emissions${byDriver ? '_by_driver' : ''}${
-        indicator ? `_in_${snakeCase(indicator.label)}` : ''
-      }`,
+      name: `Forest_related_GHG_emissions${
+        byDriver ? '_by_dominant_driver' : ''
+      }${indicator ? `_in_${snakeCase(indicator.label)}` : ''}`,
       url: getDownloadUrl(url),
     };
   }

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -386,7 +386,7 @@ export const getEmissions = (params) => {
   if (download) {
     const indicator = getIndicator(forestType, landCategory, ifl);
     return {
-      name: `Forest_related_GHG_emissions__${byDriver ? '_by_driver' : ''}${
+      name: `Forest_related_GHG_emissions${byDriver ? '_by_driver' : ''}${
         indicator ? `_in_${snakeCase(indicator.label)}` : ''
       }`,
       url: getDownloadUrl(url),


### PR DESCRIPTION
## Overview

Updates to new biomass loss keys from the postgres tables, updating the existing Biomass Loss widget and adding a new Loss by Driver widget.

<img width="984" alt="Screen Shot 2021-04-26 at 14 05 45" src="https://user-images.githubusercontent.com/30242314/116079793-887c0100-a698-11eb-8bf2-4764283fc996.png">

More to follow...

## To do

- [x] Tidy drivers code, rename vars and make it more readable
- [x] Update Biomass loss widget
- [x] Biomass widget to inherit Loss widget index
- [x] Fix downloads
- [ ] ~Fix OTF on Biomass Emissions~
- [ ] ~Add OTF to Biomass Emissions by Driver~
- [x] Update loss widgets to use new data
- [x] Update header sentence likewise