### PR TITLE
Fix/global sentence gfw 186

### DIFF
--- a/components/widgets/fires/fires-ranked/index.js
+++ b/components/widgets/fires/fires-ranked/index.js
@@ -73,21 +73,21 @@ export default {
     densityWithInd:
       'In the last {timeframe} in {location}, the region with the <b>highest density</b> of fires within {indicator} was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of all alerts detected in {location} in the same period.',
     countsInitial:
-      'In the last {timeframe} in {location}, the region with the <b>most</b> fire alerts was {topRegion}, with {topRegionCount} fire alerts. This represents {topRegionPerc} of all alerts detected in {location} in the same period.',
+      'In the last {timeframe} in {location}, the region with the <b>most</b> fire alerts was {topRegion}, with {topRegionCount} fire alerts. This represents {topRegionPerc} of all alerts detected {location} in the same period.',
     countsWithInd:
-      'In the last {timeframe} in {location}, the region with the <b>most</b> fire alerts within {indicator} was {topRegion}, with {topRegionCount} fire alerts. This represents {topRegionPerc} of all alerts detected in {location} in the same period.',
+      'In the last {timeframe} in {location}, the region with the <b>most</b> fire alerts within {indicator} was {topRegion}, with {topRegionCount} fire alerts. This represents {topRegionPerc} of all alerts detected {location} in the same period.',
     initialGlobal:
-      'In the last {timeframe}, the country with the most {significant} number of fire alerts <b>globally</b> was {topRegion}, with {topRegionCount} fire alerts.  This represents {topRegionPerc} of all alerts detected in {location} and is {status} compared to the number of fires in the same period going back to <b>2012</b>.',
+      'In the last {timeframe}, the country with the most {significant} number of fire alerts <b>globally</b> was {topRegion}, with {topRegionCount} fire alerts.  This represents {topRegionPerc} of all alerts detected {location} and is {status} compared to the number of fires in the same period going back to <b>2012</b>.',
     withIndGlobal:
-      'In the last {timeframe}, the country with the most {significant} number of fire alerts within {indicator} <b>globally</b> was {topRegion}, with {topRegionCount} fire alerts.  This represents {topRegionPerc} of all alerts detected <b>globally</b> and is {status} compared to the number of fires in the same period going back to <b>2012</b>.',
+      'In the last {timeframe}, the country with the most {significant} number of fire alerts within {indicator} <b>globally</b> was {topRegion}, with {topRegionCount} fire alerts.  This represents {topRegionPerc} of all alerts {location} and is {status} compared to the number of fires in the same period going back to <b>2012</b>.',
     densityInitialGlobal:
-      'In the last {timeframe}, the country with the <b>highest density</b> of fires <b>globally</b> was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of all alerts detected <b>globally</b> in the same period.',
+      'In the last {timeframe}, the country with the <b>highest density</b> of fires <b>globally</b> was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of all alerts {location} in the same period.',
     densityWithIndGlobal:
-      'In the last {timeframe}, the country with the <b>highest density</b> of fires within {indicator} <b>globally</b> was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of all alerts detected <b>globally</b> in the same period.',
+      'In the last {timeframe}, the country with the <b>highest density</b> of fires within {indicator} <b>globally</b> was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of all alerts {location} in the same period.',
     countsInitialGlobal:
-      'In the last {timeframe}, the country with the <b>most</b> fire alerts <b>globally</b> was {topRegion}, with {topRegionCount} fire alerts. This represents {topRegionPerc} of all alerts detected <b>globally</b> in the same period.',
+      'In the last {timeframe}, the country with the <b>most</b> fire alerts <b>globally</b> was {topRegion}, with {topRegionCount} fire alerts. This represents {topRegionPerc} of all alerts {location} in the same period.',
     countsWithIndGlobal:
-      'In the last {timeframe}, the country with the <b>most</b> fire alerts within {indicator} <b>globally</b> was {topRegion}, with {topRegionCount} fire alerts. This represents {topRegionPerc} of all alerts detected <b>globally</b> in the same periodd.',
+      'In the last {timeframe}, the country with the <b>most</b> fire alerts within {indicator} <b>globally</b> was {topRegion}, with {topRegionCount} fire alerts. This represents {topRegionPerc} of all alerts {location} in the same periodd.',
   },
   settings: {
     unit: 'significance',

--- a/components/widgets/fires/fires-ranked/selectors.js
+++ b/components/widgets/fires/fires-ranked/selectors.js
@@ -9,6 +9,7 @@ import { format } from 'd3-format';
 import groupBy from 'lodash/groupBy';
 import sumBy from 'lodash/sumBy';
 import moment from 'moment';
+import { formatNumber } from 'utils/format';
 
 import {
   stdDevData,
@@ -226,10 +227,10 @@ export const parseSentence = createSelector(
         color: statusColor,
       },
       topRegion,
-      topRegionCount: format(',')(topRegionCount),
-      topRegionPerc: topRegionPerc ? `${format('.2r')(topRegionPerc)}%` : '0%',
+      topRegionCount: formatNumber({ num: topRegionCount, unit: 'counts' }),
+      topRegionPerc: formatNumber({ num: topRegionPerc, unit: '%' }),
       topRegionDensity: `${format('.3r')(topRegionDensity)} fires/Mha`,
-      location: locationName,
+      location: locationName === 'global' ? 'globally' : locationName,
       indicator: `${indicator ? `${indicator.label}` : ''}`,
       component:
         unit === 'significance'

--- a/components/widgets/land-cover/fao-cover/selectors.js
+++ b/components/widgets/land-cover/fao-cover/selectors.js
@@ -1,13 +1,13 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
-import { format } from 'd3-format';
+import { formatNumber } from 'utils/format';
 
 // get list data
-const getData = state => state.data;
-const getLocationName = state => state.locationLabel;
-const getColors = state => state.colors;
-const getSentences = state => state.sentences;
-const getTitle = state => state.title;
+const getData = (state) => state.data;
+const getLocationName = (state) => state.locationLabel;
+const getColors = (state) => state.colors;
+const getSentences = (state) => state.sentences;
+const getTitle = (state) => state.title;
 
 // get lists selected
 export const parseData = createSelector(
@@ -19,7 +19,7 @@ export const parseData = createSelector(
       extent,
       planted_forest,
       forest_primary,
-      forest_regenerated
+      forest_regenerated,
     } = data;
     const otherCover =
       extent - (forest_regenerated + forest_primary + planted_forest);
@@ -28,33 +28,33 @@ export const parseData = createSelector(
       {
         label: 'Naturally Regenerated Forest',
         value: forest_regenerated,
-        percentage: forest_regenerated / area_ha * 100,
-        color: colors.naturalForest
+        percentage: (forest_regenerated / area_ha) * 100,
+        color: colors.naturalForest,
       },
       {
         label: 'Primary Forest',
         value: forest_primary || 0,
-        percentage: forest_primary / area_ha * 100 || 0,
-        color: colors.primaryForest
+        percentage: (forest_primary / area_ha) * 100 || 0,
+        color: colors.primaryForest,
       },
       {
         label: 'Planted Forest',
         value: planted_forest || 0,
-        percentage: planted_forest / area_ha * 100 || 0,
-        color: colors.plantedForest
+        percentage: (planted_forest / area_ha) * 100 || 0,
+        color: colors.plantedForest,
       },
       {
         label: 'Other Tree Cover',
         value: otherCover > 0 ? otherCover : 0,
-        percentage: otherCover / area_ha * 100,
-        color: colors.otherCover
+        percentage: (otherCover / area_ha) * 100,
+        color: colors.otherCover,
       },
       {
         label: 'Non-Forest',
         value: nonForest,
-        percentage: nonForest / area_ha * 100,
-        color: colors.nonForest
-      }
+        percentage: (nonForest / area_ha) * 100,
+        color: colors.nonForest,
+      },
     ];
   }
 );
@@ -67,17 +67,12 @@ export const parseSentence = createSelector(
     const { area_ha, extent, forest_primary } = data;
     const primaryPercent =
       forest_primary > 0
-        ? forest_primary / area_ha * 100
-        : extent / area_ha * 100;
-
+        ? (forest_primary / area_ha) * 100
+        : (extent / area_ha) * 100;
     const params = {
-      location: locationName,
-      extent:
-        extent < 1
-          ? `${format('.3r')(extent)}ha`
-          : `${format('.3s')(extent)}ha`,
-      primaryPercent:
-        primaryPercent >= 0.1 ? `${format('.2r')(primaryPercent)}%` : '< 0.1%'
+      location: locationName === 'global' ? 'globally' : locationName,
+      extent: formatNumber({ num: extent, unit: 'ha' }),
+      primaryPercent: formatNumber({ num: primaryPercent, unit: '%' }),
     };
     let sentence = forest_primary > 0 ? initial : noPrimary;
     if (locationName === 'global') {
@@ -85,7 +80,7 @@ export const parseSentence = createSelector(
     }
     return {
       sentence,
-      params
+      params,
     };
   }
 );
@@ -104,5 +99,5 @@ export const parseTitle = createSelector(
 export default createStructuredSelector({
   data: parseData,
   sentence: parseSentence,
-  title: parseTitle
+  title: parseTitle,
 });

--- a/components/widgets/land-cover/tree-cover-located/index.js
+++ b/components/widgets/land-cover/tree-cover-located/index.js
@@ -16,7 +16,7 @@ import getWidgetProps from './selectors';
 export default {
   widget: 'treeCoverLocated',
   title: {
-    global: 'Global Location of forest',
+    global: 'Global location of forest',
     initial: 'Location of forest in {location}',
   },
   categories: ['summary', 'land-cover'],

--- a/components/widgets/land-cover/tree-cover-located/selectors.js
+++ b/components/widgets/land-cover/tree-cover-located/selectors.js
@@ -3,7 +3,6 @@ import isEmpty from 'lodash/isEmpty';
 import uniqBy from 'lodash/uniqBy';
 import sumBy from 'lodash/sumBy';
 import sortBy from 'lodash/sortBy';
-import { format } from 'd3-format';
 import { formatNumber } from 'utils/format';
 
 // get list data
@@ -100,12 +99,16 @@ export const parseSentence = createSelector(
       num: avgExtentPercentage,
       unit: '%',
     });
+    const topExtentPercent = formatNumber({
+      num: topExtent,
+      unit: '%',
+    });
 
     const params = {
       location: locationName === 'global' ? 'Globally' : locationName,
       region: topRegion.label,
       indicator: indicator && indicator.label,
-      percentage: topExtent ? `${format('.2r')(topExtent)}%` : '0%',
+      percentage: topExtentPercent,
       year: extentYear,
       value: unit === '%' ? topRegionPercent : topRegionExtent,
       average: unit === '%' ? aveRegionPercent : aveRegionExtent,


### PR DESCRIPTION
## Overview

Updates several widgets to use the word `global` correctly on the global dashboard:

- location of forest widget (https://gfw.global/2QeSZ2d) "Globally" --> "global"
- FAO forest cover widget (https://gfw.global/3tuowLL) "global" --> "globally"
- the global regions with the most fire alerts widget (https://gfw.global/3tqPJ23) "global" --> "globally"

Aslo packs a some nice code cleaning and format refactoring where possible