### PR TITLE
Add link to caution text

### DIFF
--- a/components/widget/components/widget-caution/component.js
+++ b/components/widget/components/widget-caution/component.js
@@ -19,9 +19,23 @@ class WidgetCaution extends PureComponent {
   }
 
   render() {
-    const { caution } = this.props;
+    const {
+      caution: { text, link, linkText },
+    } = this.props;
+    if (this.isVisible() && linkText) {
+      const htmlTextArray = text && linkText && text.split(`{${linkText}}`);
+      return (
+        <div className="c-widget-caution">
+          {htmlTextArray[0]}
+          <a href={link} target="_self">
+            {linkText}
+          </a>
+          {htmlTextArray[1]}
+        </div>
+      );
+    }
     if (this.isVisible()) {
-      return <div className="c-widget-caution">{caution.text}</div>;
+      return <div className="c-widget-caution">{text}</div>;
     }
 
     return null;

--- a/components/widgets/forest-change/tree-loss/index.js
+++ b/components/widgets/forest-change/tree-loss/index.js
@@ -68,8 +68,12 @@ export default {
   categories: ['summary', 'forest-change'],
   types: ['country', 'geostore', 'aoi', 'wdpa', 'use'],
   caution: {
-    text: '2020 data coming soon for this area.',
-    visible: [],
+    text:
+      'The methods behind this data have changed over time {read more here}, be cautious comparing old and new data especially before/after 2015.',
+    visible: ['country', 'geostore', 'aoi', 'wdpa', 'use'],
+    linkText: 'read more here',
+    link:
+      'https://www.globalforestwatch.org/blog/data-and-research/tree-cover-loss-satellite-data-trend-analysis/',
   },
   admins: ['adm0', 'adm1', 'adm2'],
   large: true,


### PR DESCRIPTION
## Overview

Adds caution text to loss widgets. Also enables link within caution text.

<img width="987" alt="Screen Shot 2021-05-06 at 15 00 41" src="https://user-images.githubusercontent.com/30242314/117302374-d9031380-ae7b-11eb-8aa8-5def63e7fc15.png">
