### PR TITLE
fix top region percent divide by 0 check

### DIFF
--- a/components/widgets/fires/fires-ranked/selectors.js
+++ b/components/widgets/fires/fires-ranked/selectors.js
@@ -201,7 +201,9 @@ export const parseSentence = createSelector(
     const topRegionCount = data[0].counts || 0;
     const topRegionVariance = data[0].significance || 0;
     const topRegionDensity = data[0].density || 0;
-    const topRegionPerc = (100 * topRegionCount) / sumBy(data, 'counts');
+    const topRegionPerc =
+      topRegionCount === 0 ? 0 : (100 * topRegionCount) / sumBy(data, 'counts');
+
     const timeFrame = optionsSelected.weeks;
     const colorRange = colors.ramp;
     let statusColor = colorRange[8];


### PR DESCRIPTION
fix divide by 0 issue on top region perc 

globalforestwatch.org/dashboards/country/IDN/9/?category=fires&location=WyJjb3VudHJ5IiwiSUROIiwiOSJd&map=eyJjZW50ZXIiOnsibGF0IjotNi44Njk1NTg0MjAwODg4NzIsImxuZyI6MTA3LjYwMjE0OTk5OTk4MTQ1fSwiem9vbSI6Ni44MjA2MTczNzUxNTE0NDcsImNhbkJvdW5kIjpmYWxzZSwiZGF0YXNldHMiOlt7ImRhdGFzZXQiOiJwb2xpdGljYWwtYm91bmRhcmllcyIsImxheWVycyI6WyJkaXNwdXRlZC1wb2xpdGljYWwtYm91bmRhcmllcyIsInBvbGl0aWNhbC1ib3VuZGFyaWVzIl0sImJvdW5kYXJ5Ijp0cnVlLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlfSx7ImRhdGFzZXQiOiJmaXJlLWFsZXJ0cy12aWlycyIsImxheWVycyI6WyJmaXJlLWFsZXJ0cy12aWlycyJdLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlLCJ0aW1lbGluZVBhcmFtcyI6eyJzdGFydERhdGVBYnNvbHV0ZSI6IjIwMjEtMDItMTciLCJlbmREYXRlQWJzb2x1dGUiOiIyMDIxLTA1LTE4Iiwic3RhcnREYXRlIjoiMjAyMS0wMi0xNyIsImVuZERhdGUiOiIyMDIxLTA1LTE4IiwidHJpbUVuZERhdGUiOiIyMDIxLTA1LTE4In19XX0%3D&showMap=true

Checl: REGIONS WITH THE MOST FIRE ALERTS IN JAWA BARAT, INDONESIA widget & make sure `NaN` does not show