### PR TITLE
add global dashboard sentence

### DIFF
--- a/components/widgets/component.jsx
+++ b/components/widgets/component.jsx
@@ -8,7 +8,6 @@ import { trackEvent } from 'utils/analytics';
 import Loader from 'components/ui/loader';
 import NoContent from 'components/ui/no-content';
 import Widget from 'components/widget';
-
 import './styles.scss';
 
 class Widgets extends PureComponent {
@@ -59,7 +58,7 @@ class Widgets extends PureComponent {
       handleClickWidget,
     } = this.props;
     const hasWidgets = !isEmpty(widgets);
-
+    console.log('props', this.props);
     return (
       <div
         className={cx(

--- a/components/widgets/component.jsx
+++ b/components/widgets/component.jsx
@@ -58,7 +58,7 @@ class Widgets extends PureComponent {
       handleClickWidget,
     } = this.props;
     const hasWidgets = !isEmpty(widgets);
-    console.log('props', this.props);
+
     return (
       <div
         className={cx(

--- a/data/dashboard-summary-sentence.js
+++ b/data/dashboard-summary-sentence.js
@@ -1,0 +1,66 @@
+export default {
+  global: {
+    summary:
+      'Explore interactive charts and maps that summarize key statistics about global forests. Statistics and global rankings – including rates of forest change, forest extent and drivers of deforestation – can be customized, easily shared and downloaded for offline use.',
+    'land-cover':
+      'Explore interactive charts and maps that summarize global forest extent. Statistics – including rankings of countries with the most forest – can be customized, easily shared and downloaded for offline use.',
+    'forest-change':
+      'Explore interactive charts and maps that summarize global rates of forest change. Statistics – including rankings of countries with the most forest loss and gain, and drivers of deforestation – can be customized, easily shared and downloaded for offline use.',
+    fires:
+      'Explore real-time fire alerts and identify countries with the most significant number of fires based on historical trends. The interactive chart can be customized, easily shared and downloaded for offline use.',
+    climate:
+      'Explore interactive charts and maps that summarize the role forests play in climate change and managing the global carbon budget. Forest carbon statistics – including how much carbon forests store, emit and sequester (remove) – can be customized, easily shared and downloaded for offline use.',
+  },
+  country: {
+    summary:
+      'Explore interactive charts and maps that summarize key statistics about forests in {location}. Statistics – including rates of forest change, forest extent, drivers of deforestation, and deforestation and fire alerts – can be customized, easily shared and downloaded for offline use.',
+    'land-cover':
+      'Explore interactive charts and maps that summarize forest extent in {location}. Statistics – including rankings of regions with the most forest – can be customized, easily shared and downloaded for offline use.',
+    'forest-change':
+      'Explore interactive charts and maps that summarize rates of forest change in {location}. Statistics – including rankings of regions with the most forest loss and gain – can be customized, easily shared and downloaded for offline use.',
+    'land-use':
+      'Explore interactive charts and maps that summarize the human use of land in {location}. Statistics – including export flows of agricultural commodities, the economic impact of forests and forestry employment – can be customized, easily shared and downloaded for offline use.',
+    fires:
+      'Explore interactive charts and maps that summarize forest fires in {location}. Statistics – including regions with the most fire alerts and how current fires compare to historical trends – can be customized, easily shared and downloaded for offline use.',
+    climate:
+      'Explore interactive charts and maps that summarize the role forests play in climate change in {location}. Forest carbon statistics – including how forests store, emit and sequester (remove) carbon – can be customized, easily shared and downloaded for offline use.',
+  },
+  adm1: {
+    summary:
+      'Explore interactive charts and maps that summarize key statistics about forests in {adm1}, {location}. Statistics – including rates of forest change and forest extent – can be customized, easily shared and downloaded for offline use.',
+    'land-cover':
+      'Explore interactive charts and maps that summarize forest extent in {adm1}, {location}. Statistics – including rankings of regions with the most forest – can be customized, easily shared and downloaded for offline use.',
+    'forest-change':
+      'Explore interactive charts and maps that summarize rates of forest change in {adm1}, {location}. Statistics – including rankings of regions with the most forest loss and gain – can be customized, easily shared and downloaded for offline use.',
+    fires:
+      'Explore interactive charts and maps that summarize forest fires in {adm1}, {location}. Statistics – including regions with the most fire alerts and how current fires compare to historical trends – can be customized, easily shared and downloaded for offline use.',
+    climate:
+      'Explore interactive charts and maps that summarize the role forests play in climate change in {adm1}, {location}. Forest carbon statistics – including how forests store, emit and sequester (remove) carbon – can be customized, easily shared and downloaded for offline use.',
+  },
+  adm2: {
+    summary:
+      'Explore interactive charts and maps that summarize key statistics about forests in {adm2}, {adm1}, {location}. Statistics – including rates of forest change and forest extent – can be customized, easily shared and downloaded for offline use.',
+    'land-cover':
+      'Explore interactive charts and maps that summarize forest extent in {adm2}, {adm1}, {location}. Statistics – including types of forest cover – can be customized, easily shared and downloaded for offline use.',
+    'forest-change':
+      'Explore interactive charts and maps that summarize rates of forest change in {adm2}, {adm1}, {location}. Forest cover change statistics – including rankings of regions with the most forest loss and gain – can be customized, easily shared and downloaded for offline use.',
+    fires:
+      'Explore interactive charts and maps that summarize forest fires in {adm2}, {adm1}, {location}. Fire statistics – including how current fires compare to historical trends – can be customized, easily shared and downloaded for offline use.',
+    climate:
+      'Explore interactive charts and maps that summarize the role forests play in climate change in {adm2}, {adm1}, {location}. Forest carbon statistics – including how forests store, emit and sequester (remove) carbon – can be customized, easily shared and downloaded for offline use.',
+  },
+  area: {
+    summary:
+      'Explore interactive charts and maps that summarize key statistics about forests in {area}. Statistics – including rates of forest change and forest extent – can be customized, easily shared and downloaded for offline use.',
+    'land-cover':
+      'Explore interactive charts and maps that summarize forest extent in {area}. Statistics – including types of forest cover – can be customized, easily shared and downloaded for offline use.',
+    'forest-change':
+      'Explore interactive charts and maps that summarize rates of forest change in {area}. Statistics – including rankings of areas with the most forest loss and gain – can be customized, easily shared and downloaded for offline use.',
+    'land-use':
+      'Explore interactive charts and maps that summarize the human use of land in {area}. Statistics – including export flows of agricultural commodities, the economic impact of forests and forestry employment – can be customized, easily shared and downloaded for offline use.',
+    fires:
+      'Explore interactive charts and maps that summarize forest fires in {area}. Statistics – including how current fires compare to historical trends – can be customized, easily shared and downloaded for offline use.',
+    climate:
+      'Explore interactive charts and maps that summarize the role forests play in climate change in {area}. Forest carbon statistics – including how forests store, emit and sequester (remove) carbon – can be customized, easily shared and downloaded for offline use.',
+  },
+};

--- a/layouts/dashboards/component.jsx
+++ b/layouts/dashboards/component.jsx
@@ -34,6 +34,7 @@ import Map from './components/map';
 import Header from './components/header';
 import MapControls from './components/map-controls';
 import PendingDashboard from './components/pending-dashboard';
+import GlobalSentence from './components/global-sentence';
 
 import './styles.scss';
 
@@ -169,6 +170,7 @@ class DashboardsPage extends PureComponent {
               checkActive
             />
           )}
+          <GlobalSentence />
           {isPendingDashboard && (
             <PendingDashboard
               className="pending-message"

--- a/layouts/dashboards/components/global-sentence/component.jsx
+++ b/layouts/dashboards/components/global-sentence/component.jsx
@@ -27,7 +27,6 @@ class GlobalSentence extends PureComponent {
 
   getSentence() {
     const { location, category, locationNames } = this.props;
-
     if (!location || !category) {
       return { sentence: '', props: {} };
     }
@@ -52,6 +51,9 @@ class GlobalSentence extends PureComponent {
       }),
       ...(locationNames?.adm2?.label && {
         adm2: locationNames?.adm2?.label,
+      }),
+      ...(locationNames?.adm0?.label && {
+        area: locationNames?.adm0?.label,
       }),
     };
 

--- a/layouts/dashboards/components/global-sentence/component.jsx
+++ b/layouts/dashboards/components/global-sentence/component.jsx
@@ -1,0 +1,75 @@
+import { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import DynamicSentence from 'components/ui/dynamic-sentence';
+
+import './styles.scss';
+
+import SENTENCES from 'data/dashboard-summary-sentence';
+
+class GlobalSentence extends PureComponent {
+  static propTypes = {
+    locationNames: PropTypes.object.isRequired,
+    location: PropTypes.object.isRequired,
+    category: PropTypes.string,
+  };
+
+  getLocationType() {
+    const { location } = this.props;
+    if (location.type === 'country') {
+      if (location.adm2) return 'adm2';
+      if (location.adm1) return 'adm1';
+      return 'country';
+    }
+    if (location.type === 'global') return 'global';
+    return 'area';
+  }
+
+  getSentence() {
+    const { location, category, locationNames } = this.props;
+
+    if (!location || !category) {
+      return { sentence: '', props: {} };
+    }
+
+    let sentence;
+
+    try {
+      sentence = SENTENCES[this.getLocationType()][category];
+    } catch (_i) {
+      return {
+        sentence: null,
+        params: {},
+      };
+    }
+
+    const sentenceProps = {
+      ...(locationNames?.adm0?.label && {
+        location: locationNames?.adm0?.label,
+      }),
+      ...(locationNames?.adm1?.label && {
+        adm1: locationNames?.adm1?.label,
+      }),
+      ...(locationNames?.adm2?.label && {
+        adm2: locationNames?.adm2?.label,
+      }),
+    };
+
+    return {
+      sentence,
+      params: sentenceProps,
+    };
+  }
+
+  render() {
+    return (
+      <div className="c-widgets dashboard-widgets global-dashboard-sentence">
+        <div className="c-widget c-dashboard-sentence-widget">
+          <DynamicSentence sentence={this.getSentence()} />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default GlobalSentence;

--- a/layouts/dashboards/components/global-sentence/index.js
+++ b/layouts/dashboards/components/global-sentence/index.js
@@ -1,0 +1,7 @@
+import { connect } from 'react-redux';
+
+import GlobalSentenceComponent from './component';
+
+import { getGlobalSentenceProps } from './selectors';
+
+export default connect(getGlobalSentenceProps, {})(GlobalSentenceComponent);

--- a/layouts/dashboards/components/global-sentence/selectors.js
+++ b/layouts/dashboards/components/global-sentence/selectors.js
@@ -1,0 +1,107 @@
+import { createSelector, createStructuredSelector } from 'reselect';
+
+import { getActiveCategory } from 'components/widgets/selectors';
+
+import { getUserAreas } from 'providers/areas-provider/selectors';
+
+// get list data
+export const selectLocation = (state) =>
+  state.location && state.location.payload;
+
+export const selectCountryData = (state) =>
+  state.countryData && {
+    adm0: state.countryData.countries,
+    adm1: state.countryData.regions,
+    adm2: state.countryData.subRegions,
+    links: state.countryData.countryLinks,
+  };
+
+export const getAreasOptions = createSelector(
+  [getUserAreas, selectLocation],
+  (areas, location) => {
+    if (
+      !areas ||
+      !areas.find(
+        (a) => a.id === location.adm0 || a.subscriptionId === location.adm0
+      )
+    ) {
+      return null;
+    }
+
+    return {
+      adm0: areas.map((a) => ({
+        label: a.name,
+        value: a.id,
+        subscriptionId: a.subscriptionId,
+      })),
+    };
+  }
+);
+
+export const getAdminMetadata = createSelector(
+  [selectLocation, selectCountryData, getAreasOptions],
+  (location, countries, areas) => {
+    if (location?.type === 'aoi') return areas;
+    return countries;
+  }
+);
+
+export const getAdm0Data = createSelector(
+  [getAdminMetadata],
+  (data) => data && data.adm0
+);
+
+export const getAdm1Data = createSelector(
+  [getAdminMetadata],
+  (data) => data && data.adm1
+);
+
+export const getAdm2Data = createSelector(
+  [getAdminMetadata],
+  (data) => data && data.adm2
+);
+
+export const getAdminsSelected = createSelector(
+  [getAdm0Data, getAdm1Data, getAdm2Data, selectLocation],
+  (adm0s, adm1s, adm2s, location) => {
+    const adm0 =
+      (location &&
+        location.adm0 &&
+        adm0s &&
+        adm0s.find(
+          (i) => i.value === location.adm0 || i.subscriptionId === location.adm0
+        )) ||
+      null;
+    const adm1 =
+      (location &&
+        location.adm1 &&
+        adm1s &&
+        adm1s.find((i) => i.value === location.adm1)) ||
+      null;
+    const adm2 =
+      (location &&
+        location.adm2 &&
+        adm2s &&
+        adm2s.find((i) => i.value === location.adm2)) ||
+      null;
+    let current = adm0;
+    if (location?.adm2) {
+      current = adm2;
+    } else if (location?.adm1) {
+      current = adm1;
+    }
+
+    return {
+      ...current,
+      adm0,
+      adm1,
+      adm2,
+    };
+  }
+);
+
+export const getGlobalSentenceProps = createStructuredSelector({
+  location: selectLocation,
+  locationNames: getAdminsSelected,
+  category: getActiveCategory,
+});

--- a/layouts/dashboards/components/global-sentence/selectors.js
+++ b/layouts/dashboards/components/global-sentence/selectors.js
@@ -1,104 +1,11 @@
-import { createSelector, createStructuredSelector } from 'reselect';
+import { createStructuredSelector } from 'reselect';
 
 import { getActiveCategory } from 'components/widgets/selectors';
 
-import { getUserAreas } from 'providers/areas-provider/selectors';
-
-// get list data
-export const selectLocation = (state) =>
-  state.location && state.location.payload;
-
-export const selectCountryData = (state) =>
-  state.countryData && {
-    adm0: state.countryData.countries,
-    adm1: state.countryData.regions,
-    adm2: state.countryData.subRegions,
-    links: state.countryData.countryLinks,
-  };
-
-export const getAreasOptions = createSelector(
-  [getUserAreas, selectLocation],
-  (areas, location) => {
-    if (
-      !areas ||
-      !areas.find(
-        (a) => a.id === location.adm0 || a.subscriptionId === location.adm0
-      )
-    ) {
-      return null;
-    }
-
-    return {
-      adm0: areas.map((a) => ({
-        label: a.name,
-        value: a.id,
-        subscriptionId: a.subscriptionId,
-      })),
-    };
-  }
-);
-
-export const getAdminMetadata = createSelector(
-  [selectLocation, selectCountryData, getAreasOptions],
-  (location, countries, areas) => {
-    if (location?.type === 'aoi') return areas;
-    return countries;
-  }
-);
-
-export const getAdm0Data = createSelector(
-  [getAdminMetadata],
-  (data) => data && data.adm0
-);
-
-export const getAdm1Data = createSelector(
-  [getAdminMetadata],
-  (data) => data && data.adm1
-);
-
-export const getAdm2Data = createSelector(
-  [getAdminMetadata],
-  (data) => data && data.adm2
-);
-
-export const getAdminsSelected = createSelector(
-  [getAdm0Data, getAdm1Data, getAdm2Data, selectLocation],
-  (adm0s, adm1s, adm2s, location) => {
-    const adm0 =
-      (location &&
-        location.adm0 &&
-        adm0s &&
-        adm0s.find(
-          (i) => i.value === location.adm0 || i.subscriptionId === location.adm0
-        )) ||
-      null;
-    const adm1 =
-      (location &&
-        location.adm1 &&
-        adm1s &&
-        adm1s.find((i) => i.value === location.adm1)) ||
-      null;
-    const adm2 =
-      (location &&
-        location.adm2 &&
-        adm2s &&
-        adm2s.find((i) => i.value === location.adm2)) ||
-      null;
-    let current = adm0;
-    if (location?.adm2) {
-      current = adm2;
-    } else if (location?.adm1) {
-      current = adm1;
-    }
-
-    return {
-      ...current,
-      adm0,
-      adm1,
-      adm2,
-    };
-  }
-);
+import {
+  selectLocation,
+  getAdminsSelected,
+} from 'layouts/dashboards/components/header/selectors';
 
 export const getGlobalSentenceProps = createStructuredSelector({
   location: selectLocation,

--- a/layouts/dashboards/components/global-sentence/styles.scss
+++ b/layouts/dashboards/components/global-sentence/styles.scss
@@ -1,0 +1,9 @@
+.global-dashboard-sentence {
+  margin-bottom: 0;
+  padding-bottom: 0;
+
+  .c-dashboard-sentence-widget {
+    width: 100%;
+    margin-bottom: 0;
+  }
+}


### PR DESCRIPTION
## Overview

This pr adds a global summary header by category. It acts as a widget but is not really a widget.

<img width="853" alt="Screenshot 2021-05-24 at 12 53 16" src="https://user-images.githubusercontent.com/971129/119337602-51950d00-bc8f-11eb-8265-9903528a5894.png">


## Testing

- Check each admin level on dashboard and make sure we are displaying the correct sentence
- As depending on category; We need to verify the correct sentence is shown for its category.
- Check that sentences gets feeded the correct properties for country + admin variables. 
- Ensure app does not crash in general
- Ensure widget looks good.

