### PR TITLE
fix page size param for datasets

### DIFF
--- a/services/datasets.js
+++ b/services/datasets.js
@@ -3,10 +3,11 @@ import { rwRequest, dataRequest } from 'utils/request';
 // Feature env will always be "null" on production
 const featureEnv = process.env.NEXT_PUBLIC_FEATURE_ENV;
 
+// https://resource-watch.github.io/doc-api/concepts.html#pagination
 export const getDatasets = () =>
   rwRequest
     .get(
-      `/dataset?application=gfw&includes=metadata,vocabulary,layer&page[size]=9999&env=production${
+      `/dataset?application=gfw&includes=metadata,vocabulary,layer&page[size]=100&env=production${
         featureEnv ? `,${featureEnv},preproduction-staging` : ''
       }${featureEnv === 'staging' ? `&refresh=${new Date()}` : ''}`
     )


### PR DESCRIPTION
## Overview

RW api only supports a page size of 100 according to docs, reflect that in the dataset request. 

## Testing

Check if we need to actually implement pagination for this request, I don't think we do as 100 seems to be quite a large number anyway 