### PR TITLE
Sum over isos

### DIFF
--- a/components/widgets/land-cover/intact-tree-cover/index.js
+++ b/components/widgets/land-cover/intact-tree-cover/index.js
@@ -100,9 +100,9 @@ export default {
         let extent = 0;
         let data = {};
         if (iflExtent.length && adminExtent.length) {
-          totalArea = adminExtent[0].total_area;
-          totalExtent = adminExtent[0].extent;
-          extent = iflExtent[0].extent;
+          totalArea = adminExtent.reduce((total, d) => total + d.total_area, 0);
+          totalExtent = adminExtent.reduce((total, d) => total + d.extent, 0);
+          extent = iflExtent.reduce((total, d) => total + d.extent, 0);
           data = {
             totalArea,
             totalExtent,

--- a/components/widgets/land-cover/tree-cover/index.js
+++ b/components/widgets/land-cover/tree-cover/index.js
@@ -122,15 +122,25 @@ export default {
         spread((response, adminResponse, plantationsResponse) => {
           const extent = response.data && response.data.data;
           const adminExtent = adminResponse.data && adminResponse.data.data;
+          const plantationsExtent =
+            plantationsResponse.data && plantationsResponse.data.data;
           let totalArea = 0;
           let totalCover = 0;
           let cover = 0;
           let plantations = 0;
           let data = {};
           if (extent && extent.length) {
-            totalArea = adminExtent[0].total_area;
-            cover = extent[0].extent;
-            totalCover = adminExtent[0].extent;
+            // Sum values
+            totalArea = adminExtent.reduce(
+              (total, d) => total + d.total_area,
+              0
+            );
+            cover = extent.reduce((total, d) => total + d.extent, 0);
+            totalCover = adminExtent.reduce((total, d) => total + d.extent, 0);
+            plantations = plantationsExtent.reduce(
+              (total, d) => total + d.extent,
+              0
+            );
             data = {
               totalArea,
               totalCover,
@@ -138,23 +148,6 @@ export default {
               plantations,
             };
           }
-          if (params.forestType || params.landCategory) {
-            return data;
-          }
-          // if plantations get more data
-          const plantationsData =
-            plantationsResponse.data && plantationsResponse.data.data;
-          plantations =
-            plantationsData && plantationsData.length
-              ? plantationsData[0].extent
-              : 0;
-          if (extent && extent.length) {
-            data = {
-              ...data,
-              plantations,
-            };
-          }
-
           return data;
         })
       );


### PR DESCRIPTION
## Overview

Fix global tree cover widgets by summing over iso keys in data (previously the logic only selected the first element). Widgets effected:

- `treeCover`
- `intactTreeCover`