### PR TITLE
FIx global fires Ranked widget

### DIFF
--- a/components/widgets/fires/fires-ranked/selectors.js
+++ b/components/widgets/fires/fires-ranked/selectors.js
@@ -26,7 +26,8 @@ const getOptionsSelected = (state) => state.optionsSelected;
 const getIndicator = (state) => state.indicator;
 const getAdm1 = (state) => state.adm1;
 const getLocation = (state) => state.location || null;
-const getLocationsMeta = (state) => state.childData;
+const getLocationsMeta = (state) =>
+  state.adm0 ? state.locationData : state.childData;
 const getLocationName = (state) => state.locationLabel;
 const getColors = (state) => state.colors;
 const getSentences = (state) => state.sentences;
@@ -101,7 +102,7 @@ export const getStatsByAdmin = createSelector(
 export const parseList = createSelector(
   [getStatsByAdmin, getAreas, getLocationsMeta, getLocation, getAdm1],
   (data, areas, meta, location, adm1) => {
-    if (isEmpty(data) || isEmpty(areas) || isEmpty(meta)) {
+    if (isEmpty(data) || isEmpty(areas)) {
       return null;
     }
     // Now we have partial data, we iterate through and calculate
@@ -131,9 +132,10 @@ export const parseList = createSelector(
         path: (region && region.path) || '',
       };
     });
-    return matchKey === 'iso'
-      ? mappedData.filter((d) => d.area > 1e6 && d.density > 1) // At least one fire per MHa at iso level
-      : mappedData;
+    const filteredData = mappedData.filter((d) => d.label);
+    return matchKey === 'iso' && location.value !== 'global'
+      ? filteredData.filter((d) => d.area > 1e6 && d.density > 1) // At least one fire per MHa at iso level
+      : filteredData;
   }
 );
 
@@ -157,8 +159,7 @@ export const parseData = createSelector(
           ? b.stdDev
           : minValue + (b.limit * (maxValue - minValue)) / 100,
     }));
-
-    return sortBy(
+    const sortedData = sortBy(
       data.map((d) => ({
         ...d,
         value: d[value], // value === 'density' ? d[value] : d.counts,
@@ -167,6 +168,7 @@ export const parseData = createSelector(
       })),
       value
     ).reverse();
+    return sortedData;
   }
 );
 

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -129,13 +129,12 @@ export const getIndicator = (activeForestType, activeLandCategory, ifl) => {
 // build the base query for the query with the correct dataset id
 const getRequestUrl = ({ type, adm1, adm2, dataset, datasetType, grouped }) => {
   let typeByLevel = type;
-  if (type === 'country' || type === 'global') {
+  if (type === 'country') {
     if (!adm1) typeByLevel = 'adm0';
     if (adm1) typeByLevel = 'adm1';
     if (adm2 || datasetType === 'daily') typeByLevel = 'adm2';
-    typeByLevel = typeByGrouped[typeByLevel][grouped ? 'grouped' : 'default'];
   }
-
+  typeByLevel = typeByGrouped[typeByLevel][grouped ? 'grouped' : 'default'];
   const datasetId =
     DATASETS[
       `${dataset?.toUpperCase()}_${typeByLevel?.toUpperCase()}_${datasetType?.toUpperCase()}`
@@ -717,8 +716,10 @@ export const getAreaIntersection = (params) => {
       .replace(/{location}/g, getLocationSelect(params))
       .replace(
         /{intersection}/g,
-        `, ${intersectionPolyname.tableKey}` ||
-          `, ${intersectionPolyname.tableKeys.annual}`
+        intersectionPolyname?.tableKey
+          ? `, ${intersectionPolyname.tableKey}` ||
+              `, ${intersectionPolyname.tableKeys.annual}`
+          : ''
       )
       .replace('{WHERE}', getWHEREQuery({ ...params, dataset: 'annual' }))
   );
@@ -753,7 +754,6 @@ export const getAreaIntersectionGrouped = (params) => {
   const intersectionPolyname = forestTypes
     .concat(landCategories)
     .find((o) => [forestType, landCategory].includes(o.value));
-
   const requestUrl = getRequestUrl({
     ...params,
     dataset: 'annual',
@@ -774,7 +774,7 @@ export const getAreaIntersectionGrouped = (params) => {
       )
       .replace(
         /{intersection}/g,
-        intersectionPolyname
+        intersectionPolyname?.tableKey
           ? `, ${intersectionPolyname.tableKey}` ||
               `, ${intersectionPolyname.tableKeys.annual}`
           : ''

--- a/services/sentences.js
+++ b/services/sentences.js
@@ -104,14 +104,24 @@ export const getSentenceData = (params = GLOBAL_LOCATION) =>
             : 0;
 
         const data = {
-          totalArea: (extent[0] && extent[0].total_area) || 0,
-          extent: (extent[0] && extent[0].extent) || 0,
+          totalArea:
+            extent && extent.length && extent[0].total_area
+              ? sumBy(extent, 'total_area')
+              : 0,
+          extent:
+            extent && extent.length && extent[0].extent
+              ? sumBy(extent, 'extent')
+              : 0,
           plantationsExtent:
-            plantationsExtent && plantationsExtent.length
-              ? plantationsExtent[0].extent
+            plantationsExtent &&
+            plantationsExtent.length &&
+            plantationsExtent[0].extent
+              ? sumBy(plantationsExtent, 'extent')
               : 0,
           primaryExtent:
-            primaryExtent && primaryExtent.length ? primaryExtent[0].extent : 0,
+            primaryExtent && primaryExtent.length && primaryExtent[0].extent
+              ? sumBy(primaryExtent, 'extent')
+              : 0,
           totalLoss: {
             area: summedLoss || 0,
             year: latestYear || 0,


### PR DESCRIPTION
## Overview

At global level, ignore filtering. Also adds some QoL improvements to the widget.

WARNING: when embedding the widget using `http://localhost:3000/embed/widget/firesRanked/global` the `getLocationsMeta` selector seems not to have access to data (returns `{}`) 