### PR TITLE
Final touches to burned areas widgets

### DIFF
--- a/components/widgets/fires/burned-area-cumulative/index.js
+++ b/components/widgets/fires/burned-area-cumulative/index.js
@@ -96,9 +96,11 @@ const defaultConfig = {
   },
   sentences: {
     allBurn:
-      'In {location}, {area} of land has burned so far in {latestYear}. This total is {status} compared to the total for previous years going back to {dataset_start_year}. The most fires recorded in a year was {maxYear}, with {maxArea}.',
+      'In {location}, {area} of land has burned so far in {latestYear}. This total is {status} compared to the total for previous years going back to {dataset_start_year}. The most fires recorded in a year was {maxYear}, with {maxArea}',
     allBurnWithInd:
-      'In {location}, {area} of land within {indicator} has burned so far in {latestYear}. This total is {status} compared to the total for previous years going back to {dataset_start_year}. The most fires recorded in a year was {maxYear}, with {maxArea}.',
+      'In {location}, {area} of land within {indicator} has burned so far in {latestYear}. This total is {status} compared to the total for previous years going back to {dataset_start_year}. The most fires recorded in a year was {maxYear}, with {maxArea}',
+    thresholdStatement:
+      ', considering land with {thresh} tree canopy or greater.',
   },
   getData: (params) =>
     all([fetchBurnedArea(params), fetchMODISLatest(params)]).then(

--- a/components/widgets/fires/burned-area-cumulative/selectors.js
+++ b/components/widgets/fires/burned-area-cumulative/selectors.js
@@ -399,10 +399,8 @@ export const parseSentence = createSelector(
     parseData,
     getColors,
     getSentences,
-    getDataset,
     getLocationName,
     getStartIndex,
-    // getEndIndex,
     getOptionsSelected,
     getIndicator,
   ],
@@ -411,15 +409,15 @@ export const parseSentence = createSelector(
     data,
     colors,
     sentences,
-    dataset,
     location,
     startIndex,
-    // endIndex //broken?
     options,
     indicator
   ) => {
     if (!data || isEmpty(data)) return null;
-    const { allBurnWithInd, allBurn } = sentences;
+    const { allBurnWithInd, allBurn, thresholdStatement } = sentences;
+    const thresh = options?.firesThreshold?.value;
+
     const indicatorLabel =
       indicator && indicator.label ? indicator.label : null;
     const start = startIndex;
@@ -481,12 +479,16 @@ export const parseSentence = createSelector(
       statusColor = colorRange[6];
     }
 
-    const sentence = indicator ? allBurnWithInd : allBurn;
-
+    let sentence = indicator ? allBurnWithInd : allBurn;
+    sentence =
+      thresh && thresh > 0
+        ? sentence + thresholdStatement
+        : sentence.concat('.');
     const formattedData = moment(date).format('Do of MMMM YYYY');
     const params = {
       location,
       indicator: indicatorLabel,
+      thresh: `${thresh}%`,
       date: formattedData,
       latestYear,
       dataset_start_year: 2001,
@@ -495,7 +497,6 @@ export const parseSentence = createSelector(
         value: maxTotal ? format(',')(maxTotal) : 0,
         color: colors.main,
       },
-      dataset: 'MODIS',
       area: {
         value: totalCurrentYear
           ? `${format('.2s')(totalCurrentYear)}ha`

--- a/components/widgets/fires/burned-area-ranked/index.js
+++ b/components/widgets/fires/burned-area-ranked/index.js
@@ -101,29 +101,31 @@ const defaultConfig = {
   metaKey: 'umd_modis_burned_areas',
   sentences: {
     initial:
-      'In the most recent {timeframe} of data in {location}, the region with the most {significant} burned area was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned in {location} and is {status} compared to the same period going back to <b>2001</b>.',
+      'In the most recent {timeframe} of data in {location}, the region with the most {significant} burned area was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned in {location} and is {status} compared to the same period going back to <b>2001</b>',
     withInd:
-      'In the most recent {timeframe} of data in {location}, the region with the most {significant} burned area within {indicator} was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned in {location} and is {status} compared to the same period going back to <b>2001</b>.',
+      'In the most recent {timeframe} of data in {location}, the region with the most {significant} burned area within {indicator} was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned in {location} and is {status} compared to the same period going back to <b>2001</b>',
     densityInitial:
-      'In the most recent {timeframe} of data in {location}, the region with the <b>highest proportion</b> of land area burned was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned in {location} in the same period.',
+      'In the most recent {timeframe} of data in {location}, the region with the <b>highest proportion</b> of land area burned was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned in {location} in the same period',
     densityWithInd:
-      'In the most recent {timeframe} of data in {location}, the region with the <b>highest proportion</b> of land area burned within {indicator} was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned in {location} in the same period.',
+      'In the most recent {timeframe} of data in {location}, the region with the <b>highest proportion</b> of land area burned within {indicator} was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned in {location} in the same period',
     countsInitial:
-      'In the most recent {timeframe} of data in {location}, the region with the <b>most</b> burned area was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same period.',
+      'In the most recent {timeframe} of data in {location}, the region with the <b>most</b> burned area was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same period',
     countsWithInd:
-      'In the most recent {timeframe} of data in {location}, the region with the <b>most</b> burned area within {indicator} was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same period.',
+      'In the most recent {timeframe} of data in {location}, the region with the <b>most</b> burned area within {indicator} was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same period',
     initialGlobal:
-      'In the most recent {timeframe} of data, the country with the most {significant} burned area <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} and is {status} compared to the same period going back to <b>2001</b>.',
+      'In the most recent {timeframe} of data, the country with the most {significant} burned area <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} and is {status} compared to the same period going back to <b>2001</b>',
     withIndGlobal:
-      'In the most recent {timeframe} of data, the country with the most {significant} burned area within {indicator} <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} and is {status} compared to the same period going back to <b>2001</b>.',
+      'In the most recent {timeframe} of data, the country with the most {significant} burned area within {indicator} <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} and is {status} compared to the same period going back to <b>2001</b>',
     densityInitialGlobal:
-      'In the most recent {timeframe} of data, the country with the <b>highest proportion</b> of land area burned <b>globally</b> was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned {location} in the same period.',
+      'In the most recent {timeframe} of data, the country with the <b>highest proportion</b> of land area burned <b>globally</b> was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned {location} in the same period',
     densityWithIndGlobal:
-      'In the most recent {timeframe} of data, the country with the <b>highest proportion</b> of land area burned within {indicator} <b>globally</b> was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned {location} in the same period.',
+      'In the most recent {timeframe} of data, the country with the <b>highest proportion</b> of land area burned within {indicator} <b>globally</b> was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned {location} in the same period',
     countsInitialGlobal:
-      'In the most recent {timeframe} of data, the country with the <b>most</b> burned area <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same period.',
+      'In the most recent {timeframe} of data, the country with the <b>most</b> burned area <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same period',
     countsWithIndGlobal:
-      'In the most recent {timeframe} of data, the country with the <b>most</b> burned area within {indicator} <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same periodd.',
+      'In the most recent {timeframe} of data, the country with the <b>most</b> burned area within {indicator} <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same period',
+    thresholdStatement:
+      ', considering land with {thresh} tree canopy or greater.',
   },
   settings: {
     unit: 'significance',

--- a/components/widgets/fires/burned-area-ranked/index.js
+++ b/components/widgets/fires/burned-area-ranked/index.js
@@ -101,29 +101,29 @@ const defaultConfig = {
   metaKey: 'umd_modis_burned_areas',
   sentences: {
     initial:
-      'In the last {timeframe} in {location}, the region with the most {significant} burned area was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned in {location} and is {status} compared to the same period going back to <b>2001</b>.',
+      'In the most recent {timeframe} of data in {location}, the region with the most {significant} burned area was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned in {location} and is {status} compared to the same period going back to <b>2001</b>.',
     withInd:
-      'In the last {timeframe} in {location}, the region with the most {significant} burned area within {indicator} was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned in {location} and is {status} compared to the same period going back to <b>2001</b>.',
+      'In the most recent {timeframe} of data in {location}, the region with the most {significant} burned area within {indicator} was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned in {location} and is {status} compared to the same period going back to <b>2001</b>.',
     densityInitial:
-      'In the last {timeframe} in {location}, the region with the <b>highest proportion</b> of land area burned was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned in {location} in the same period.',
+      'In the most recent {timeframe} of data in {location}, the region with the <b>highest proportion</b> of land area burned was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned in {location} in the same period.',
     densityWithInd:
-      'In the last {timeframe} in {location}, the region with the <b>highest proportion</b> of land area burned within {indicator} was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned in {location} in the same period.',
+      'In the most recent {timeframe} of data in {location}, the region with the <b>highest proportion</b> of land area burned within {indicator} was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned in {location} in the same period.',
     countsInitial:
-      'In the last {timeframe} in {location}, the region with the <b>most</b> burned area was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same period.',
+      'In the most recent {timeframe} of data in {location}, the region with the <b>most</b> burned area was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same period.',
     countsWithInd:
-      'In the last {timeframe} in {location}, the region with the <b>most</b> burned area within {indicator} was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same period.',
+      'In the most recent {timeframe} of data in {location}, the region with the <b>most</b> burned area within {indicator} was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same period.',
     initialGlobal:
-      'In the last {timeframe}, the country with the most {significant} burned area <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} and is {status} compared to the same period going back to <b>2001</b>.',
+      'In the most recent {timeframe} of data, the country with the most {significant} burned area <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} and is {status} compared to the same period going back to <b>2001</b>.',
     withIndGlobal:
-      'In the last {timeframe}, the country with the most {significant} burned area within {indicator} <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} and is {status} compared to the same period going back to <b>2001</b>.',
+      'In the most recent {timeframe} of data, the country with the most {significant} burned area within {indicator} <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} and is {status} compared to the same period going back to <b>2001</b>.',
     densityInitialGlobal:
-      'In the last {timeframe}, the country with the <b>highest proportion</b> of land area burned <b>globally</b> was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned {location} in the same period.',
+      'In the most recent {timeframe} of data, the country with the <b>highest proportion</b> of land area burned <b>globally</b> was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned {location} in the same period.',
     densityWithIndGlobal:
-      'In the last {timeframe}, the country with the <b>highest proportion</b> of land area burned within {indicator} <b>globally</b> was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned {location} in the same period.',
+      'In the most recent {timeframe} of data, the country with the <b>highest proportion</b> of land area burned within {indicator} <b>globally</b> was {topRegion}, with {topRegionDensity}. This represents {topRegionPerc} of the total area burned {location} in the same period.',
     countsInitialGlobal:
-      'In the last {timeframe}, the country with the <b>most</b> burned area <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same period.',
+      'In the most recent {timeframe} of data, the country with the <b>most</b> burned area <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same period.',
     countsWithIndGlobal:
-      'In the last {timeframe}, the country with the <b>most</b> burned area within {indicator} <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same periodd.',
+      'In the most recent {timeframe} of data, the country with the <b>most</b> burned area within {indicator} <b>globally</b> was {topRegion}, with {topRegionCount} land area burned. This represents {topRegionPerc} of the total area burned {location} in the same periodd.',
   },
   settings: {
     unit: 'significance',

--- a/components/widgets/fires/burned-area-ranked/selectors.js
+++ b/components/widgets/fires/burned-area-ranked/selectors.js
@@ -187,7 +187,7 @@ export const parseSentence = createSelector(
     getSentences,
     getColors,
   ],
-  (data, unit, optionsSelected, indicator, locationName, sentences, colors) => {
+  (data, unit, options, indicator, locationName, sentences, colors) => {
     if (!data || !unit || !locationName) return null;
 
     const {
@@ -212,8 +212,8 @@ export const parseSentence = createSelector(
     const topRegionPerc =
       topRegionCount === 0 ? 0 : (100 * topRegionCount) / sumBy(data, 'counts');
 
-    const timeFrame = optionsSelected.weeks;
-    const thresh = optionsSelected?.firesThreshold?.value;
+    const timeFrame = options?.weeks;
+    const thresh = options?.firesThreshold?.value;
 
     const colorRange = colors.ramp;
     let statusColor = colorRange[8];

--- a/components/widgets/fires/burned-area-ranked/selectors.js
+++ b/components/widgets/fires/burned-area-ranked/selectors.js
@@ -270,10 +270,10 @@ export const parseSentence = createSelector(
         sentence = indicator ? countsWithIndGlobal : countsInitialGlobal;
       }
     }
-    if (thresh && thresh > 0) sentence += thresholdStatement;
-    else {
-      sentence += '.';
-    }
+    sentence =
+      thresh && thresh > 0
+        ? sentence + thresholdStatement
+        : sentence.concat('.');
     return { sentence, params };
   }
 );

--- a/components/widgets/fires/burned-area-ranked/selectors.js
+++ b/components/widgets/fires/burned-area-ranked/selectors.js
@@ -203,6 +203,7 @@ export const parseSentence = createSelector(
       densityWithIndGlobal,
       countsInitialGlobal,
       countsWithIndGlobal,
+      thresholdStatement,
     } = sentences;
     const topRegion = data[0].label;
     const topRegionCount = data[0].counts || 0;
@@ -212,6 +213,8 @@ export const parseSentence = createSelector(
       topRegionCount === 0 ? 0 : (100 * topRegionCount) / sumBy(data, 'counts');
 
     const timeFrame = optionsSelected.weeks;
+    const thresh = optionsSelected?.firesThreshold?.value;
+
     const colorRange = colors.ramp;
     let statusColor = colorRange[8];
 
@@ -235,6 +238,7 @@ export const parseSentence = createSelector(
         value: status,
         color: statusColor,
       },
+      thresh: `${thresh}%`,
       topRegion,
       topRegionCount: formatNumber({ num: topRegionCount, unit: 'ha' }),
       topRegionPerc: formatNumber({ num: topRegionPerc, unit: '%' }),
@@ -265,6 +269,10 @@ export const parseSentence = createSelector(
       } else if (unit === 'total_burn') {
         sentence = indicator ? countsWithIndGlobal : countsInitialGlobal;
       }
+    }
+    if (thresh && thresh > 0) sentence += thresholdStatement;
+    else {
+      sentence += '.';
     }
     return { sentence, params };
   }

--- a/components/widgets/fires/burned-area/index.js
+++ b/components/widgets/fires/burned-area/index.js
@@ -92,11 +92,13 @@ export default {
   sentences: {
     defaultSentence: 'In {location} there ',
     seasonSentence:
-      'In {location} the peak fire season typically begins in {fires_season_start} and lasts around {fire_season_length} weeks. ',
+      'In {location} the peak fire season typically begins in {fires_season_start} and lasts around {fire_season_length} weeks',
     allBurn:
-      'Fires burned {area} of land between {start_date} and {end_date}, when data were most recently available. The area burned during this time period is {status} compared to the area burned in previous years going back to {dataset_start_year}.',
+      'Fires burned {area} of land between {start_date} and {end_date}, when data were most recently available. The area burned during this time period is {status} compared to the area burned in previous years going back to {dataset_start_year}',
     allBurnWithInd:
-      'Fires burned {area} of land within {indicator} between {start_date} and {end_date}, when data were most recently available. The area burned during this time period is {status} compared to the area burned in previous years going back to {dataset_start_year}.',
+      'Fires burned {area} of land within {indicator} between {start_date} and {end_date}, when data were most recently available. The area burned during this time period is {status} compared to the area burned in previous years going back to {dataset_start_year}',
+    thresholdStatement:
+      ', considering land with {thresh} tree canopy or greater.',
   },
   whitelists: {
     adm0: [

--- a/components/widgets/fires/burned-area/selectors.js
+++ b/components/widgets/fires/burned-area/selectors.js
@@ -366,7 +366,10 @@ export const parseSentence = createSelector(
       seasonSentence,
       allBurn,
       allBurnWithInd,
+      thresholdStatement,
     } = sentences;
+    const thresh = options?.firesThreshold?.value;
+
     const indicatorLabel =
       indicator && indicator.label ? indicator.label : null;
     const { startIndex, endIndex } = indexes;
@@ -436,14 +439,20 @@ export const parseSentence = createSelector(
 
     const initialSentence = seasonStartDate ? seasonSentence : defaultSentence;
 
-    const sentence = indicator
+    let sentence = indicator
       ? initialSentence + allBurnWithInd
       : initialSentence + allBurn;
+
+    sentence =
+      thresh && thresh > 0
+        ? sentence + thresholdStatement
+        : sentence.concat('.');
 
     const formattedData = moment(date).format('Do of MMMM YYYY');
     const params = {
       location,
       indicator: indicatorLabel,
+      thresh: `${thresh}%`,
       date: formattedData,
       fires_season_start: seasonStatement,
       fire_season_length: sortedPeakWeeks.length,

--- a/components/widgets/fires/fire-alerts-simple/index.js
+++ b/components/widgets/fires/fire-alerts-simple/index.js
@@ -288,6 +288,7 @@ export default {
     },
     {
       key: 'dataset',
+      whitelist: ['viirs', 'modis'],
       label: 'fires dataset',
       type: 'select',
     },

--- a/components/widgets/fires/fires-alerts-historical-weekly/index.js
+++ b/components/widgets/fires/fires-alerts-historical-weekly/index.js
@@ -40,6 +40,7 @@ export default {
     {
       key: 'dataset',
       label: 'fires dataset',
+      whitelist: ['viirs', 'modis'],
       type: 'select',
     },
     {

--- a/components/widgets/manifest.js
+++ b/components/widgets/manifest.js
@@ -17,13 +17,10 @@ import gladRanked from 'components/widgets/forest-change/glad-ranked';
 // fires
 import firesOTF from 'components/widgets/fires/fires';
 import firesAlerts from 'components/widgets/fires/fires-alerts';
-// import firesAlertsCumulative from 'components/widgets/fires/fires-alerts-cumulative';
-// import burnedArea from 'components/widgets/fires/burned-area';
 import burnedAreaCumulative from 'components/widgets/fires/burned-area-cumulative';
 import burnedAreaRanked from 'components/widgets/fires/burned-area-ranked';
 import firesAlertsHistorical from 'components/widgets/fires/fires-alerts-historical-weekly';
 import firesAlertsHistoricalDaily from 'components/widgets/fires/fires-alerts-historical-daily';
-// import firesRanked from 'components/widgets/fires/fires-ranked';
 import firesAlertsSimple from 'components/widgets/fires/fire-alerts-simple';
 
 // land cover
@@ -71,12 +68,9 @@ export default {
 
   // fires
   firesAlerts,
-  // firesAlertsCumulative,
-  // burnedArea,
   burnedAreaCumulative,
   burnedAreaRanked,
   firesAlertsHistorical,
-  // firesRanked,
   firesAlertsHistoricalDaily,
   firesOTF,
   firesAlertsSimple,

--- a/data/forest-types.js
+++ b/data/forest-types.js
@@ -49,6 +49,7 @@ export default [
       glad: 'is__ifl_intact_forest_landscape_2016',
       viirs: 'is__ifl_intact_forest_landscape_2016',
       modis: 'is__ifl_intact_forest_landscape_2016',
+      modis_burned_area: 'is__ifl_intact_forest_landscape_2016',
     },
     metaKey: 'intact_forest_landscapes_change',
     global: true,


### PR DESCRIPTION
## Overview

Addresses feedback for Fires Widgets currently in develop branch.

- Adds whitelist to fires datasets in widgets not currently using burned areas (`firesHistorical`, `firesAlertsSimple`)
- Fixes intact forest issues (adds burned areas datasets
- Some cleaning of code