### PR TITLE
Fix missing week-53 when comparing years

### DIFF
--- a/components/widgets/fires/burned-area/selectors.js
+++ b/components/widgets/fires/burned-area/selectors.js
@@ -149,17 +149,26 @@ export const parseData = createSelector(
     if (!data || isEmpty(data) || !currentData || isEmpty(currentData))
       return null;
 
-    return currentData.map((d) => {
-      const yearDifference = maxminYear.max - d.year;
-      const { week } = d;
+    // @TODO: better compare year parsing
+    const { year: startYear, week: startWeek } = currentData[0];
+    const yearDifference = maxminYear.max - startYear;
 
+    const compareStartYear = compareYear - yearDifference;
+    const weekFound = !!data.find(
+      (el) => el.year === compareStartYear && el.week === startWeek
+    );
+
+    const findWeek = weekFound ? startWeek : 1;
+    const findYear = weekFound ? compareStartYear : compareStartYear + 1;
+
+    const compareStartIndex = data.findIndex(
+      (el) => el.year === findYear && el.week === findWeek
+    );
+
+    const parsedData = currentData.map((d, i) => {
       if (compareYear) {
         const parsedCompareYear = compareYear - yearDifference;
-
-        const compareWeek = data.find(
-          (dt) => dt.year === parsedCompareYear && dt.week === week
-        );
-
+        const compareWeek = data[compareStartIndex + i];
         return {
           ...d,
           compareYear: parsedCompareYear,
@@ -169,6 +178,7 @@ export const parseData = createSelector(
 
       return d;
     });
+    return parsedData;
   }
 );
 

--- a/components/widgets/fires/fires-alerts/selectors.js
+++ b/components/widgets/fires/fires-alerts/selectors.js
@@ -149,17 +149,26 @@ export const parseData = createSelector(
     if (!data || isEmpty(data) || !currentData || isEmpty(currentData))
       return null;
 
-    return currentData.map((d) => {
-      const yearDifference = maxminYear.max - d.year;
-      const { week } = d;
+    // @TODO: better compare year parsing
+    const { year: startYear, week: startWeek } = currentData[0];
+    const yearDifference = maxminYear.max - startYear;
 
+    const compareStartYear = compareYear - yearDifference;
+    const weekFound = !!data.find(
+      (el) => el.year === compareStartYear && el.week === startWeek
+    );
+
+    const findWeek = weekFound ? startWeek : 1;
+    const findYear = weekFound ? compareStartYear : compareStartYear + 1;
+
+    const compareStartIndex = data.findIndex(
+      (el) => el.year === findYear && el.week === findWeek
+    );
+
+    const parsedData = currentData.map((d, i) => {
       if (compareYear) {
         const parsedCompareYear = compareYear - yearDifference;
-
-        const compareWeek = data.find(
-          (dt) => dt.year === parsedCompareYear && dt.week === week
-        );
-
+        const compareWeek = data[compareStartIndex + i];
         return {
           ...d,
           compareYear: parsedCompareYear,
@@ -169,6 +178,7 @@ export const parseData = createSelector(
 
       return d;
     });
+    return parsedData;
   }
 );
 


### PR DESCRIPTION
## Overview

When selecting a compare year in the fires alert widgets, if the current year had a week 53 whilst the comparison did not - the chart would show a null datapoint (missing point)

e.g. [Australia 2019](https://preproduction.globalforestwatch.org/dashboards/country/AUS/?category=fires&fireAlertStats=eyJjb21wYXJlWWVhciI6MjAxOX0%3D&location=WyJjb3VudHJ5IiwiQVVTIl0%3D&map=eyJjZW50ZXIiOnsibGF0IjotMjAuNjMyNzk3NDg3NTYyODA0LCJsbmciOjEzNi4wMTM4NDczNTAwNTUwN30sImNhbkJvdW5kIjpmYWxzZSwiZGF0YXNldHMiOlt7ImRhdGFzZXQiOiJwb2xpdGljYWwtYm91bmRhcmllcyIsImxheWVycyI6WyJkaXNwdXRlZC1wb2xpdGljYWwtYm91bmRhcmllcyIsInBvbGl0aWNhbC1ib3VuZGFyaWVzIl0sImJvdW5kYXJ5Ijp0cnVlLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlfSx7ImRhdGFzZXQiOiJmaXJlLWFsZXJ0cy12aWlycyIsImxheWVycyI6WyJmaXJlLWFsZXJ0cy12aWlycyJdLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlLCJ0aW1lbGluZVBhcmFtcyI6eyJzdGFydERhdGVBYnNvbHV0ZSI6IjIwMjEtMDQtMDEiLCJlbmREYXRlQWJzb2x1dGUiOiIyMDIxLTA2LTMwIiwic3RhcnREYXRlIjoiMjAyMS0wNC0wMSIsImVuZERhdGUiOiIyMDIxLTA2LTMwIiwidHJpbUVuZERhdGUiOiIyMDIxLTA2LTMwIn19XX0%3D)

![Screen Shot 2021-07-01 at 14 05 19](https://user-images.githubusercontent.com/30242314/124121693-7ee68f00-da75-11eb-8c76-d917d1c158f5.png)

This fix now skips over those weeks and jumps to the start of the following year by iterating over the index instead of trying to find elements with matching year/week combos.

