### PR TITLE
Add flux widget

### DIFF
--- a/components/analysis/components/show-analysis/styles.scss
+++ b/components/analysis/components/show-analysis/styles.scss
@@ -7,7 +7,6 @@
 
   .show-analysis-body {
     width: 100%;
-    height: 100%;
     min-height: rem(260px);
     padding: rem(20px);
   }

--- a/components/widgets/climate/carbon-flux/index.js
+++ b/components/widgets/climate/carbon-flux/index.js
@@ -6,12 +6,16 @@ import { getCarbonFlux, getCarbonFluxOTF } from 'services/analysis-cached';
 import {
   POLITICAL_BOUNDARIES_DATASET,
   CARBON_FLUX_DATASET,
+  CARBON_REMOVALS_DATASET,
+  CARBON_EMISSIONS_DATASET,
 } from 'data/datasets';
 
 import {
   DISPUTED_POLITICAL_BOUNDARIES,
   POLITICAL_BOUNDARIES,
   CARBON_FLUX,
+  CARBON_REMOVALS,
+  CARBON_EMISSIONS,
 } from 'data/layers';
 
 import { shouldQueryPrecomputedTables } from 'components/widgets/utils/helpers';
@@ -70,6 +74,14 @@ export default {
     {
       dataset: CARBON_FLUX_DATASET,
       layers: [CARBON_FLUX],
+    },
+    {
+      dataset: CARBON_REMOVALS_DATASET,
+      layers: [CARBON_REMOVALS],
+    },
+    {
+      dataset: CARBON_EMISSIONS_DATASET,
+      layers: [CARBON_EMISSIONS],
     },
   ],
   pendingKeys: ['threshold'],

--- a/data/datasets.js
+++ b/data/datasets.js
@@ -11,6 +11,7 @@ export const FOREST_EXTENT_DATASET = 'tree-cover';
 export const BIOMASS_LOSS_DATASET =
   'carbon-dioxide-emissions-from-tree-cover-loss';
 export const CARBON_EMISSIONS_DATASET = 'carbon-emissions';
+export const CARBON_REMOVALS_DATASET = 'carbon-removals';
 export const CARBON_FLUX_DATASET = 'net-carbon-flux';
 export const BURNED_AREA_MODIS_DATASET = 'burned-area-modis';
 

--- a/data/layers.js
+++ b/data/layers.js
@@ -9,6 +9,7 @@ export const TREE_COVER_LOSS_BY_DOMINANT_DRIVER =
 export const RIVER_BASINS_BOUNDARIES = 'river-basin-boundaries';
 export const BIOMASS_LOSS = 'carbon-dioxide-emissions-from-tree-cover-loss';
 export const CARBON_EMISSIONS = 'carbon-emissions-2001-2020';
+export const CARBON_REMOVALS = 'carbon-removals-2001-2020';
 export const CARBON_FLUX = 'net-carbon-flux-2001-2020';
 export const BURNED_AREA_MODIS = 'burned-area-modis';
 export const SOIL_CARBON_DENSITY = 'soil-carbon-density';

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -599,9 +599,9 @@ export const getCarbonFluxOTF = (params) => {
 
   return apiRequest.get(url).then(({ data: { data } }) =>
     data.map((d) => ({
-      removals: -d.gfw_forest_carbon_net_flux__Mg_CO2e || 0,
+      removals: -d.gfw_forest_carbon_gross_removals__Mg_CO2e || 0,
       emissions: d.gfw_forest_carbon_gross_emissions__Mg_CO2e || 0,
-      flux: d.gfw_forest_carbon_gross_removals__Mg_CO2e || 0,
+      flux: d.gfw_forest_carbon_net_flux__Mg_CO2e || 0,
     }))
   );
 };


### PR DESCRIPTION
## Overview

Adds Carbon Flux Widget _on the fly_ (OTF) analysis for custom shapes on the map.

*Carbon Flux*
![Screen Shot 2021-07-13 at 09 47 01](https://user-images.githubusercontent.com/30242314/125412633-62c0e700-e3bf-11eb-89dd-8c17771f6a27.png)

*Carbon Emissions*
<img width="1429" alt="Screen Shot 2021-07-13 at 11 24 51" src="https://user-images.githubusercontent.com/30242314/125428049-da2cef5c-0121-4d85-a172-04f5dafe8120.png">


## Testing

Open map, open `Climate` tab, select a layer in the  `CARBON FLUX` sub-section, create custom analysis by drawing an area.

## Notes

Analysis functions in `analysis-cached.js` using OTF are slightly different to Postgre table analyses since they use different fields and require `geostore_id` and `geostore_orging` query params.

Additionally, since they hit a different dataset route in the data-api, they require `staticStatement.table` to be passed in the `params`.

As such, these functions are labelled as `<function_name>OTF` to distinguish them from regular (postgres) table analysis functions.