### PR TITLE
Planet Visual and Analytic basemaps

### DIFF
--- a/components/basemaps/index.js
+++ b/components/basemaps/index.js
@@ -51,7 +51,7 @@ class BasemapsContainer extends React.Component {
       }),
       ...(value === 'planet' && {
         name: this.handlePlanetName(name, color),
-        color: color || 'rgb',
+        color: color || '',
       }),
     };
 

--- a/components/modals/welcome/index.js
+++ b/components/modals/welcome/index.js
@@ -86,7 +86,7 @@ const welcomeCards = [
         // @planet We have to do this in a static fashion for now
         // An option would be to fetch the options on compilation time at a later stage
         name: 'planet_medres_normalized_analytic_2021-05_mosaic',
-        color: 'rgb',
+        color: '',
       },
     },
     mainMap: {

--- a/components/satellite-basemaps/component.jsx
+++ b/components/satellite-basemaps/component.jsx
@@ -50,12 +50,11 @@ const SatelliteBasemaps = ({
   const [open, setOpen] = useState(false);
   const [defaultSatSet, setDefaultSatSet] = useState(false);
   const toggleOpen = () => setOpen(!open);
-
   useEffect(() => {
     if (isTropics && !defaultSatSet) {
       setMapBasemap({
         value: 'planet',
-        color: 'rgb',
+        color: '',
         name: planetPeriods[planetPeriods.length - 1].value,
       });
       setDefaultSatSet(true);
@@ -72,8 +71,9 @@ const SatelliteBasemaps = ({
     setMapBasemap({
       value: activeBasemap.active ? 'default' : activeBasemap.value,
       ...(activeBasemap.value === 'planet' && {
-        color: 'rgb',
+        color: '',
         name: planetPeriods[planetPeriods.length - 1].value,
+        imageType: planetPeriods[planetPeriods.length - 1].imageType,
       }),
       ...(activeBasemap.value === 'landsat' && {
         year: landsatYear,
@@ -96,8 +96,9 @@ const SatelliteBasemaps = ({
     setMapBasemap({
       value,
       ...(value === 'planet' && {
-        color: 'rgb',
+        color: '',
         name: planetPeriods[planetPeriods.length - 1].value,
+        imageType: planetPeriods[planetPeriods.length - 1].imageType,
       }),
       ...(value === 'landsat' && {
         year: landsatYear,

--- a/components/satellite-basemaps/planet-selectors.js
+++ b/components/satellite-basemaps/planet-selectors.js
@@ -8,10 +8,7 @@ const selectPlanetBasemaps = (state) => {
   // const activeType = state?.map?.settings?.basemap?.color;
   // This can be either rgb<string> hex value <#xxx> or nir<string>
   // const imageType = activeType !== 'cir' ? 'visual' : 'analytic';
-  const imageType = 'analytic';
-  const planetBasemaps = state.planet?.data;
-  // XXX: Filter planet basemaps based on active image type
-  return planetBasemaps?.filter((bm) => bm.name.includes(imageType));
+  return state.planet?.data;
 };
 
 // ES6 provision, replace the hyphens with slashes forces UTC to be calculated from timestamp
@@ -31,6 +28,13 @@ export const getPlanetBasemaps = createSelector(
         const monthDiff = differenceInMonths(endDate, startDate);
         const year = format(startDate, 'yyyy');
 
+        let imageType = null;
+        if (name.includes('visual')) {
+          imageType = 'visual';
+        } else if (name.includes('analytic')) {
+          imageType = 'analytic';
+        }
+
         const period =
           monthDiff === 1
             ? `${format(startDate, 'MMM yyyy')}`
@@ -49,6 +53,7 @@ export const getPlanetBasemaps = createSelector(
           period,
           label,
           year,
+          imageType,
           sortOrder: Date(startDate),
         };
       }),

--- a/components/satellite-basemaps/planet-selectors.js
+++ b/components/satellite-basemaps/planet-selectors.js
@@ -5,9 +5,7 @@ import sortBy from 'lodash/sortBy';
 import { format, differenceInMonths } from 'date-fns';
 
 const selectPlanetBasemaps = (state) => {
-  // const activeType = state?.map?.settings?.basemap?.color;
   // This can be either rgb<string> hex value <#xxx> or nir<string>
-  // const imageType = activeType !== 'cir' ? 'visual' : 'analytic';
   return state.planet?.data;
 };
 
@@ -20,7 +18,7 @@ const cleanPlanetDate = (dateStr) =>
 export const getPlanetBasemaps = createSelector(
   [selectPlanetBasemaps],
   (planetBasemaps) => {
-    if (isEmpty(planetBasemaps)) return null;
+    if (!planetBasemaps || isEmpty(planetBasemaps)) return null;
     return sortBy(
       planetBasemaps.map(({ name, first_acquired, last_acquired } = {}) => {
         const startDate = cleanPlanetDate(first_acquired);
@@ -29,10 +27,12 @@ export const getPlanetBasemaps = createSelector(
         const year = format(startDate, 'yyyy');
 
         let imageType = null;
+        let proc = '';
         if (name.includes('visual')) {
           imageType = 'visual';
         } else if (name.includes('analytic')) {
           imageType = 'analytic';
+          proc = 'cir';
         }
 
         const period =
@@ -53,6 +53,7 @@ export const getPlanetBasemaps = createSelector(
           period,
           label,
           year,
+          proc,
           imageType,
           sortOrder: Date(startDate),
         };

--- a/components/satellite-basemaps/settings/planet-menu/component.jsx
+++ b/components/satellite-basemaps/settings/planet-menu/component.jsx
@@ -12,6 +12,7 @@ function periodsAsSelect(periods) {
 
 export const PlanetMenu = ({
   periodOptions,
+  defaultPeriodOption,
   periodSelectedIndex,
   setMapBasemap,
   colorOptions,
@@ -38,7 +39,8 @@ export const PlanetMenu = ({
       theme="theme-dropdown-native theme-dropdown-native-button-green theme-dropdown-full-width"
       value={colorSelected}
       options={colorOptions}
-      onChange={(color) => setMapBasemap({ color })}
+      onChange={(color) =>
+        setMapBasemap({ color, name: defaultPeriodOption?.value })}
       native
     />
   </div>
@@ -46,6 +48,7 @@ export const PlanetMenu = ({
 
 PlanetMenu.propTypes = {
   periodOptions: PropTypes.array,
+  defaultPeriodOption: PropTypes.object,
   periodSelectedIndex: PropTypes.number,
   colorOptions: PropTypes.array,
   colorSelected: PropTypes.string,

--- a/components/satellite-basemaps/settings/planet-menu/selectors.js
+++ b/components/satellite-basemaps/settings/planet-menu/selectors.js
@@ -25,22 +25,43 @@ const selectBasemapColorSelected = (state) =>
 const selectBasemapImageTypeSelected = (state) =>
   state?.map?.settings?.basemap?.color === '' ? 'visual' : 'analytic';
 
+const serializePlanetTile = ({
+  label,
+  period,
+  name,
+  imageType,
+  sortOrder,
+  year,
+  proc,
+} = {}) => ({
+  label,
+  period,
+  year,
+  imageType,
+  sortOrder,
+  proc,
+  value: name,
+});
+
+// Returns the opposite default option, used when switching image types
+const getDefaultPeriodOption = createSelector(
+  [selectBasemapImageTypeSelected, getPlanetBasemaps],
+  (selected, planetBasemaps) => {
+    if (isEmpty(planetBasemaps)) return null;
+    const oppositeImage = selected === 'visual' ? 'analytic' : 'visual';
+    const periodOptions = planetBasemaps
+      .map((tile) => serializePlanetTile(tile))
+      .filter((bm) => bm.imageType === oppositeImage);
+    return periodOptions[0];
+  }
+);
+
 export const getPeriodOptions = createSelector(
   [selectBasemapImageTypeSelected, getPlanetBasemaps],
   (selected, planetBasemaps) => {
     if (isEmpty(planetBasemaps)) return null;
     const periodOptions = planetBasemaps
-      ?.map(
-        ({ label, period, name, imageType, sortOrder, year, proc } = {}) => ({
-          label,
-          period,
-          year,
-          imageType,
-          sortOrder,
-          proc,
-          value: name,
-        })
-      )
+      ?.map((tile) => serializePlanetTile(tile))
       .filter((bm) => bm.imageType === selected)
       .reverse();
     return periodOptions;
@@ -48,8 +69,8 @@ export const getPeriodOptions = createSelector(
 );
 
 export const getPeriodSelected = createSelector(
-  [getPeriodOptions, selectBasemapSelected],
-  (periodOptions, selected) => {
+  [selectBasemapSelected, getPeriodOptions],
+  (selected, periodOptions) => {
     if (isEmpty(periodOptions)) return null;
     const period = periodOptions?.find((r) => r.value === selected);
     if (!period) return periodOptions[0];
@@ -84,4 +105,5 @@ export default createStructuredSelector({
   periodSelectedIndex: getPeriodSelectedIndex,
   colorOptions: getColorOptions,
   colorSelected: getColorSelected,
+  defaultPeriodOption: getDefaultPeriodOption,
 });

--- a/components/satellite-basemaps/settings/planet-menu/selectors.js
+++ b/components/satellite-basemaps/settings/planet-menu/selectors.js
@@ -5,11 +5,13 @@ import { getPlanetBasemaps } from '../../planet-selectors';
 
 const COLOR_OPTIONS = [
   {
-    label: 'Natural color',
-    value: 'rgb',
+    label: 'Visual',
+    imageType: 'visual',
+    value: '',
   },
   {
-    label: 'False color (NIR)',
+    label: 'Analytic',
+    imageType: 'analytic',
     value: 'cir',
   },
 ];
@@ -25,10 +27,11 @@ export const getPeriodOptions = createSelector(
   (planetBasemaps) => {
     if (isEmpty(planetBasemaps)) return null;
     return planetBasemaps
-      ?.map(({ label, period, name, year } = {}) => ({
+      ?.map(({ label, period, name, imageType, year } = {}) => ({
         label,
         period,
         year,
+        imageType,
         value: name,
       }))
       .reverse();
@@ -61,7 +64,8 @@ export const getColorOptions = createSelector([], () => COLOR_OPTIONS);
 
 export const getColorSelected = createSelector(
   [getColorOptions, selectBasemapColorSelected],
-  (options, selected) => options.find((o) => o.value === selected)?.value
+  (options, selected) =>
+    options.find((o) => o.imageType === selected)?.imageType
 );
 
 export default createStructuredSelector({

--- a/components/satellite-basemaps/settings/planet-menu/selectors.js
+++ b/components/satellite-basemaps/settings/planet-menu/selectors.js
@@ -22,19 +22,28 @@ const selectBasemapSelected = (state) => {
 const selectBasemapColorSelected = (state) =>
   state?.map?.settings?.basemap?.color;
 
+const selectBasemapImageTypeSelected = (state) =>
+  state?.map?.settings?.basemap?.color === '' ? 'visual' : 'analytic';
+
 export const getPeriodOptions = createSelector(
-  [getPlanetBasemaps],
-  (planetBasemaps) => {
+  [selectBasemapImageTypeSelected, getPlanetBasemaps],
+  (selected, planetBasemaps) => {
     if (isEmpty(planetBasemaps)) return null;
-    return planetBasemaps
-      ?.map(({ label, period, name, imageType, year } = {}) => ({
-        label,
-        period,
-        year,
-        imageType,
-        value: name,
-      }))
+    const periodOptions = planetBasemaps
+      ?.map(
+        ({ label, period, name, imageType, sortOrder, year, proc } = {}) => ({
+          label,
+          period,
+          year,
+          imageType,
+          sortOrder,
+          proc,
+          value: name,
+        })
+      )
+      .filter((bm) => bm.imageType === selected)
       .reverse();
+    return periodOptions;
   }
 );
 
@@ -64,8 +73,9 @@ export const getColorOptions = createSelector([], () => COLOR_OPTIONS);
 
 export const getColorSelected = createSelector(
   [getColorOptions, selectBasemapColorSelected],
-  (options, selected) =>
-    options.find((o) => o.imageType === selected)?.imageType
+  (options, selected) => {
+    return options.find((o) => o.value === selected)?.value;
+  }
 );
 
 export default createStructuredSelector({

--- a/components/satellite-basemaps/settings/planet-menu/selectors.js
+++ b/components/satellite-basemaps/settings/planet-menu/selectors.js
@@ -5,12 +5,12 @@ import { getPlanetBasemaps } from '../../planet-selectors';
 
 const COLOR_OPTIONS = [
   {
-    label: 'Visual',
+    label: 'Natural Color',
     imageType: 'visual',
     value: '',
   },
   {
-    label: 'Analytic',
+    label: 'False color (NIR)',
     imageType: 'analytic',
     value: 'cir',
   },

--- a/pages/api/planet-tiles/[...params].js
+++ b/pages/api/planet-tiles/[...params].js
@@ -10,7 +10,7 @@ export default async function userHandler(req, res) {
       const tile = await axios.get(
         `https://tiles.planet.com/basemaps/v1/planet-tiles/${params?.join(
           '/'
-        )}.png?proc=${proc || 'rgb'}&api_key=${
+        )}.png?proc=${proc || ''}&api_key=${
           process.env.NEXT_PUBLIC_PLANET_API_KEY
         }`,
         {


### PR DESCRIPTION
## Update

We need to implement this in a way that allows it to work when there are Visual basemaps (using the staging key) and when there are not (using the current production key).

The user should always see2 options:

1. Natural Colour (`proc=''` if visual basemaps are available, else `proc='rgb'` and analytic basemap if not)
2. False Colour (NIR) (always `proc='cir' and analytic basemap`)

## Overview

Adds new code to test new visual basemaps for Planet. Note that is should fix a previous issue where visual basemaps were not returning correctly.

New basemaps have the the following nomenclature:

- `planet_medres_visual_20YY-MM_20YY-MM_mosaic` for 6-monthly mosaics
- `planet_medres_visual_20YY-MM_mosaic` for monthly mosaics

Here 'visual' basemaps need to be sent with the query param `proc=''`, whereas analytic mosaics can be sent with `proc='rgb'` or `proc='cir'` for 'false colour'.

This means that we have 3 options for each time range:

- **Visual** with `proc=''` (True colour)
- **Analytic** with `proc='cir'` (False colour NIR)

<img width="449" alt="Screen Shot 2021-07-19 at 13 44 59" src="https://user-images.githubusercontent.com/30242314/126155222-1cde1482-f7cc-43f2-a9e1-ff0211ebbf22.png">

## Note

Requires a new Planet API key in `.env`: `NEXT_PUBLIC_PLANET_API_KEY` ping @01painadam for a test key.

## Todo

- Legend title missing date when you switch from Visual to Analytic
- When switching, the default map is often the earliest date (not latest)