### PR TITLE
Unhide download button for geostore analysis on map

### DIFF
--- a/components/widget/components/widget-header/component.jsx
+++ b/components/widget/components/widget-header/component.jsx
@@ -64,15 +64,18 @@ class WidgetHeader extends PureComponent {
       preventCloseSettings,
       getDataURL,
       status,
+
       shouldSettingsOpen,
       toggleSettingsMenu,
     } = this.props;
 
     const showSettingsBtn = !simple && !isEmpty(settingsConfig);
     const showDownloadBtn = !embed && getDataURL && status !== 'pending';
+    const disableDownloadBtn = disableDownload || status !== 'saved'
+    console.log(disableDownloadBtn, disableDownload, status)
     const showMapBtn = !embed && !simple && datasets;
     const showSeparator = showSettingsBtn || showMapBtn;
-    let disabledMessageString = null;
+    let disabledMessageString = status === 'unsaved' ? 'Save area in My GFW to access downloads.': 'Download unavailable.';
     if (disableDownload) {
       disabledMessageString = filterSelected
         ? `Remove Forest Type and Land Category filters to download.`
@@ -113,7 +116,7 @@ class WidgetHeader extends PureComponent {
             {showDownloadBtn && (
               <WidgetDownloadButton
                 disabled={
-                  disableDownload ||
+                  disableDownloadBtn ||
                   widget === 'gladAlerts' ||
                   widget === 'gladRanked'
                 }

--- a/components/widget/components/widget-header/component.jsx
+++ b/components/widget/components/widget-header/component.jsx
@@ -71,11 +71,13 @@ class WidgetHeader extends PureComponent {
 
     const showSettingsBtn = !simple && !isEmpty(settingsConfig);
     const showDownloadBtn = !embed && getDataURL && status !== 'pending';
-    const disableDownloadBtn = disableDownload || status !== 'saved'
-    console.log(disableDownloadBtn, disableDownload, status)
+    const disableDownloadBtn = disableDownload || status !== 'saved';
     const showMapBtn = !embed && !simple && datasets;
     const showSeparator = showSettingsBtn || showMapBtn;
-    let disabledMessageString = status === 'unsaved' ? 'Save area in My GFW to access downloads.': 'Download unavailable.';
+    let disabledMessageString =
+      status === 'unsaved'
+        ? 'Save area in My GFW to access downloads.'
+        : 'Download unavailable.';
     if (disableDownload) {
       disabledMessageString = filterSelected
         ? `Remove Forest Type and Land Category filters to download.`

--- a/components/widget/components/widget-header/component.jsx
+++ b/components/widget/components/widget-header/component.jsx
@@ -70,10 +70,11 @@ class WidgetHeader extends PureComponent {
     } = this.props;
 
     const showSettingsBtn = !simple && !isEmpty(settingsConfig);
-    const showDownloadBtn = !embed && getDataURL && status !== 'pending';
-    const disableDownloadBtn = disableDownload || status !== 'saved';
+    const showDownloadBtn = !embed && getDataURL; // Show everywhere
+    const disableDownloadBtn = disableDownload || status !== 'saved'; // Disable everywhere
     const showMapBtn = !embed && !simple && datasets;
     const showSeparator = showSettingsBtn || showMapBtn;
+
     let disabledMessageString =
       status === 'unsaved'
         ? 'Save area in My GFW to access downloads.'

--- a/components/widget/components/widget-header/components/widget-download-button/component.jsx
+++ b/components/widget/components/widget-header/components/widget-download-button/component.jsx
@@ -150,7 +150,9 @@ class WidgetDownloadButton extends PureComponent {
         .join('\n');
 
     if (location.type === 'geostore') {
-      locationData = locationData[location.adm0];
+      locationData = locationData
+        ? locationData[location.adm0]
+        : { [`${title || 'Selected Area'}`]: location.adm0 };
       locationMetadataFile =
         !isEmpty(locationData) &&
         [`name,${adminLevel}${adminLevel !== 'iso' ? '__id' : ''}`]
@@ -247,11 +249,10 @@ class WidgetDownloadButton extends PureComponent {
 
   render() {
     const { areaTooLarge, disabled, disabledMessage } = this.props;
-
     let tooltipText =
       this.isGladAlertsWidget() && this.isCustomShape()
-        ? 'Download the data. Please add .csv to the filename if extension is missing.'
-        : 'Download the data.';
+        ? 'Download data. Please add .csv to the filename if extension is missing.'
+        : 'Download data.';
 
     if (areaTooLarge) {
       tooltipText =

--- a/components/widgets/forest-change/tree-cover-gain-simple/index.js
+++ b/components/widgets/forest-change/tree-cover-gain-simple/index.js
@@ -93,5 +93,8 @@ export default {
 
     return getOTFAnalysis(params);
   },
+  getDataURL: (params) => {
+    return [getGain({ ...params, download: true })];
+  },
   getWidgetProps,
 };

--- a/components/widgets/selectors.js
+++ b/components/widgets/selectors.js
@@ -196,7 +196,7 @@ export const getLocationData = createSelector(
 
     const status = ['global', 'country', 'wdpa'].includes(locationObj.type)
       ? 'saved'
-      : (currentLocation && currentLocation.status) || 'pending';
+      : (currentLocation && currentLocation.status) || 'unsaved';
 
     return {
       parent,


### PR DESCRIPTION
## Overview

Brings back download button for map analysis results. There are 4 contexts:

1. **On custom shape Map analysis**: show button, download disabled, prompt to save as AoI  (shape is not yet saved)
2. **In newly saved custom AoI dashboards:** show button, download disabled, prompt `Download unavailable` (shape saved but is` status='pending'` for processed data)
3. **In saved custom AoI dashboards**: show button, allow download (shape saved and processed, `status='saved'`)  
4. **All other dashboards (Coountry, WDPA)**: allow download as data tables exist