### PR TITLE
Feat/vocabulary env splitting

### DIFF
--- a/providers/datasets-provider/actions.js
+++ b/providers/datasets-provider/actions.js
@@ -12,20 +12,13 @@ import decodeLayersConfig from './config';
 export const setDatasetsLoading = createAction('setDatasetsLoading');
 export const setDatasets = createAction('setDatasets');
 
+const ENV = process.env.NEXT_PUBLIC_FEATURE_ENV;
 const byVocabulary = (dataset) =>
   dataset.vocabulary &&
   dataset.vocabulary.some(
     (o) => o.name === 'layer_manager_ver' && o.tags.includes('3.0')
-  );
-
-const handleFeatureEnvLock = (env) => {
-  const currEnv = process.env.NEXT_PUBLIC_FEATURE_ENV;
-  const MIXED_ENV = 'preproduction-staging';
-  if (env === MIXED_ENV && currEnv !== 'production') {
-    return true;
-  }
-  return env === currEnv;
-};
+  ) &&
+  dataset.vocabulary.some((o) => o.name === 'gfw_env' && o.tags.includes(ENV));
 
 export const fetchDatasets = createThunkAction(
   'fetchDatasets',
@@ -33,257 +26,244 @@ export const fetchDatasets = createThunkAction(
     dispatch(setDatasetsLoading({ loading: true, error: false }));
     getDatasets()
       .then((datasets) => {
-        const parsedDatasets = datasets
-          .filter(
-            (d) =>
-              d.published &&
-              d.layer.length &&
-              (d.env === 'production' || handleFeatureEnvLock(d.env))
-          )
-          .filter(byVocabulary)
-          .map((d) => {
-            const { layer, metadata } = d;
-            const appMeta =
-              (metadata && metadata.find((m) => m.application === 'gfw')) || {};
-            const { info } = appMeta || {};
-            const defaultLayer =
-              (layer &&
-                layer.find(
-                  (l) =>
-                    (l.env === 'production' || handleFeatureEnvLock(l.env)) &&
-                    l.applicationConfig &&
-                    l.applicationConfig.default
-                )) ||
-              layer[0];
-            // we need a default layer so we can set it when toggled onto the map
-            if (!defaultLayer) return null;
+        const filterDatasets = datasets.filter(
+          (d) => d.published && d.layer.length && d.env === 'production'
+        );
+        const byVocabularyDatasets = filterDatasets.filter(byVocabulary);
 
-            const {
-              isSelectorLayer,
-              isMultiSelectorLayer,
-              isLossLayer,
-              isLossDriverLayer,
-              isKbaLayer,
-            } = info || {};
-            const { iso, applicationConfig } = defaultLayer || {};
-            const { global, selectorConfig } = applicationConfig || {};
+        const parsedDatasets = byVocabularyDatasets.map((d) => {
+          const { layer, metadata } = d;
+          const appMeta =
+            (metadata && metadata.find((m) => m.application === 'gfw')) || {};
+          const { info } = appMeta || {};
+          const defaultLayer =
+            (layer &&
+              layer.find(
+                (l) =>
+                  l.env === 'production' &&
+                  l.applicationConfig &&
+                  l.applicationConfig.default
+              )) ||
+            layer[0];
+          // we need a default layer so we can set it when toggled onto the map
+          if (!defaultLayer) return null;
 
-            // build statement config
-            let statementConfig =
-              defaultLayer.legendConfig && defaultLayer.legendConfig.statement
-                ? { statement: defaultLayer.legendConfig.statement }
-                : null;
-            if (isLossLayer) {
-              statementConfig = {
-                type: 'lossLayer',
-              };
-            } else if (isLossDriverLayer) {
-              statementConfig = {
-                type: 'lossDriverLayer',
-              };
-            } else if (isKbaLayer) {
-              statementConfig = {
-                type: 'kbaLayer',
-              };
-            } else if (global && !!iso.length && iso[0]) {
-              statementConfig = {
-                type: 'isoLayer',
-                isos: iso,
-              };
-            }
+          const {
+            isSelectorLayer,
+            isMultiSelectorLayer,
+            isLossLayer,
+            isLossDriverLayer,
+            isKbaLayer,
+          } = info || {};
+          const { iso, applicationConfig } = defaultLayer || {};
+          const { global, selectorConfig } = applicationConfig || {};
 
-            return {
-              id: applicationConfig?.dataset_slug || applicationConfig.slug,
-              dataset:
-                applicationConfig?.dataset_slug || applicationConfig.slug,
-              name: d.name,
-              layer: applicationConfig.slug,
-              ...applicationConfig,
-              ...info,
-              iso,
-              slug: applicationConfig?.dataset_slug || applicationConfig.slug,
-              tags: flatten(d.vocabulary.map((v) => v.tags)),
-              // dropdown selector config
-              ...((isSelectorLayer || isMultiSelectorLayer) && {
-                selectorLayerConfig: {
-                  options: layer.map((l) => ({
-                    ...l.applicationConfig.selectorConfig,
-                    value: l?.applicationConfig?.slug,
-                  })),
-                  ...selectorConfig,
-                },
-              }),
-              // disclaimer statement config
-              statementConfig,
-              // layers config
-              layers:
-                layer &&
-                sortBy(
-                  layer
-                    .filter(
-                      (l) =>
-                        (l.env === 'production' ||
-                          handleFeatureEnvLock(l.env)) &&
-                        l.published
-                    )
-                    .map((l, i) => {
-                      const { layerConfig, legendConfig } = l;
-                      const { position, confirmedOnly, multiConfig } =
-                        l.applicationConfig || {};
-                      const {
-                        params_config,
-                        decode_config,
-                        sql_config,
-                        timeline_config,
-                        source, // v3
-                        decode_function, // v3
-                      } = layerConfig;
-                      const { tiles } = source || {}; // previously url
-                      const decodeFunction =
-                        decodeLayersConfig[decode_function];
-                      const customColor =
-                        legendConfig &&
-                        legendConfig.items &&
-                        legendConfig.items[0].color;
-
-                      // check if has a timeline
-                      const hasParamsTimeline =
-                        params_config &&
-                        params_config.map((p) => p.key).includes('startDate');
-                      const hasDecodeTimeline =
-                        decode_config &&
-                        decode_config.map((p) => p.key).includes('startDate');
-                      const timelineConfig = timeline_config && {
-                        ...timeline_config,
-                        railStyle: {
-                          background: '#d6d6d9',
-                          borderRadius: '0px',
-                        },
-                        trackStyle: [
-                          {
-                            background: customColor,
-                          },
-                          {
-                            background: chroma(customColor).darken(1.3).hex(),
-                          },
-                        ],
-                      };
-
-                      // get params
-                      const params =
-                        params_config && reduceParams(params_config);
-                      const decodeParams =
-                        decode_config && reduceParams(decode_config);
-                      const sqlParams =
-                        sql_config && reduceSqlParams(sql_config);
-
-                      return {
-                        ...info,
-                        ...l,
-                        id: l?.applicationConfig.slug,
-                        ...(d.tableName && { tableName: d.tableName }),
-                        ...l.applicationConfig,
-                        dataset:
-                          applicationConfig.dataset_slug ||
-                          applicationConfig.slug,
-                        // sorting position
-                        position: l.applicationConfig.default
-                          ? 0
-                          : position ||
-                            (multiConfig && multiConfig.position) ||
-                            i + 1,
-                        // check if needs timeline
-                        timelineConfig,
-                        hasParamsTimeline,
-                        hasDecodeTimeline,
-                        // params for tile url
-                        ...(params && {
-                          params: {
-                            url: tiles && tiles.length && tiles[0],
-                            ...params,
-                            ...(hasParamsTimeline && {
-                              minDate: params && params.startDate,
-                              maxDate: params && params.endDate,
-                              trimEndDate: params && params.endDate,
-                            }),
-                          },
-                        }),
-                        // params selector config
-                        ...(params_config && {
-                          paramsSelectorConfig: params_config.map((p) => ({
-                            ...p,
-                            ...(p.key.includes('thresh') && {
-                              sentence:
-                                p.sentence ||
-                                'Displaying {name} with {selector} canopy density',
-                              options: p.options || thresholdOptions,
-                            }),
-                            ...(p.min &&
-                              p.max && {
-                                options: Array.from(
-                                  Array(p.max - p.min + 1).keys()
-                                ).map((o) => ({
-                                  label: o + p.min,
-                                  value: o + p.min,
-                                })),
-                              }),
-                            ...(p.sentence &&
-                              p.options && {
-                                sentence: p.sentence,
-                                options: p.options,
-                              }),
-                          })),
-                        }),
-                        // decode params selector config
-                        ...(decode_config && {
-                          decodeParamsSelectorConfig: decode_config.map(
-                            (p) => ({
-                              ...p,
-                              ...(p.key.includes('thresh') && {
-                                sentence:
-                                  'Displaying {name} with {selector} canopy density',
-                                options: thresholdOptions,
-                              }),
-                              ...(p.min &&
-                                p.max && {
-                                  options: Array.from(
-                                    Array(p.max - p.min + 1).keys()
-                                  ).map((o) => ({
-                                    label: o + p.min,
-                                    value: o + p.min,
-                                  })),
-                                }),
-                            })
-                          ),
-                        }),
-                        // params for sql query
-                        ...(sqlParams && {
-                          sqlParams,
-                        }),
-                        // decode func and params for canvas layers
-                        decodeFunction,
-                        ...(decodeParams && {
-                          decodeParams: {
-                            // timeline config
-                            ...decodeParams,
-                            ...(hasDecodeTimeline && {
-                              minDate: decodeParams.startDate,
-                              maxDate: decodeParams.endDate,
-                              trimEndDate: decodeParams.endDate,
-                              canPlay: true,
-                            }),
-                          },
-                        }),
-                        // special key for GLAD alerts
-                        ...(confirmedOnly && {
-                          id: 'confirmedOnly',
-                        }),
-                      };
-                    }),
-                  'position'
-                ),
+          // build statement config
+          let statementConfig =
+            defaultLayer.legendConfig && defaultLayer.legendConfig.statement
+              ? { statement: defaultLayer.legendConfig.statement }
+              : null;
+          if (isLossLayer) {
+            statementConfig = {
+              type: 'lossLayer',
             };
-          });
+          } else if (isLossDriverLayer) {
+            statementConfig = {
+              type: 'lossDriverLayer',
+            };
+          } else if (isKbaLayer) {
+            statementConfig = {
+              type: 'kbaLayer',
+            };
+          } else if (global && !!iso.length && iso[0]) {
+            statementConfig = {
+              type: 'isoLayer',
+              isos: iso,
+            };
+          }
+
+          return {
+            id: applicationConfig?.dataset_slug || applicationConfig.slug,
+            dataset: applicationConfig?.dataset_slug || applicationConfig.slug,
+            name: d.name,
+            layer: applicationConfig.slug,
+            ...applicationConfig,
+            ...info,
+            iso,
+            slug: applicationConfig?.dataset_slug || applicationConfig.slug,
+            tags: flatten(d.vocabulary.map((v) => v.tags)),
+            // dropdown selector config
+            ...((isSelectorLayer || isMultiSelectorLayer) && {
+              selectorLayerConfig: {
+                options: layer.map((l) => ({
+                  ...l.applicationConfig.selectorConfig,
+                  value: l?.applicationConfig?.slug,
+                })),
+                ...selectorConfig,
+              },
+            }),
+            // disclaimer statement config
+            statementConfig,
+            // layers config
+            layers:
+              layer &&
+              sortBy(
+                layer
+                  .filter((l) => l.env === 'production' && l.published)
+                  .map((l, i) => {
+                    const { layerConfig, legendConfig } = l;
+                    const { position, confirmedOnly, multiConfig } =
+                      l.applicationConfig || {};
+                    const {
+                      params_config,
+                      decode_config,
+                      sql_config,
+                      timeline_config,
+                      source, // v3
+                      decode_function, // v3
+                    } = layerConfig;
+                    const { tiles } = source || {}; // previously url
+                    const decodeFunction = decodeLayersConfig[decode_function];
+                    const customColor =
+                      legendConfig &&
+                      legendConfig.items &&
+                      legendConfig.items[0].color;
+
+                    // check if has a timeline
+                    const hasParamsTimeline =
+                      params_config &&
+                      params_config.map((p) => p.key).includes('startDate');
+                    const hasDecodeTimeline =
+                      decode_config &&
+                      decode_config.map((p) => p.key).includes('startDate');
+                    const timelineConfig = timeline_config && {
+                      ...timeline_config,
+                      railStyle: {
+                        background: '#d6d6d9',
+                        borderRadius: '0px',
+                      },
+                      trackStyle: [
+                        {
+                          background: customColor,
+                        },
+                        {
+                          background: chroma(customColor).darken(1.3).hex(),
+                        },
+                      ],
+                    };
+
+                    // get params
+                    const params = params_config && reduceParams(params_config);
+                    const decodeParams =
+                      decode_config && reduceParams(decode_config);
+                    const sqlParams = sql_config && reduceSqlParams(sql_config);
+
+                    return {
+                      ...info,
+                      ...l,
+                      id: l?.applicationConfig.slug,
+                      ...(d.tableName && { tableName: d.tableName }),
+                      ...l.applicationConfig,
+                      dataset:
+                        applicationConfig.dataset_slug ||
+                        applicationConfig.slug,
+                      // sorting position
+                      position: l.applicationConfig.default
+                        ? 0
+                        : position ||
+                          (multiConfig && multiConfig.position) ||
+                          i + 1,
+                      // check if needs timeline
+                      timelineConfig,
+                      hasParamsTimeline,
+                      hasDecodeTimeline,
+                      // params for tile url
+                      ...(params && {
+                        params: {
+                          url: tiles && tiles.length && tiles[0],
+                          ...params,
+                          ...(hasParamsTimeline && {
+                            minDate: params && params.startDate,
+                            maxDate: params && params.endDate,
+                            trimEndDate: params && params.endDate,
+                          }),
+                        },
+                      }),
+                      // params selector config
+                      ...(params_config && {
+                        paramsSelectorConfig: params_config.map((p) => ({
+                          ...p,
+                          ...(p.key.includes('thresh') && {
+                            sentence:
+                              p.sentence ||
+                              'Displaying {name} with {selector} canopy density',
+                            options: p.options || thresholdOptions,
+                          }),
+                          ...(p.min &&
+                            p.max && {
+                              options: Array.from(
+                                Array(p.max - p.min + 1).keys()
+                              ).map((o) => ({
+                                label: o + p.min,
+                                value: o + p.min,
+                              })),
+                            }),
+                          ...(p.sentence &&
+                            p.options && {
+                              sentence: p.sentence,
+                              options: p.options,
+                            }),
+                        })),
+                      }),
+                      // decode params selector config
+                      ...(decode_config && {
+                        decodeParamsSelectorConfig: decode_config.map((p) => ({
+                          ...p,
+                          ...(p.key.includes('thresh') && {
+                            sentence:
+                              'Displaying {name} with {selector} canopy density',
+                            options: thresholdOptions,
+                          }),
+                          ...(p.min &&
+                            p.max && {
+                              options: Array.from(
+                                Array(p.max - p.min + 1).keys()
+                              ).map((o) => ({
+                                label: o + p.min,
+                                value: o + p.min,
+                              })),
+                            }),
+                        })),
+                      }),
+                      // params for sql query
+                      ...(sqlParams && {
+                        sqlParams,
+                      }),
+                      // decode func and params for canvas layers
+                      decodeFunction,
+                      ...(decodeParams && {
+                        decodeParams: {
+                          // timeline config
+                          ...decodeParams,
+                          ...(hasDecodeTimeline && {
+                            minDate: decodeParams.startDate,
+                            maxDate: decodeParams.endDate,
+                            trimEndDate: decodeParams.endDate,
+                            canPlay: true,
+                          }),
+                        },
+                      }),
+                      // special key for GLAD alerts
+                      ...(confirmedOnly && {
+                        id: 'confirmedOnly',
+                      }),
+                    };
+                  }),
+                'position'
+              ),
+          };
+        });
+        console.log('parsedDatasets', parsedDatasets);
         dispatch(setDatasets(sortBy(parsedDatasets, 'menuPosition')));
       })
       .catch(() => {

--- a/providers/datasets-provider/actions.js
+++ b/providers/datasets-provider/actions.js
@@ -263,7 +263,6 @@ export const fetchDatasets = createThunkAction(
               ),
           };
         });
-        console.log('parsedDatasets', parsedDatasets);
         dispatch(setDatasets(sortBy(parsedDatasets, 'menuPosition')));
       })
       .catch(() => {

--- a/services/datasets.js
+++ b/services/datasets.js
@@ -3,7 +3,7 @@ import { rwRequest, dataRequest } from 'utils/request';
 export const getDatasets = () =>
   rwRequest
     .get(
-      `/dataset?application=gfw&includes=metadata,vocabulary,layer&page[size]=9999&env=production`
+      `/dataset?application=gfw&includes=metadata,vocabulary,layer&env=production&published=true&page[size]=9999`
     )
     .then((res) => res?.data);
 

--- a/services/datasets.js
+++ b/services/datasets.js
@@ -1,14 +1,9 @@
 import { rwRequest, dataRequest } from 'utils/request';
 
-// Feature env will always be "null" on production
-const featureEnv = process.env.NEXT_PUBLIC_FEATURE_ENV;
-
 export const getDatasets = () =>
   rwRequest
     .get(
-      `/dataset?application=gfw&includes=metadata,vocabulary,layer&page[size]=9999&env=production${
-        featureEnv ? `,${featureEnv},preproduction-staging` : ''
-      }${featureEnv === 'staging' ? `&refresh=${new Date()}` : ''}`
+      `/dataset?application=gfw&includes=metadata,vocabulary,layer&page[size]=9999&env=production`
     )
     .then((res) => res?.data);
 


### PR DESCRIPTION
## Overview

First step to allow Dataset & Layer separation between gfw and gfw staging applications.

Filters Datasets and Layers based on the presence of an associated Vocabulary object where:

`vocab.name === 'gfw_env' && vocab.tags.includes(ENV)`

This allows multiple environments to be allowed for a given Dataset and it's child Layers.