### PR TITLE
Filter datasets layers by env on first fetch

### DIFF
--- a/services/datasets.js
+++ b/services/datasets.js
@@ -1,9 +1,25 @@
 import { rwRequest, dataRequest } from 'utils/request';
 
+const environmentString = () => {
+  const env = process.env.NEXT_PUBLIC_FEATURE_ENV;
+  let envString = 'production';
+  if (env === 'preproduction') {
+    envString += ',preproduction';
+  }
+  if (env === 'staging') {
+    return 'staging';
+  }
+  return envString;
+};
+
 export const getDatasets = () =>
   rwRequest
     .get(
-      `/dataset?application=gfw&includes=metadata,vocabulary,layer&env=production&published=true&page[size]=9999`
+      `/dataset?application=gfw&includes=metadata,vocabulary,layer&published=true&page[size]=9999&env=${environmentString()}${
+        environmentString() === 'staging'
+          ? `&filterIncludesByEnv=true&refresh=${new Date()}`
+          : ''
+      }`
     )
     .then((res) => res?.data);
 


### PR DESCRIPTION
## Overview

Reverts recent update to filter by staging/production layers by `Vocabulary['gfw_env']`