### PR TITLE
adds download version to map and dashborad excel downloads

### DIFF
--- a/components/analysis/components/show-analysis/selectors.js
+++ b/components/analysis/components/show-analysis/selectors.js
@@ -15,7 +15,7 @@ import { FOREST_GAIN, FOREST_LOSS } from 'data/layers';
 
 const gainID = FOREST_GAIN;
 const lossID = FOREST_LOSS;
-const MAX_YEAR = 2020;
+const DOWNLOAD_VERSION = '20200331';
 
 const selectLocation = (state) => state.location && state.location.payload;
 const selectData = (state) => state.analysis && state.analysis.data;
@@ -85,7 +85,7 @@ export const getCountryDownloadLink = createSelector(
   [selectLocation],
   (location) =>
     location.type === 'country'
-      ? `https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/${MAX_YEAR}/${
+      ? `https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/${DOWNLOAD_VERSION}/${
           location.adm0 || 'global'
         }.xlsx`
       : null

--- a/layouts/dashboards/components/header/selectors.js
+++ b/layouts/dashboards/components/header/selectors.js
@@ -12,7 +12,7 @@ import {
 } from 'providers/areas-provider/selectors';
 
 const isServer = typeof window === 'undefined';
-const MAX_YEAR = 2020;
+const DOWNLOAD_VERSION = '20200331';
 
 // get list data
 export const selectLocation = (state) =>
@@ -115,7 +115,7 @@ export const getDownloadLink = createSelector(
     const { admin } = area || {};
     const { adm0 } = admin || {};
 
-    return `https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/${MAX_YEAR}/${
+    return `https://gfw2-data.s3.amazonaws.com/country-pages/country_stats/download/${DOWNLOAD_VERSION}/${
       adm0 || location?.adm0 || 'global'
     }.xlsx`;
   }


### PR DESCRIPTION
## Overview

This PR adds a new version of the country spreadsheets that include the new carbon data at s3://gfw2-data/country-pages/country_stats/download/20200331/ 

## Testing

- Go to a country dashboard and select the download from the header (this should function for global, country and admin regions)
-  Same as for Map and country analysis.
- To test, compare to the current excel downloads in production

