### PR TITLE
fix bug making it impossible to switch active widget on dashboards

### DIFF
--- a/components/widgets/index.js
+++ b/components/widgets/index.js
@@ -80,7 +80,13 @@ class WidgetsContainer extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    const { getWidgetsData, activeWidget, embed, location } = this.props;
+    const {
+      getWidgetsData,
+      activeWidget,
+      embed,
+      category,
+      location,
+    } = this.props;
     if (location.type === 'global' && prevProps.location?.type !== 'global') {
       getWidgetsData();
     }
@@ -99,15 +105,16 @@ class WidgetsContainer extends PureComponent {
         prevProps.activeWidget
       );
       const widgetSettingsChanged = !isEqual(prevSettings, settings);
-
+      const categoryChanged = !isEqual(prevProps?.category, category);
       const datasetsChanged = !isEqual(datasets, prevDatasets);
+
       if (
         (datasets &&
           datasetsChanged &&
           (mapSettingsChanged || activeWidgetChanged)) ||
         widgetSettingsChanged
       ) {
-        this.syncWidgetWithMap();
+        this.syncWidgetWithMap(categoryChanged);
       } else if (
         !datasets &&
         activeWidgetChanged &&
@@ -118,7 +125,7 @@ class WidgetsContainer extends PureComponent {
     }
   }
 
-  syncWidgetWithMap = () => {
+  syncWidgetWithMap = (categoryChanged = false) => {
     const { activeWidget, setMapSettings, setWidgetsCategory } = this.props;
     const { datasets, settings, optionsSelected } = activeWidget || {};
     const widgetDatasets =
@@ -132,7 +139,13 @@ class WidgetsContainer extends PureComponent {
     if (widgetDatasets) {
       allDatasets = [...allDatasets, ...widgetDatasets];
     }
-    setWidgetsCategory(this.props?.category || 'summary');
+
+    // XXX: If user changes category on dashboards, reset active widget + set new category
+    // otherwise user is changing active layer on current dashboard, so no need to sync
+    if (categoryChanged) {
+      setWidgetsCategory(this.props?.category || 'summary');
+    }
+
     setMapSettings({
       datasets: allDatasets,
     });

--- a/components/widgets/index.js
+++ b/components/widgets/index.js
@@ -63,6 +63,7 @@ class WidgetsContainer extends PureComponent {
     category: PropTypes.string,
     activeWidget: PropTypes.object,
     setMapSettings: PropTypes.func,
+    setActiveWidget: PropTypes.func,
     embed: PropTypes.bool,
     setWidgetsCategory: PropTypes.func,
     setDashboardPromptsSettings: PropTypes.func,
@@ -84,12 +85,19 @@ class WidgetsContainer extends PureComponent {
       getWidgetsData,
       activeWidget,
       embed,
-      category,
       location,
+      category,
+      setActiveWidget,
     } = this.props;
+
+    if (!isEqual(category, prevProps.category)) {
+      setActiveWidget(null);
+    }
+
     if (location.type === 'global' && prevProps.location?.type !== 'global') {
       getWidgetsData();
     }
+
     // if widget is active and layers or params change push to map
     if (!embed && activeWidget) {
       const { settings, datasets } = activeWidget || {};
@@ -105,7 +113,6 @@ class WidgetsContainer extends PureComponent {
         prevProps.activeWidget
       );
       const widgetSettingsChanged = !isEqual(prevSettings, settings);
-      const categoryChanged = !isEqual(prevProps?.category, category);
       const datasetsChanged = !isEqual(datasets, prevDatasets);
 
       if (
@@ -114,7 +121,7 @@ class WidgetsContainer extends PureComponent {
           (mapSettingsChanged || activeWidgetChanged)) ||
         widgetSettingsChanged
       ) {
-        this.syncWidgetWithMap(categoryChanged);
+        this.syncWidgetWithMap();
       } else if (
         !datasets &&
         activeWidgetChanged &&
@@ -125,7 +132,7 @@ class WidgetsContainer extends PureComponent {
     }
   }
 
-  syncWidgetWithMap = (categoryChanged = false) => {
+  syncWidgetWithMap = () => {
     const { activeWidget, setMapSettings, setWidgetsCategory } = this.props;
     const { datasets, settings, optionsSelected } = activeWidget || {};
     const widgetDatasets =
@@ -140,11 +147,7 @@ class WidgetsContainer extends PureComponent {
       allDatasets = [...allDatasets, ...widgetDatasets];
     }
 
-    // XXX: If user changes category on dashboards, reset active widget + set new category
-    // otherwise user is changing active layer on current dashboard, so no need to sync
-    if (categoryChanged) {
-      setWidgetsCategory(this.props?.category || 'summary');
-    }
+    setWidgetsCategory(this.props?.category || 'summary');
 
     setMapSettings({
       datasets: allDatasets,

--- a/components/widgets/reducers.js
+++ b/components/widgets/reducers.js
@@ -36,7 +36,6 @@ const setShowMap = (state, { payload }) => ({
 const setWidgetsCategory = (state, { payload }) => ({
   ...state,
   category: payload,
-  activeWidget: '',
 });
 
 const setWidgetsSettings = (state, { payload }) => ({


### PR DESCRIPTION
Currently on flagship, when switching the active widget, it resets right away as we were syncing the map + resetting the active widget when we were not suppose to. 