### PR TITLE
add high confidence alerts in the integrated deforestation alerts again

### DIFF
--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -263,7 +263,7 @@ const decodes = {
         color.r = 237. / 255.;
         color.g = 164. / 255.;
         color.b = 194. / 255.;
-        alpha = intensity / 255.;
+        alpha = (intensity -confidenceValue) / 255.;
       } else if (agreementValue == 8. || agreementValue == 32. || agreementValue ==  128.){
         // ONE HIGH CONF ALERT: 8,32,128 i.e. 2**(2+n) for n<8 and odd
 


### PR DESCRIPTION
## Overview

This PR should reactive and just show the high and highest confidence alerts when activating the high conf toggle in integrated deforestation alerts.

## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

