### PR TITLE
add new RGB values to individual alerts

### DIFF
--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -417,9 +417,9 @@ const decodes = {
         color.b = 0.;
         alpha = intensity / 255.;
       } else {
-        color.r = 220. / 255.;
-        color.g = 102. / 255.;
-        color.b = 153. / 255.;
+        color.r = 237. / 255.;
+        color.g = 164. / 255.;
+        color.b = 194. / 255.;
         alpha = intensity / 255.;
       }
     } else {
@@ -458,9 +458,9 @@ const decodes = {
         color.b = 0.;
         alpha = intensity / 255.;
       } else {
-        color.r = 220. / 255.;
-        color.g = 102. / 255.;
-        color.b = 153. / 255.;
+        color.r = 237. / 255.;
+        color.g = 164. / 255.;
+        color.b = 194. / 255.;
         alpha = intensity / 255.;
       }
     } else {

--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -411,15 +411,15 @@ const decodes = {
       if (intensity > 255.) {
         intensity = 255.;
       }
-      if (day >= numberOfDays - 7. && day <= numberOfDays) {
-        color.r = 219. / 255.;
-        color.g = 168. / 255.;
-        color.b = 0.;
-        alpha = intensity / 255.;
-      } else {
+      if (confidence < 200.) {
         color.r = 237. / 255.;
         color.g = 164. / 255.;
         color.b = 194. / 255.;
+        alpha = intensity / 255.;
+      } else {
+        color.r = 220. / 255.;
+        color.g = 102. / 255.;
+        color.b = 153. / 255.;
         alpha = intensity / 255.;
       }
     } else {
@@ -452,15 +452,15 @@ const decodes = {
       if (intensity > 255.) {
         intensity = 255.;
       }
-      if (day >= numberOfDays - 7. && day <= numberOfDays) {
-        color.r = 219. / 255.;
-        color.g = 168. / 255.;
-        color.b = 0.;
-        alpha = intensity / 255.;
-      } else {
+      if (confidence < 1.) {
         color.r = 237. / 255.;
         color.g = 164. / 255.;
         color.b = 194. / 255.;
+        alpha = intensity / 255.;
+      } else {
+        color.r = 220. / 255.;
+        color.g = 102. / 255.;
+        color.b = 153. / 255.;
         alpha = intensity / 255.;
       }
     } else {


### PR DESCRIPTION
## Overview

Change RGB values to individual alerts to match low confidence values of integrated deforestation alerts.

## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

