### PR TITLE
add min absolute date for decoding integrated

### DIFF
--- a/components/map/utils.js
+++ b/components/map/utils.js
@@ -3,8 +3,10 @@ import { differenceInDays } from 'date-fns';
 import has from 'lodash/has';
 
 export const getDayRange = (params) => {
-  const { startDate, endDate, minDate, maxDate, weeks } = params || {};
-  const minDateTime = new Date(minDate);
+  const { startDate, endDate, minDate, maxDate, weeks, minDateAbsolut = null } =
+    params || {};
+  // If min date absolut, always take its value (dynamic timeline)
+  const minDateTime = new Date(minDateAbsolut || minDate);
   const maxDateTime = new Date(maxDate);
 
   const numberOfDays = differenceInDays(maxDateTime, minDateTime);
@@ -23,7 +25,6 @@ export const getDayRange = (params) => {
   // get start and end day
   const startDayIndex = activeStartDay || rangeStartDate || 0;
   const endDayIndex = activeEndDay || numberOfDays;
-
   return {
     startDayIndex,
     endDayIndex,
@@ -31,7 +32,12 @@ export const getDayRange = (params) => {
   };
 };
 
-export const handleDynamicTimeline = (l, dsMetadata, timelineParams, callback) => {
+export const handleDynamicTimeline = (
+  l,
+  dsMetadata,
+  timelineParams,
+  callback
+) => {
   const hasLatest = l.dataset === 'integrated-deforestation-alerts-8bit';
   const range = {
     default: 549,

--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -238,6 +238,7 @@ const decodes = {
 
     float day = r * 255. + g;
     float confidence = floor(b / 100.) - 1.;
+    // float confidence = 255.;
     float intensity = mod(b, 100.) * 50.;
     // float intensity = 255.; //this is temporal above one does not work
 
@@ -439,7 +440,7 @@ const decodes = {
 
     // **** CHECK THIS
     // 1461 = days from 2019/01/01 to 2014/12/31
-    float day = (r * 255.) + g - 1461.;
+    float day = (r * 255.) + g;
     float confidence = floor(b / 100.) - 1.;
     if (
       day > 0. &&


### PR DESCRIPTION
## Overview

Update `getDayRange` function to include a `minDateAbsolut` param for decoding when this param is included in the`layerConfig.decodefuntion`. I've also updated the `layerConfig.decodefuntion` of the following layers to include this min value:

- Integrated alerts layer
- Glad l alerts layer
- Glad s alerts layer
- radd alerts layer

Finally, I've changed the Radd decode function for parsing this minDateAbsolut value from the layer config as min/max dayIndex instead of hardcoding the value directly in the code.

## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

