### PR TITLE
add support for layer cautions

### DIFF
--- a/components/map/components/legend/component.jsx
+++ b/components/map/components/legend/component.jsx
@@ -18,6 +18,7 @@ import {
 import Loader from 'components/ui/loader';
 import NoContent from 'components/ui/no-content';
 import SentenceSelector from 'components/sentence-selector';
+import WidgetCaution from 'components/widget/components/widget-caution';
 
 import Timeline from './components/timeline';
 import LayerListMenu from './components/layer-list-menu';
@@ -70,6 +71,7 @@ const MapLegend = ({
               id,
               layers,
               statementConfig,
+              caution,
               name,
             } = lg || {};
 
@@ -207,6 +209,12 @@ const MapLegend = ({
                   <LayerStatement
                     className="layer-statement"
                     {...statementConfig}
+                  />
+                )}
+                {caution && (
+                  <WidgetCaution
+                    locationType="map"
+                    caution={{ text: caution, visible: ['map', 'dashboard'] }}
                   />
                 )}
                 {moreInfo && (

--- a/components/map/components/legend/component.jsx
+++ b/components/map/components/legend/component.jsx
@@ -214,7 +214,16 @@ const MapLegend = ({
                 {caution && (
                   <WidgetCaution
                     locationType="map"
-                    caution={{ text: caution, visible: ['map', 'dashboard'] }}
+                    caution={{
+                      text: caution,
+                      visible: [
+                        'wdpa',
+                        'country',
+                        'aoi',
+                        'geostore',
+                        'dashboard',
+                      ],
+                    }}
                   />
                 )}
                 {moreInfo && (

--- a/components/widgets/forest-change/glad-alerts-simple/index.js
+++ b/components/widgets/forest-change/glad-alerts-simple/index.js
@@ -101,7 +101,7 @@ export default {
   caution: {
     visible: ['wdpa', 'country', 'aoi', 'geostore', 'dashboard'],
     text:
-      'Due to satellite malfunction, there is a decrease in RADD alerts\' frequency for the time being. <a href="https://groups.google.com/g/globalforestwatch/c/v4WhGxbKG1I" rel="noreferrer" target="__BLANK">See this discussion forum post</a> for more information.',
+      'GLAD-L alerts won\'t be updated during January 2022 due to maintenance. Stay updated via the <a href="https://groups.google.com/g/globalforestwatch/c/v4WhGxbKG1I" rel="noreferrer" target="__BLANK">discussion forum</a> or email <a href="mailto:gfw@wri.org">gfw@wri.org</a> with any questions.',
   },
   getData: async (params) => {
     const GLAD = await handleGladMeta(params);

--- a/components/widgets/forest-change/glad-alerts-simple/index.js
+++ b/components/widgets/forest-change/glad-alerts-simple/index.js
@@ -99,7 +99,7 @@ export default {
     dataset: 'glad',
   },
   caution: {
-    visible: ['wdpa', 'country', 'aoi'],
+    visible: ['wdpa', 'country', 'aoi', 'geostore', 'dashboard'],
     text:
       'Due to satellite malfunction, there is a decrease in RADD alerts\' frequency for the time being. <a href="https://groups.google.com/g/globalforestwatch/c/v4WhGxbKG1I" rel="noreferrer" target="__BLANK">See this discussion forum post</a> for more information.',
   },

--- a/components/widgets/forest-change/glad-alerts-simple/index.js
+++ b/components/widgets/forest-change/glad-alerts-simple/index.js
@@ -101,7 +101,7 @@ export default {
   caution: {
     visible: ['wdpa', 'country', 'aoi'],
     text:
-      'GLAD-L alerts won\'t be updated during January 2022 due to maintenance. Stay updated via the <a href="https://groups.google.com/g/globalforestwatch/c/v4WhGxbKG1I" rel="noreferrer" target="__BLANK">discussion forum</a> or email <a href="mailto:gfw@wri.org">gfw@wri.org</a> with any questions.',
+      'Due to satellite malfunction, there is a decrease in RADD alerts\' frequency for the time being. <a href="https://groups.google.com/g/globalforestwatch/c/v4WhGxbKG1I" rel="noreferrer" target="__BLANK">See this discussion forum post</a> for more information.',
   },
   getData: async (params) => {
     const GLAD = await handleGladMeta(params);


### PR DESCRIPTION
## Overview

Similar to widgets, layers now support caution messages if needed. It works a bit different than widgets but you can now define inside a layer config the property "caution" with a text. if present it will show up under the specified layer.

## Demo

<img width="355" alt="Screenshot 2022-01-25 at 13 25 41" src="https://user-images.githubusercontent.com/971129/150976897-c771417f-0226-4ea1-acce-247029c61137.png">


