### PR TITLE
make metaKey dynamic

### DIFF
--- a/components/map/components/legend/component.jsx
+++ b/components/map/components/legend/component.jsx
@@ -76,7 +76,6 @@ const MapLegend = ({
             } = lg || {};
 
             const activeLayer = layers && layers.find((l) => l.active);
-
             const {
               params,
               paramsSelectorConfig,
@@ -85,7 +84,6 @@ const MapLegend = ({
               moreInfo,
               timelineParams,
             } = activeLayer || {};
-
             return (
               <LegendListItem
                 index={i}

--- a/components/widget/components/widget-header/component.jsx
+++ b/components/widget/components/widget-header/component.jsx
@@ -77,6 +77,9 @@ class WidgetHeader extends PureComponent {
       disableDownload || (status !== 'saved' && !settings?.canDownloadUnsaved); // Disable everywhere
     const showMapBtn = !embed && !simple && datasets;
     const showSeparator = showSettingsBtn || showMapBtn;
+    const metaInfo = typeof metaKey === 'function' ? metaKey() : metaKey;
+
+    console.log('props', this.props);
 
     let disabledMessageString =
       status === 'unsaved'
@@ -93,7 +96,7 @@ class WidgetHeader extends PureComponent {
             ','
           )(maxSize)} by narrowing the date range.`;
     }
-
+    console.log('meta key', metaInfo);
     return (
       <div className={cx('c-widget-header', { simple })}>
         <div className="title">{title}</div>
@@ -137,7 +140,7 @@ class WidgetHeader extends PureComponent {
             )}
             <WidgetInfoButton
               square={simple}
-              handleOpenInfo={() => handleShowInfo(metaKey)}
+              handleOpenInfo={() => handleShowInfo(metaInfo)}
             />
             {!simple && <WidgetShareButton handleShowShare={handleShowShare} />}
           </div>

--- a/components/widgets/forest-change/integrated-deforestation-alerts/index.js
+++ b/components/widgets/forest-change/integrated-deforestation-alerts/index.js
@@ -48,7 +48,13 @@ export default {
     noReportedAlerts:
       'There were {total} deforestation alerts reported in {location} between {startDate} and {endDate}.',
   },
-  metaKey: 'widget_deforestation_graph',
+  metaKey: (params) => {
+    const { deforestationAlertsDataset } = params;
+    if (deforestationAlertsDataset === 'all') {
+      return 'widget_deforestation_graph';
+    }
+    return 'widget_deforestation_graph';
+  },
   large: false,
   visible: ['dashboard', 'analysis'],
   colors: 'loss',


### PR DESCRIPTION
currently metaKey for integrated alerts points to: api.resourcewatch.org/v1/gfw-metadata/widget_deforestatgion_graph 

where metaKey in config is widget_deforestatgion_graph 

Make metaKey a function that exposes widget config, and we can dynamicly change this meta key based on widget settings.