### PR TITLE
Fix bug when loading integrated alerts endpoints

### DIFF
--- a/providers/latest-provider/index.js
+++ b/providers/latest-provider/index.js
@@ -1,4 +1,4 @@
-import { PureComponent } from 'react';
+import { useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import reducerRegistry from 'redux/registry';
@@ -7,21 +7,17 @@ import * as actions from './actions';
 import { getLatestProps } from './selectors';
 import reducers, { initialState } from './reducers';
 
-class LatestProvider extends PureComponent {
-  componentDidUpdate() {
-    const { getLatest, latestEndpoints } = this.props;
-    if (
-      latestEndpoints
-      // TODO: Figure out how to look for updates, length will be the same!
-    ) {
-      getLatest(latestEndpoints);
-    }
-  }
+const LatestProvider = ({ latestEndpoints, getLatest }) => {
+  const endpoint = useMemo(() => {
+    return latestEndpoints;
+  }, [latestEndpoints]);
 
-  render() {
-    return null;
-  }
-}
+  useEffect(() => {
+    getLatest(endpoint);
+  }, [endpoint]);
+
+  return null;
+};
 
 LatestProvider.propTypes = {
   getLatest: PropTypes.func.isRequired,


### PR DESCRIPTION
## Overview

Sometimes when loading Integrated Alerts, the app would crash

## Testing

To reproduce:

- open Map with default layers
- remove all active layers
- load an AOI
- load Integrated Alerts layer
- crash!