### PR TITLE
fix parsing of system in aoi pending areas map dashboards

### DIFF
--- a/components/widgets/forest-change/integrated-deforestation-alerts/selectors.js
+++ b/components/widgets/forest-change/integrated-deforestation-alerts/selectors.js
@@ -162,6 +162,7 @@ export const parseSentence = createSelector(
   ],
   (data, settings, sentences, indicator, currentLabel, options) => {
     if (!data || isEmpty(data)) return null;
+    // TODO explore why the getOptionsSelected is returning null
 
     const {
       alertSystem = 'all',
@@ -261,18 +262,27 @@ export const parseSentence = createSelector(
           alertSystem === 'all' && {
             system: ' ',
           }),
-        ...(systemSlug === 'all' &&
+        ...((systemSlug === 'all' &&
           alertSystem === 'radd' && {
             system: 'RADD',
-          }),
-        ...(systemSlug === 'all' &&
+          }) ||
+          (alertSystem === 'radd' && {
+            system: 'RADD',
+          })),
+        ...((systemSlug === 'all' &&
           alertSystem === 'glad_l' && {
             system: 'GLAD-L',
-          }),
-        ...(systemSlug === 'all' &&
+          }) ||
+          (alertSystem === 'glad_l' && {
+            system: 'GLAD-L',
+          })),
+        ...((systemSlug === 'all' &&
           alertSystem === 'glad_s2' && {
             system: 'GLAD-S2',
-          }),
+          }) ||
+          (alertSystem === 'glad_s2' && {
+            system: 'GLAD-S2',
+          })),
         highConfidenceAlerts: 'high confidence alerts',
       },
     };


### PR DESCRIPTION
## Overview

Quick fix of the {system} parsing for the AOI, status pending integrated alerts dashboards in the map view.  We need to explore why the getOptionsSelected returns as null. 

## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

