### PR TITLE
parse geostore id for wdpa download data

### DIFF
--- a/components/widgets/forest-change/integrated-deforestation-alerts/index.js
+++ b/components/widgets/forest-change/integrated-deforestation-alerts/index.js
@@ -434,8 +434,8 @@ export default {
     const defaultEndDate = GLAD?.defaultEndDate;
     const startDate = params?.startDate || defaultStartDate;
     const endDate = params?.endDate || defaultEndDate;
-    const geostoreId = params?.geostore?.hash;
     const alertSystem = handleAlertSystem(params, 'deforestationAlertsDataset');
+    const isWDPA = params?.locationType === 'wdpa';
 
     let table = 'gfw_integrated_alerts';
     if (alertSystem === 'glad_l') {
@@ -446,6 +446,11 @@ export default {
     }
     if (alertSystem === 'radd') {
       table = 'wur_radd_alerts';
+    }
+
+    let geostoreId = params?.geostore?.hash;
+    if (isWDPA) {
+      geostoreId = params?.geostore?.id;
     }
 
     return [


### PR DESCRIPTION
## Overview

Parse geostoreId for download wdpa integrated alerts data. The query stills failing but the configuration is the same as they are providing in the following excel spreadsheet: https://docs.google.com/spreadsheets/d/16Ui_wfCHQj64qVpvyR_S4fY6HjLzzIxXDYavZsB4hm4/edit#gid=351780396


Current request: https://data-api.globalforestwatch.org/dataset/gfw_integrated_alerts/v20220205/download/csv?geostore_id=23d2f7cc-6b6c-d3e8-fe49-6e97f642448b&geostore_origin=rw&sql=SELECT+latitude%2C+longitude%2C+gfw_integrated_alerts__date%2C+umd_glad_landsat_alerts__confidence%2C+umd_glad_sentinel2_alerts__confidence%2C+wur_radd_alerts__confidence%2C+gfw_integrated_alerts__confidence+FROM+data+WHERE+gfw_integrated_alerts__date+%3E%3D+%272020-08-05%27+AND+gfw_integrated_alerts__date+%3C%3D+%272022-02-05%27


## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

