### PR TITLE
Check geostoreId exists

### DIFF
--- a/components/widgets/forest-change/integrated-deforestation-alerts/index.js
+++ b/components/widgets/forest-change/integrated-deforestation-alerts/index.js
@@ -199,6 +199,9 @@ export default {
 
     const geostoreId = params?.geostore?.hash;
 
+    // Stop if geostoreId undefined
+    if (geostoreId.length <= 0) return null;
+
     // Default all integrated alerts
     let dataset = 'gfw_integrated_alerts';
 


### PR DESCRIPTION
## Overview

When loading the Areas Dashboard, the app would crash because it tries to call the API before having a valid `geostoreId` value. This PR will check that it exists before reaching the API.