### PR TITLE
add new decode function for radd and glads integrated alerts layer

### DIFF
--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -428,6 +428,7 @@ const decodes = {
     }
   `,
   RADDs: `
+  // todo: this decode function would be deprecated when replacing indicidual radd and glads alerts by integrated alerts
   // values for creating power scale, domain (input), and range (output)
     float confidenceValue = 0.;
     if (confirmedOnly > 0.) {
@@ -440,7 +441,52 @@ const decodes = {
 
     // **** CHECK THIS
     // 1461 = days from 2019/01/01 to 2014/12/31
-    float day = (r * 255.) + g - 1461. ;
+    // 1870 = days from 2020/02/14 to 2014/12/31
+    float day = (r * 255.) + g - 1870. ;
+
+    float confidence = floor(b / 100.) - 1.;
+    if (
+      day > 0. &&
+      day >= startDayIndex &&
+      day <= endDayIndex  &&
+      confidence >= confidenceValue
+    ) {
+      // get intensity
+      float intensity = mod(b, 100.) * 50.;
+      // float intensity = 255.;
+      if (intensity > 255.) {
+        intensity = 255.;
+      }
+      if (confidence < 1.) {
+        color.r = 237. / 255.;
+        color.g = 164. / 255.;
+        color.b = 194. / 255.;
+        alpha = intensity / 255.;
+      } else {
+        color.r = 220. / 255.;
+        color.g = 102. / 255.;
+        color.b = 153. / 255.;
+        alpha = intensity / 255.;
+      }
+    } else {
+      alpha = 0.;
+    }
+  `,
+  RADDs2yearsTimeline: `
+  // values for creating power scale, domain (input), and range (output)
+    float confidenceValue = 0.;
+    if (confirmedOnly > 0.) {
+      confidenceValue = 1.;
+    }
+
+    float r = color.r * 255.;
+    float g = color.g * 255.;
+    float b = color.b * 255.;
+
+    // **** CHECK THIS
+    // 1461 = days from 2019/01/01 to 2014/12/31
+    // 1870 = days from 2020/02/14 to 2014/12/31
+    float day = (r * 255.) + g;
 
     float confidence = floor(b / 100.) - 1.;
     if (
@@ -950,6 +996,7 @@ export default {
   integratedAlerts16Bit: decodes.integratedAlerts16Bit,
   GLADs: decodes.GLADs,
   RADDs: decodes.RADDs,
+  RADDs2yearsTimeline: decodes.RADDs2yearsTimeline,
   RADDsCoverage: decodes.RADDsCoverage,
   staticRemap: decodes.staticRemap,
   forestHeight: decodes.forestHeight,


### PR DESCRIPTION
## Overview

This PR fixes the issue related with parsing the day in the RADDs decode function which was affecting the radd and glad-s individual alerts tiles. This was produced due to the new implementation of the two years rolling timeline and therefore the calculation of the `startDayIndex` - `endDayIndex`.  

The way it worked in the past for the old timeline config and those individual alerts was by deducting a hardcoded value directly on the RADDs decode function, that had to be updated manually based on the count of days between the new set of dates. 

In order to avoid working with this hardcoded value with this 2-years-rolling timeline, we have implemented a `minDateAbsolute` in the layerConfig, which is exclusively linked with a individual layer. We compute therefore the `startdayIndex` and `endDayIndex` using this `minDateAbsolute`.


![Screenshot from 2022-02-24 12-15-53](https://user-images.githubusercontent.com/49622839/155514377-94748d98-6f41-4460-97b0-5c073b5762c9.png)

This has been applied just to the individual layers under the integrated alert dataset. The old Radds decode function will be deprecated once this integrated alerts layer is deployed to production. 

## Testing

Check that[ this area](https://preproduction.globalforestwatch.org/map/?map=eyJjZW50ZXIiOnsibGF0IjozLjg0MjcyNTIyOTk4OTk1NjYsImxuZyI6MTEuODkzNDkxODk3OTE2Nzc4fSwiem9vbSI6MTMuODYzMzU1MzAwMDk3Njc5LCJkYXRhc2V0cyI6W3siZGF0YXNldCI6ImludGVncmF0ZWQtZGVmb3Jlc3RhdGlvbi1hbGVydHMtOGJpdCIsIm9wYWNpdHkiOjEsInZpc2liaWxpdHkiOnRydWUsImxheWVycyI6WyJpbnRlZ3JhdGVkLWRlZm9yZXN0YXRpb24tYWxlcnRzLThiaXQtcmFkZCIsInJhZGRPbmx5Il0sInRpbWVsaW5lUGFyYW1zIjp7InN0YXJ0RGF0ZSI6IjIwMjAtMDMtMDEiLCJlbmREYXRlIjoiMjAyMi0wMS0yNyIsInRyaW1FbmREYXRlIjoiMjAyMi0wMS0yNyJ9fSx7ImRhdGFzZXQiOiJwb2xpdGljYWwtYm91bmRhcmllcyIsImxheWVycyI6WyJkaXNwdXRlZC1wb2xpdGljYWwtYm91bmRhcmllcyIsInBvbGl0aWNhbC1ib3VuZGFyaWVzIl0sIm9wYWNpdHkiOjEsInZpc2liaWxpdHkiOnRydWV9XX0%3D) between production and preproduction have the same view with the same range of dates.

NOTE: Right now the decoding is not working in the link provided above as the layer is expecting a decode function implemented in this PR. 

