### PR TITLE
update glad and integrated alerts dataset version

### DIFF
--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -1166,7 +1166,7 @@ export const fetchIntegratedAlerts = (params) => {
       dataset: alertSystem === 'glad_l' ? 'glad_alerts' : 'integrated_alerts',
       datasetType: 'daily',
       // version override necessary here (no 'latest' defined)
-      version: 'latest',
+      version: alertSystem === 'glad_l' ? 'v20220304' : 'v20220308',
     });
   }
 
@@ -1317,7 +1317,7 @@ export const getIntegratedAlertsRanked = (params) => {
       dataset: 'integrated_alerts',
       datasetType: 'daily',
       // version override necessary here (no 'latest' defined)
-      version: 'latest',
+      version: 'v20220308',
     });
   }
 
@@ -1406,7 +1406,7 @@ export const fetchGladAlertsDaily = (params) => {
     dataset: 'glad_alerts',
     datasetType: 'daily',
     // version override necessary here (no 'latest' defined)
-    version: 'latest',
+    version: 'v20220304',
     // Refernces the base SQL from the SQL_QUERIES object
   })}${SQL_QUERIES.integratedAlertsDaily}`;
 
@@ -1460,7 +1460,7 @@ export const fetchGladAlertsDailyRanked = (params) => {
     dataset: 'glad_alerts',
     datasetType: 'daily',
     // version override necessary here (no 'latest' defined)
-    version: 'latest',
+    version: 'v20220304',
     // Refernces the base SQL from the SQL_QUERIES object
   })}${SQL_QUERIES.integratedAlertsRanked}`;
 


### PR DESCRIPTION
## Overview

Update dataset version and query column names for Q3/Q4 data updates.
Datasets to update:

- [x] Integrated alerts https://staging-data-api.globalforestwatch.org/dataset/gadm__integrated_alerts__iso_daily_alerts/v20220308
- [x] GLAD: https://staging-data-api.globalforestwatch.org/dataset/gadm__glad__iso_daily_alerts/v20220304
- [x] TCL:[ https://staging-data-api.globalforestwatch.org/dataset/gadm__tcl__iso_change/v2022030](https://staging-data-api.globalforestwatch.org/dataset/gadm__tcl__iso_change/v20220304)

This task also involves the update of the following column names:

- [x] `is__birdlife_alliance_for_zero_extinction_site`  to `is__birdlife_alliance_for_zero_extinction_sites`
- [x] `tsc_tree_cover_loss_drivers__type`  to `tsc_tree_cover_loss_drivers__drivers`
- [x] `is__gfw_tiger_landscapes` to `is__wwf_tiger_conservation_landscapes`
- [x] `is__gfw_mining` to  `is__gfw_mining_concessions`
- [x] `gfw_plantation__type` to `gfw_planted_forests__type`
- [x] `is__gmw_mangroves_1996` to `is__gmw_global_mangrove_extent_1996`
- [x] `is__gmw_mangroves_2016` to `is__gmw_global_mangrove_extent_2016`
- [x] `ifl_intact_forest_landscape__year` to `ifl_intact_forest_landscapes__year`
- [x] `is__landmark_land_right` to `is__landmark_indigenous_and_community_lands`
- [x] `is__gfw_land_right` to `is__gfw_land_rights`
- [x] `is__birdlife_key_biodiversity_area` to `is__birdlife_key_biodiversity_areas`
- [x] `is__peatland` to `is__gfw_peatlands`
- [x] `is__gfw_resource_right` to `is__gfw_resource_rights`
- [x] `is__umd_tree_cover_gain_2000-2012` to `is__umd_tree_cover_gain`
- [x] `is__gfw_managed_forest` to `is__gfw_managed_forests`
- [x] `idn_forest_area__type` to `idn_forest_area__class`
- [x] `per_forest_concession__type` to `per_forest_concessions__type`
- [x] `is__ifl_intact_forest_landscape_2016` to `is__ifl_intact_forest_landscapes_2016`
- [x] `bra_biome__name` to `ibge_bra_biomes__name`
- [x] `wdpa_protected_area__iucn_cat` to `wdpa_protected_areas__iucn_cat`
- [x] `wdpa_protected_area__name` to `wdpa_protected_areas__name`
- [x] `wdpa_protected_area__id` to `wdpa_protected_areas__id`
- [x] `wdpa_protected_area__iso` to `wdpa_protected_areas__iso`
- [x] `wdpa_protected_area__status` to `wdpa_protected_areas__status`
- [x] `umd_tree_cover_density__threshold` to `umd_tree_cover_density_2000__threshold`

## Testing

Check the corresponding dashboards to check that the data is retrieved correctly.
