### PR TITLE
Update dashboards downloadable data version to 2021

### DIFF
--- a/layouts/dashboards/components/header/selectors.js
+++ b/layouts/dashboards/components/header/selectors.js
@@ -12,7 +12,7 @@ import {
 } from 'providers/areas-provider/selectors';
 
 const isServer = typeof window === 'undefined';
-const DOWNLOAD_VERSION = '20200331';
+const DOWNLOAD_VERSION = '2021';
 
 // get list data
 export const selectLocation = (state) =>


### PR DESCRIPTION
## Overview

This PR modifies the version of the downloadable data in the dashboards page. Bumps from version '20200331' to '2021'

## Notes

Approved by the client to be deployed, and now the S3 bucket has access permissions 

