### PR TITLE
change geostoreOrigin in download

### DIFF
--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -1255,7 +1255,7 @@ export const fetchIntegratedAlerts = (params) => {
       .replace(/{endDate}/g, endDate)
       .replace('{WHERE}', getWHEREQuery({ ...params, dataset: 'glad' }))
       .replace(/{AND_OPERATION}/, AND_OPERATION)
-      .replace(/{geostoreOrigin}/g, 'rw')
+      .replace(/{geostoreOrigin}/g, 'gfw')
       .replace(/{geostoreId}/g, geostoreId)
   );
 


### PR DESCRIPTION
## Overview

Change geostoreOrigin in download when fetching Integrated Alerts. We need to check if this is a conscious change and if we need to update it also in the analysis part. 

## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

