### PR TITLE
Add decoding for TCLF

### DIFF
--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -55,6 +55,36 @@ const decodes = {
       alpha = 0.;
     }
   `,
+  treeCoverLossFire: `
+  // values for creating power scale, domain (input), and range (output)
+  float domainMin = 0.;
+  float domainMax = 255.;
+  float rangeMin = 0.;
+  float rangeMax = 255.;
+
+  float exponent = zoom < 13. ? 0.3 + (zoom - 3.) / 20. : 1.;
+  float intensity = color.r * 255.;
+
+  // get the min, max, and current values on the power scale
+  float minPow = pow(domainMin, exponent - domainMin);
+  float maxPow = pow(domainMax, exponent);
+  float currentPow = pow(intensity, exponent);
+
+  // get intensity value mapped to range
+  float scaleIntensity = ((currentPow - minPow) / (maxPow - minPow) * (rangeMax - rangeMin)) + rangeMin;
+  // a value between 0 and 255
+  alpha = zoom < 13. ? scaleIntensity / 255. : color.g;
+
+  float year = 2000.0 + (color.b * 255.);
+  // map to years
+  if (year >= startYear && year <= endYear && year >= 2001.) {
+    color.r = 147. / 255.;
+    color.g = (72. - zoom + 34. - 3. * scaleIntensity / zoom) / 255.;
+    color.b = (33. - zoom + 86. - intensity / zoom) / 255.;
+  } else {
+    alpha = 0.;
+  }
+`,
   treeLossByDriver: `
     float year = 2000.0 + (color.b * 255.);
     // map to years
@@ -991,6 +1021,7 @@ const decodes = {
 export default {
   treeCover: decodes.treeCover,
   treeCoverLoss: decodes.treeCoverLoss,
+  treeCoverLossFire: decodes.treeCoverLossFire,
   treeLossByDriver: decodes.treeLossByDriver,
   integratedAlerts8Bit: decodes.integratedAlerts8Bit,
   integratedAlerts16Bit: decodes.integratedAlerts16Bit,


### PR DESCRIPTION
## Overview

Add a new decoding function for Tree Cover Loss by Fires, based on the one used for Tree Cover Loss, but adapting the RGB values to match the color of the legend and selector.


## Testing

- The Tree Cover Loss by Fires layers now shows in the [staging map](https://staging.globalforestwatch.org/map/?map=eyJkYXRhc2V0cyI6W3siZGF0YXNldCI6InRyZWUtY292ZXItbG9zcy1maXJlcyIsIm9wYWNpdHkiOjEsInZpc2liaWxpdHkiOnRydWUsImxheWVycyI6WyJ0cmVlLWNvdmVyLWxvc3MtZmlyZXMiXX0seyJkYXRhc2V0IjoicG9saXRpY2FsLWJvdW5kYXJpZXMiLCJsYXllcnMiOlsiZGlzcHV0ZWQtcG9saXRpY2FsLWJvdW5kYXJpZXMiLCJwb2xpdGljYWwtYm91bmRhcmllcyJdLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlfSx7ImRhdGFzZXQiOiJ0cmVlLWNvdmVyLWxvc3MiLCJsYXllcnMiOlsidHJlZS1jb3Zlci1sb3NzIl0sIm9wYWNpdHkiOjEsInZpc2liaWxpdHkiOnRydWV9XX0%3D&mapMenu=eyJkYXRhc2V0Q2F0ZWdvcnkiOiJmb3Jlc3RDaGFuZ2UifQ%3D%3D) with same color as in the legend description and toggle selectors. Year interval selection still provides correct functionality.

Example:
This is how it looks now on staging (no decoding function available):

![Screenshot 2022-05-25 at 13 40 35](https://user-images.githubusercontent.com/57727579/170254022-73cbb71b-72cd-45ae-a230-3484efa4db77.png)


This is what it should look like with the updated decoding function provided:
![Screenshot 2022-05-23 at 12 58 38](https://user-images.githubusercontent.com/57727579/170254158-96b98b70-c0c3-4462-a613-538bcfbdf714.png)


