### PR TITLE
Change intensity factor on GLAD-L decoding function

### DIFF
--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -437,8 +437,8 @@ const decodes = {
       day <= endDayIndex &&
       confidence >= confidenceValue
     ) {
-      // get intensity
-      float intensity = mod(confidence, 100.) * 50.;
+      // get intensity (max value multiplication per request from GFW after median resampling)
+      float intensity = mod(confidence, 100.) *  255.;
       if (intensity > 255.) {
         intensity = 255.;
       }


### PR DESCRIPTION
## Overview

This PR modifies the decoding function for the GLAD-L deforestation alerts layer, to increase the intensity factor so that the new layers (based on median value for resampling) have better visibility at global zoom levels.

## Demo

<img width="1048" alt="Screenshot 2022-05-30 at 17 28 45" src="https://user-images.githubusercontent.com/57727579/171165237-cde288d7-888b-4f99-8215-5a35f8f9e160.png">


## Notes
Originally, the multiplying factor for intensity was 50. it has been set up to 255 to maximise it, but part of the decoding function becomes quite pointless. This will require reformulating the decoding function in the future if this change is set as definitive.


