### PR TITLE
Adjust TCLF decoding function

### DIFF
--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -74,7 +74,7 @@ const decodes = {
   float scaleIntensity = ((currentPow - minPow) / (maxPow - minPow) * (rangeMax - rangeMin)) + rangeMin;
   // a value between 0 and 255
   // multiplier added to increase intensity at global zoom levels
-  alpha = zoom < 13. ? (1.5 * scaleIntensity)/ 255. : color.g;
+  alpha = zoom < 13. ? (scaleIntensity)/ 255. : color.g;
 
   float year = 2000.0 + (color.b * 255.);
   // map to years

--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -73,14 +73,16 @@ const decodes = {
   // get intensity value mapped to range
   float scaleIntensity = ((currentPow - minPow) / (maxPow - minPow) * (rangeMax - rangeMin)) + rangeMin;
   // a value between 0 and 255
-  alpha = zoom < 13. ? scaleIntensity / 255. : color.g;
+  // multiplier added to increase intensity at global zoom levels
+  alpha = zoom < 13. ? (1.5 * scaleIntensity)/ 255. : color.g;
 
   float year = 2000.0 + (color.b * 255.);
   // map to years
   if (year >= startYear && year <= endYear && year >= 2001.) {
+    // values entered directly, unlike TCL where final color changes with zoom level
     color.r = 154. / 255.;
-    color.g = (72. - zoom + 91. - 3. * scaleIntensity / zoom) / 255.;
-    color.b = (33. - zoom + 80. - intensity / zoom) / 255.;
+    color.g = 91. / 255.;
+    color.b = 80. / 255.;
   } else {
     alpha = 0.;
   }

--- a/providers/datasets-provider/config.js
+++ b/providers/datasets-provider/config.js
@@ -73,7 +73,6 @@ const decodes = {
   // get intensity value mapped to range
   float scaleIntensity = ((currentPow - minPow) / (maxPow - minPow) * (rangeMax - rangeMin)) + rangeMin;
   // a value between 0 and 255
-  // multiplier added to increase intensity at global zoom levels
   alpha = zoom < 13. ? (scaleIntensity)/ 255. : color.g;
 
   float year = 2000.0 + (color.b * 255.);


### PR DESCRIPTION
## Overview

Adjust TCLF decoding function to show the correct legend color across all zoom levels (avoid color changes based on zoom). Increased intensity at global zoom levels for better visualization (might require further tweaks to reach the desired aspect)

## Demo

With the new changes, global view should look like this:
![Screenshot 2022-08-23 at 13 52 03](https://user-images.githubusercontent.com/57727579/186154145-24e290dc-4117-4661-9e43-9cd79b509f8d.png)


