### PR TITLE
col names changes TCL drivers

### DIFF
--- a/components/widgets/climate/emissions-deforestation-drivers/index.js
+++ b/components/widgets/climate/emissions-deforestation-drivers/index.js
@@ -95,7 +95,7 @@ export default {
         if (emissions && emissions.data) {
           data = {
             emissions: emissions.data.data.filter(
-              (d) => d.tsc_tree_cover_loss_drivers__type !== 'Unknown'
+              (d) => d.tsc_tree_cover_loss_drivers__driver !== 'Unknown'
             ),
           };
         }

--- a/components/widgets/forest-change/tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/tree-loss-drivers/index.js
@@ -108,7 +108,7 @@ export default {
         if (loss && loss.data && extent && extent.data) {
           data = {
             loss: loss.data.data.filter(
-              (d) => d.tsc_tree_cover_loss_drivers__type !== 'Unknown'
+              (d) => d.tsc_tree_cover_loss_drivers__driver !== 'Unknown'
             ),
             extent: (loss.data.data && extent.data.data[0].value) || 0,
           };

--- a/data/forest-types.js
+++ b/data/forest-types.js
@@ -102,7 +102,7 @@ export default [
     label: 'Tree cover loss driver category',
     value: 'tsc',
     dataType: 'keyword',
-    tableKey: 'tsc_tree_cover_loss_drivers__type',
+    tableKey: 'tsc_tree_cover_loss_drivers__driver',
     hidden: true,
   },
 ];

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -21,7 +21,7 @@ const GFW_API = ENVIRONMENT === 'staging' ? GFW_STAGING_DATA_API : GFW_DATA_API;
 
 const SQL_QUERIES = {
   lossTsc:
-    'SELECT tsc_tree_cover_loss_drivers__type, umd_tree_cover_loss__year, SUM(umd_tree_cover_loss__ha) AS umd_tree_cover_loss__ha, SUM("gfw_gross_emissions_co2e_all_gases__Mg") AS "gfw_gross_emissions_co2e_all_gases__Mg" FROM data {WHERE} GROUP BY tsc_tree_cover_loss_drivers__type, umd_tree_cover_loss__year',
+    'SELECT tsc_tree_cover_loss_drivers__driver, umd_tree_cover_loss__year, SUM(umd_tree_cover_loss__ha) AS umd_tree_cover_loss__ha, SUM("gfw_gross_emissions_co2e_all_gases__Mg") AS "gfw_gross_emissions_co2e_all_gases__Mg" FROM data {WHERE} GROUP BY tsc_tree_cover_loss_drivers__driver, umd_tree_cover_loss__year',
   loss:
     'SELECT {select_location}, umd_tree_cover_loss__year, SUM(umd_tree_cover_loss__ha) AS umd_tree_cover_loss__ha, SUM("gfw_gross_emissions_co2e_all_gases__Mg") AS "gfw_gross_emissions_co2e_all_gases__Mg" FROM data {WHERE} GROUP BY umd_tree_cover_loss__year, {location} ORDER BY umd_tree_cover_loss__year, {location}',
   lossFires:
@@ -31,7 +31,7 @@ const SQL_QUERIES = {
   emissionsLossOTF:
     'SELECT umd_tree_cover_loss__year, SUM(area__ha), SUM("gfw_forest_carbon_gross_emissions__Mg_CO2e") FROM data WHERE umd_tree_cover_density_2000__threshold >= {threshold} AND umd_tree_cover_loss__year >= {startYear} AND umd_tree_cover_loss__year <= {endYear} GROUP BY umd_tree_cover_loss__year ORDER BY umd_tree_cover_loss__year&geostore_origin={geostoreOrigin}&geostore_id={geostoreId}',
   emissionsByDriver:
-    'SELECT tsc_tree_cover_loss_drivers__type, umd_tree_cover_loss__year, SUM("gfw_gross_emissions_co2e_all_gases__Mg") AS "gfw_gross_emissions_co2e_all_gases__Mg", SUM("gfw_full_extent_gross_emissions_non_CO2__Mg_CO2e") AS "gfw_gross_emissions_co2e_non_co2__Mg", SUM("gfw_full_extent_gross_emissions_CO2_only__Mg_CO2") AS "gfw_gross_emissions_co2e_co2_only__Mg" FROM data {WHERE} GROUP BY tsc_tree_cover_loss_drivers__type, umd_tree_cover_loss__year',
+    'SELECT tsc_tree_cover_loss_drivers__driver, umd_tree_cover_loss__year, SUM("gfw_gross_emissions_co2e_all_gases__Mg") AS "gfw_gross_emissions_co2e_all_gases__Mg", SUM("gfw_full_extent_gross_emissions_non_CO2__Mg_CO2e") AS "gfw_gross_emissions_co2e_non_co2__Mg", SUM("gfw_full_extent_gross_emissions_CO2_only__Mg_CO2") AS "gfw_gross_emissions_co2e_co2_only__Mg" FROM data {WHERE} GROUP BY tsc_tree_cover_loss_drivers__driver, umd_tree_cover_loss__year',
   carbonFlux:
     'SELECT SUM("gfw_net_flux_co2e__Mg") AS "gfw_net_flux_co2e__Mg", SUM("gfw_gross_cumulative_aboveground_belowground_co2_removals__Mg") AS "gfw_gross_cumulative_aboveground_belowground_co2_removals__Mg", SUM("gfw_gross_emissions_co2e_all_gases__Mg") AS "gfw_gross_emissions_co2e_all_gases__Mg", TRUE AS "includes_gain_pixels" FROM data {WHERE}',
   carbonFluxOTF: `SELECT SUM("gfw_forest_carbon_net_flux__Mg_CO2e"), SUM("gfw_forest_carbon_gross_removals__Mg_CO2e"), SUM("gfw_forest_carbon_gross_emissions__Mg_CO2e") FROM data WHERE umd_tree_cover_density_2000__threshold >= {threshold} OR is__umd_tree_cover_gain = 'true'&geostore_origin={geostoreOrigin}&geostore_id={geostoreId}`,
@@ -470,7 +470,7 @@ export const getLoss = (params) => {
     data: {
       data: response.data.data.map((d) => ({
         ...d,
-        bound1: d.tsc_tree_cover_loss_drivers__type,
+        bound1: d.tsc_tree_cover_loss_drivers__driver,
         year: d.umd_tree_cover_loss__year,
         area: d.umd_tree_cover_loss__ha,
         emissions: d.gfw_gross_emissions_co2e_all_gases__Mg,
@@ -518,7 +518,7 @@ export const getEmissions = (params) => {
     data: {
       data: response.data.data.map((d) => ({
         ...d,
-        bound1: d.tsc_tree_cover_loss_drivers__type,
+        bound1: d.tsc_tree_cover_loss_drivers__driver,
         year: d.umd_tree_cover_loss__year,
         allGases: d.gfw_gross_emissions_co2e_all_gases__Mg,
         co2Only: d.gfw_gross_emissions_co2e_co2_only__Mg,


### PR DESCRIPTION
## Overview

Column names changes:
Old name: tsc_tree_cover_loss_drivers__type
New name: tsc_tree_cover_loss_drivers__driver

## Testing

TCL by driver type on:
Forest change widgets
Climate widgets







