### PR TITLE
Column names landmark indigenous lands

### DIFF
--- a/data/land-categories.js
+++ b/data/land-categories.js
@@ -96,7 +96,7 @@ export default [
     value: 'landmark',
     dataType: 'keyword',
     metaKey: 'landmark_icls_2020',
-    tableKey: 'is__landmark_land_right',
+    tableKey: 'is__landmark_indigenous_and_community_lands',
     global: true,
     datasets: [
       {


### PR DESCRIPTION
## Overview

Column name changes:
Old: is__landmark_land_right
New: is__landmark_indigenous_and_community_lands


## Testing

Indigenous land options on Land Type filter (e.g. Tree Cover Loss widget)

