### PR TITLE
New cookies design

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "fast-redux": "^0.7.1",
     "file-saver": "^2.0.2",
     "final-form": "^4.18.7",
-    "gfw-components": "1.8.4",
+    "gfw-components": "1.8.5",
     "heroku-ssl-redirect": "^0.1.1",
     "image-trace-loader": "^1.0.2",
     "imagemin-mozjpeg": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "fast-redux": "^0.7.1",
     "file-saver": "^2.0.2",
     "final-form": "^4.18.7",
-    "gfw-components": "1.7.11",
+    "gfw-components": "1.8.4",
     "heroku-ssl-redirect": "^0.1.1",
     "image-trace-loader": "^1.0.2",
     "imagemin-mozjpeg": "^8.0.0",

--- a/wrappers/cookies/component.jsx
+++ b/wrappers/cookies/component.jsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react';
 import Head from 'next/head';
+import cx from 'classnames';
+import useRouter from 'utils/router';
 
 import { CookiesBanner } from 'gfw-components';
 
@@ -11,6 +13,8 @@ import './styles.scss';
 const Cookies = () => {
   const [accepted, setAccepted] = useState(false);
   const [open, setOpen] = useState(false);
+
+  const router = useRouter();
 
   useEffect(() => {
     const agreedCookies = getAgreedCookies();
@@ -33,7 +37,11 @@ const Cookies = () => {
   return (
     <>
       {open && (
-        <div className="c-cookies">
+        <div
+          className={cx('c-cookies', {
+            'c-cookies--map': router?.asPath.startsWith('/map'),
+          })}
+        >
           <CookiesBanner onAccept={acceptCookies} />
         </div>
       )}

--- a/wrappers/cookies/styles.scss
+++ b/wrappers/cookies/styles.scss
@@ -1,8 +1,24 @@
-@import '~styles/settings.scss';
+@import "~styles/settings.scss";
 
 .c-cookies {
   position: fixed;
+  z-index: 99999;
+  left: 50%;
+  transform: translateX(-50%);
   width: 100%;
   bottom: 0;
-  z-index: 99999;
+
+  @media screen and (min-width: $screen-m) {
+    max-width: 620px;
+    bottom: 30px;
+  }
+
+  &--map {
+    bottom: 50px;
+
+    @media screen and (min-width: $screen-m) {
+      bottom: 30px;
+      width: 92%;
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8179,10 +8179,10 @@ gettext-parser@^1.3.1:
     encoding "^0.1.12"
     safe-buffer "^5.1.1"
 
-gfw-components@1.7.11:
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.7.11.tgz#0e68fd75b96965f083d71b6174b8970dcb0abfff"
-  integrity sha512-ZLpA26+/8yODOfND/+Z/AblNBUL05QcmxeFSb2AmNlyUPHEwQd/U4SD2Evxb2yq2/c/MM+CBforPUc718d3E5Q==
+gfw-components@1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.4.tgz#d3522eadfa9bb93cd1cce3dc789c5942ca274c51"
+  integrity sha512-ILf89p1mUlkwOx1fQGvPfzy2uw2L63LK+xHNzNPLu7d0IZaQ15LT1J7entguFdfXsW84pGvzvwAjHBBR5RfRBw==
   dependencies:
     "@artsy/fresnel" "^1.1.0"
     "@tippyjs/react" "^4.0.2"
@@ -8191,6 +8191,7 @@ gfw-components@1.7.11:
     date-fns "^2.13.0"
     emotion-rgba "^0.0.8"
     final-form "^4.19.1"
+    moment "^2.29.3"
     polished "^3.6.2"
     query-string "^6.12.0"
     react-final-form "^6.4.0"
@@ -11466,6 +11467,11 @@ moment@^2.27.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
+moment@^2.29.3:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 move-concurrently@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8179,10 +8179,10 @@ gettext-parser@^1.3.1:
     encoding "^0.1.12"
     safe-buffer "^5.1.1"
 
-gfw-components@1.8.4:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.4.tgz#d3522eadfa9bb93cd1cce3dc789c5942ca274c51"
-  integrity sha512-ILf89p1mUlkwOx1fQGvPfzy2uw2L63LK+xHNzNPLu7d0IZaQ15LT1J7entguFdfXsW84pGvzvwAjHBBR5RfRBw==
+gfw-components@1.8.5:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.5.tgz#40ab572955ba84d34337edc5a0f8d374b07bbdc6"
+  integrity sha512-FiCQIasQo37oJO2kdVNmtg6Dczy9RuJDYPvWCCGsY/eU6lCb1O5BHUKoJP0qV9h/Bzb6lRZxIjjIDTzw6PtvUg==
   dependencies:
     "@artsy/fresnel" "^1.1.0"
     "@tippyjs/react" "^4.0.2"


### PR DESCRIPTION
## ~~IMPORTANT~~

~~https://github.com/Vizzuality/gfw-components/pull/60 (1.8.4) must be published first.~~ - _It has been published_

## Overview

This PR implements the new cookies design.  

Given that the goal of this implementation is for the Cookies banner not obscure the _"My GFW"_ button on the top left of the map, I paid extra attention to the mobile layout so that the same issue didn't occur on mobile. When on the map pages, on mobile, the cookies banner will show up _above_ the bottom navigation buttons, as to not obscure the _"My GFW"_ buttons. 

## Tracking  

[FLAG-484](https://gfw.atlassian.net/browse/FLAG-484)

## Demo

https://gfw-staging-pr-4436.herokuapp.com/

## Screenshots

**Desktop**
<img width="1455" alt="Screenshot 2022-09-19 at 12 51 11" src="https://user-images.githubusercontent.com/6273795/191017944-abda7c65-5cdb-4973-8768-a7b92aae4a5b.png">

**Mobile**
<img width="374" alt="Screenshot 2022-09-19 at 13 36 22" src="https://user-images.githubusercontent.com/6273795/191018845-d1df4aac-875e-4abe-a67c-9bc5934f9cab.png">
