### PR TITLE
Add a noindex metatag to staging and preprod environments

### DIFF
--- a/pages/privacy-policy.js
+++ b/pages/privacy-policy.js
@@ -5,7 +5,6 @@ const PrivacyPolicyPage = () => (
   <PageLayout
     title="Privacy Policy | Global Forest Watch"
     description="This Privacy Policy tells you how WRI handles information collected about you through our websites and applications."
-    noIndex
   >
     <PrivacyPolicy />
   </PageLayout>

--- a/pages/terms.js
+++ b/pages/terms.js
@@ -5,7 +5,6 @@ const TermsPage = () => (
   <PageLayout
     title="Terms of Service | Global Forest Watch"
     description="Welcome to the WRI family of environmental data platforms. By using the Services, you agree to be bound by these Terms of Service and any future updates."
-    noIndex
   >
     <Terms />
   </PageLayout>

--- a/wrappers/head/component.jsx
+++ b/wrappers/head/component.jsx
@@ -6,6 +6,8 @@ import ReactHtmlParser from 'react-html-parser';
 // if the metaTags prop is returned from getStaticProps or getServerSide props
 // we parse it and use in favour of page props
 const Head = ({ title, description, noIndex, metaTags }) => {
+  const isProduction = process.env.NEXT_PUBLIC_FEATURE_ENV === 'production';
+
   return metaTags ? (
     ReactHtmlParser(metaTags)
   ) : (
@@ -20,13 +22,16 @@ const Head = ({ title, description, noIndex, metaTags }) => {
       <meta property="og:description" content={description} />
       <meta property="og:type" content="website" />
       <meta property="og:image" content="/preview.jpg" />
-      {noIndex && <meta name="robots" content="noindex,follow" />}
+      {(!isProduction || noIndex) && (
+        <meta name="robots" content="noindex,follow" />
+      )}
       <meta
         name="viewport"
         content="width=device-width, initial-scale=1, maximum-scale=5"
       />
     </NextHead>
-  )};
+  );
+};
 
 Head.propTypes = {
   title: PropTypes.string,


### PR DESCRIPTION
## Overview

This PR adds a `noindex` metatag to the header of the pages when:  
- Not in production, or
- a `noIndex` prop exists  

In addition, and following the suggestion from [here](https://gfw.atlassian.net/browse/FLAG-136?focusedCommentId=14279), `noIndex` was removed for the _Privacy Policy_ and _Terms of Service_ pages. 

## Demo

https://gfw-staging-pr-4437.herokuapp.com/

## Tracking  

[FLAG-136](https://gfw.atlassian.net/browse/FLAG-136)
