### PR TITLE
col names changes logging managed forests

### DIFF
--- a/data/land-categories.js
+++ b/data/land-categories.js
@@ -169,7 +169,7 @@ export default [
     value: 'managed_forests',
     dataType: 'keyword',
     metaKey: 'gfw_logging',
-    tableKey: 'is__gfw_managed_forest',
+    tableKey: 'is__gfw_managed_forests',
     global: true,
     datasets: [
       {


### PR DESCRIPTION
## Overview

Column name changes:
Old: is__gfw_managed_forest
New: is__gfw_managed_forests

## Testing

TCL widgets (land type = Logging concessions)

