### PR TITLE
col names changes tree threshold logic update

### DIFF
--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -297,6 +297,7 @@ export const getWHEREQuery = (params) => {
     (p) => (params[p] || p === 'threshold') && allowedParams.includes(p)
   );
   const { type, dataset } = params || {};
+  let comparisonString = ' = ';
   if (paramKeysFiltered && paramKeysFiltered.length) {
     let paramString = 'WHERE ';
     paramKeysFiltered.forEach((p, i) => {
@@ -325,11 +326,12 @@ export const getWHEREQuery = (params) => {
       let paramKey = p;
       if (p === 'confidence') paramKey = 'confidence__cat';
       if (p === 'threshold') {
-        if (dataset === 'modis_burned_area') {
-          paramKey = 'umd_tree_cover_density__threshold';
-        } else {
-          paramKey = 'umd_tree_cover_density_2000__threshold';
-        }
+        // if (dataset === 'modis_burned_area') {
+        //   paramKey = 'umd_tree_cover_density__threshold';
+        // } else {
+        paramKey = 'umd_tree_cover_density_2000__threshold';
+        comparisonString = ' >= ';
+        // }
       }
       if (p === 'adm0' && type === 'country') paramKey = 'iso';
       if (p === 'adm1' && type === 'country') paramKey = 'adm1';
@@ -361,7 +363,9 @@ export const getWHEREQuery = (params) => {
           : ''
       }${
         !isPolyname
-          ? `${paramKey} = ${isNumericValue ? value : `'${value}'`}`
+          ? `${paramKey}${comparisonString}${
+              isNumericValue ? value : `'${value}'`
+            }`
           : ''
       }${isLast ? '' : ' AND '}`;
 
@@ -2273,16 +2277,13 @@ export const getNonGlobalDatasets = () => {
 
 // get a boolean list of forest types and land categories inside a given shape
 export const getLocationPolynameWhitelist = (params) => {
-
   const requestUrl = getRequestUrl({ ...params, datasetType: 'whitelist' });
 
   if (!requestUrl) {
     return new Promise(() => {});
   }
 
-  const url = `${requestUrl}${
-    SQL_QUERIES.getLocationPolynameWhitelist
-  }`
+  const url = `${requestUrl}${SQL_QUERIES.getLocationPolynameWhitelist}`
     .replace(
       /{select_location}/g,
       getLocationSelect({ ...params, cast: false })

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -326,11 +326,13 @@ export const getWHEREQuery = (params) => {
       let paramKey = p;
       if (p === 'confidence') paramKey = 'confidence__cat';
       if (p === 'threshold') {
-        // if (dataset === 'modis_burned_area') {
-        //   paramKey = 'umd_tree_cover_density__threshold';
+        if (dataset === 'modis_burned_area') {
+          //   paramKey = 'umd_tree_cover_density__threshold';
+          comparisonString = ' >= ';
+        }
         // } else {
         paramKey = 'umd_tree_cover_density_2000__threshold';
-        comparisonString = ' >= ';
+        // comparisonString = ' >= ';
         // }
       }
       if (p === 'adm0' && type === 'country') paramKey = 'iso';

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -326,13 +326,14 @@ export const getWHEREQuery = (params) => {
       let paramKey = p;
       if (p === 'confidence') paramKey = 'confidence__cat';
       if (p === 'threshold') {
-        if (dataset === 'modis_burned_area') {
+        if (dataset === 'annual') {
           //   paramKey = 'umd_tree_cover_density__threshold';
+          comparisonString = ' = ';
+        } else {
           comparisonString = ' >= ';
         }
-        // } else {
         paramKey = 'umd_tree_cover_density_2000__threshold';
-        // comparisonString = ' >= ';
+
         // }
       }
       if (p === 'adm0' && type === 'country') paramKey = 'iso';


### PR DESCRIPTION
## Overview

Updates on the logic to use the column name `umd_tree_cover_density_2000__threshold`  for all cases, including MODIS burned areas (which used the old one, `umd_tree_cover_density__threshold`).
Also, and more importantly, update the logic for the use of this field in comparisons:
When using TCL datasets, should be = `threshold`
For every other dataset, should be >= `threshold`

## Testing

Can be tested on [this page](https://www.globalforestwatch.org/dashboards/country/BRA/?category=fires&location=WyJjb3VudHJ5IiwiQlJBIl0%3D&map=eyJjZW50ZXIiOnsibGF0IjotMTUuMTI4MzAwNzgxNjEyMTQ5LCJsbmciOi01NC4zOTA1NzkyMjAwMDM2N30sImNhbkJvdW5kIjpmYWxzZSwiZGF0YXNldHMiOlt7ImRhdGFzZXQiOiJwb2xpdGljYWwtYm91bmRhcmllcyIsImxheWVycyI6WyJkaXNwdXRlZC1wb2xpdGljYWwtYm91bmRhcmllcyIsInBvbGl0aWNhbC1ib3VuZGFyaWVzIl0sImJvdW5kYXJ5Ijp0cnVlLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlfSx7ImRhdGFzZXQiOiJmaXJlLWFsZXJ0cy12aWlycyIsImxheWVycyI6WyJmaXJlLWFsZXJ0cy12aWlycyJdLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlLCJ0aW1lbGluZVBhcmFtcyI6eyJzdGFydERhdGVBYnNvbHV0ZSI6IjIwMjItMDctMDgiLCJlbmREYXRlQWJzb2x1dGUiOiIyMDIyLTEwLTA2Iiwic3RhcnREYXRlIjoiMjAyMi0wNy0wOCIsImVuZERhdGUiOiIyMDIyLTEwLTA2IiwidHJpbUVuZERhdGUiOiIyMDIyLTEwLTA2In19XX0%3D&showMap=true).

