### PR TITLE
Fix help center staging urls in the staging environment

### DIFF
--- a/data/rewrites-staging.json
+++ b/data/rewrites-staging.json
@@ -1,17 +1,17 @@
 [
   {
     "source": "/help/",
-    "destination": "https://gfw-help-center.herokuapp.com/help/",
+    "destination": "https://gfw-help-center-staging.herokuapp.com/help/",
     "basePath": false
   },
   {
     "source": "/help/:path*/",
-    "destination": "https://gfw-help-center.herokuapp.com/help/:path*/",
+    "destination": "https://gfw-help-center-staging.herokuapp.com/help/:path*/",
     "basePath": false
   },
   {
     "source": "/help/:path*",
-    "destination": "https://gfw-help-center.herokuapp.com/help/:path*",
+    "destination": "https://gfw-help-center-staging.herokuapp.com/help/:path*",
     "basePath": false
   },
   {


### PR DESCRIPTION
## Overview

This PR fixes the URL rewrites for the staging environment; the URLs currently set up for the help center are pointing to production instead of staging, causing the help center's `robots` `noindex` metatag to not work correctly. 

## Notes

There are two other accompanying PRs to this one: 
- **Blog**: https://github.com/Vizzuality/gfw-blog/pull/70
- **Help center**: https://github.com/Vizzuality/gfw-help-center/pull/40

These PRs are follow ups to:  

- **Flagship**: https://github.com/Vizzuality/gfw/pull/4437
- **Blog**: https://github.com/Vizzuality/gfw-blog/pull/67
- **Help center**: https://github.com/Vizzuality/gfw-help-center/pull/37

## Testing  

1. `gfw` 
  - Visit: https://staging.globalforestwatch.org  
  - Open the browser's dev tools   
  - Verify that:  
    - There is only one `robots` meta tag  
    - The tag's content is `noindex,follow`
2. `gfw-blog` 
  - Visit: https://staging.globalforestwatch.org/blog/  
  - Open the browser's dev tools   
  - Verify that:  
    - There is only one `robots` meta tag  
    - The tag's content is `noindex,follow`
3. `gfw-help-center` 
  - Visit: https://staging.globalforestwatch.org/help/  
  - Open the browser's dev tools   
  - Verify that:  
    - There is only one `robots` meta tag  
    - The tag's content is `noindex,follow`