### PR TITLE
Remove the second instance of the word "change" in the net change widget

### DIFF
--- a/components/widgets/forest-change/net-change/index.js
+++ b/components/widgets/forest-change/net-change/index.js
@@ -69,9 +69,9 @@ export default {
   },
   sentence: {
     globalInitial:
-      'From 2000 to 2020, the world experienced a net change of {netChange} ({netChangePerc}) change in tree cover.',
+      'From 2000 to 2020, the world experienced a net change of {netChange} ({netChangePerc}) in tree cover.',
     initial:
-      'From 2000 to 2020, {location} experienced a net change of {netChange} ({netChangePerc}) change in tree cover.',
+      'From 2000 to 2020, {location} experienced a net change of {netChange} ({netChangePerc}) in tree cover.',
     // noLoss:
     //   'Fires were responsible for {lossFiresPercentage} of tree cover loss in {location} between {startYear} and {endYear}.',
   },


### PR DESCRIPTION
## Overview

This PR removes the second instance of the word _"change"_ in the net change widget's sentences. 

## Tracking

[FLAG-544 - Remove unnecessary “change” word from net change widget](https://gfw.atlassian.net/browse/FLAG-544)

## Screenshot  

<img width="757" alt="Screenshot 2022-10-25 at 10 31 35" src="https://user-images.githubusercontent.com/6273795/197738293-e7ffa0f3-5c03-4ef6-a9cc-86ec8330fa3b.png">



