### PR TITLE
Add TagsList component to display a list of clickable tags

### DIFF
--- a/components/tags-list/component.jsx
+++ b/components/tags-list/component.jsx
@@ -1,0 +1,45 @@
+import PropTypes from 'prop-types';
+import Link from 'next/link';
+
+import cx from 'classnames';
+
+import './styles.scss';
+
+const TagsList = ({ title, tags, onClick }) => (
+  <div className="c-tags-list">
+    {title && <h5>{title}</h5>}
+    <div className="c-tags-list__group">
+      {tags.map(({ id, name, link, active = false } = {}) => (
+        <span key={id}>
+          {link ? (
+            <Link href={link}>
+              <a className={cx('tag', { active })}>{name}</a>
+            </Link>
+          ) : (
+            <button
+              className={cx('tag', { active })}
+              onClick={() => onClick(id)}
+            >
+              {name}
+            </button>
+          )}
+        </span>
+      ))}
+    </div>
+  </div>
+);
+
+TagsList.propTypes = {
+  title: PropTypes.string,
+  tags: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      link: PropTypes.string,
+      active: PropTypes.bool,
+    })
+  ).isRequired,
+  onClick: PropTypes.func,
+};
+
+export default TagsList;

--- a/components/tags-list/index.js
+++ b/components/tags-list/index.js
@@ -1,0 +1,3 @@
+import Component from './component';
+
+export default Component;

--- a/components/tags-list/styles.scss
+++ b/components/tags-list/styles.scss
@@ -1,0 +1,44 @@
+@import '~styles/settings.scss';
+
+.c-tags-list {
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  font-size: 0; // Fixes an issue with unwanted space above the items
+  gap: rem(24px);
+
+  @media screen and (min-width: $screen-m) {
+    flex-wrap: nowrap;
+  }
+
+  h5 {
+    color: $medium-grey;
+    font-size: rem(14px);
+    text-transform: uppercase;
+  }
+
+  .tag {
+    cursor: pointer;
+    padding: rem(5px) rem(14px);
+    font-size: rem(12px);
+    background-color: $slate-light;
+    border-radius: 0;
+    text-transform: uppercase;
+    color: $white;
+    transition: all 0.15s ease-in-out;
+
+    &.active,
+    &:hover {
+      background-color: $green-gfw;
+    }
+  }
+
+  &__group {
+    display: flex;
+    flex-grow: 1;
+    flex-wrap: wrap;
+    align-items: center;
+    min-height: rem(24px);
+    gap: rem(8px) rem(16px);
+  }
+}


### PR DESCRIPTION
## Overview

This PR adds a new `TagsList` component to allow us to display a list of clickable tags (like the ones displayed in the blog for categories). 

## Notes  

This component is intended to be used in:  

- #4456 
- #4453

## Demo

https://gfw-staging-pr-4456.herokuapp.com/grants-and-fellowships/projects/

## Screenshot

<img width="681" alt="Screenshot 2022-11-02 at 13 18 00" src="https://user-images.githubusercontent.com/6273795/199499873-972ac3ee-761f-4116-a592-b18171502334.png">

