### PR TITLE
Indent net change widgets categories further to the right

### DIFF
--- a/components/charts/components/pie-chart-legend/component.jsx
+++ b/components/charts/components/pie-chart-legend/component.jsx
@@ -7,8 +7,8 @@ import './styles.scss';
 
 class PieChartLegend extends PureComponent {
   render() {
-    const { data, config = {}, className, simple } = this.props;
-    const { legend } = config;
+    const { data, chartSettings = {}, config, className, simple } = this.props;
+    const { legend } = chartSettings;
 
     let sizeClass = '';
     if (data.length > 5) {
@@ -52,6 +52,7 @@ class PieChartLegend extends PureComponent {
 PieChartLegend.propTypes = {
   data: PropTypes.array,
   config: PropTypes.object,
+  chartSettings: PropTypes.object,
   simple: PropTypes.bool,
   className: PropTypes.string,
 };

--- a/components/charts/components/pie-chart-legend/component.jsx
+++ b/components/charts/components/pie-chart-legend/component.jsx
@@ -7,7 +7,9 @@ import './styles.scss';
 
 class PieChartLegend extends PureComponent {
   render() {
-    const { data, config, className, simple } = this.props;
+    const { data, config = {}, className, simple } = this.props;
+    const { legend } = config;
+
     let sizeClass = '';
     if (data.length > 5) {
       sizeClass = 'x-small';
@@ -16,30 +18,33 @@ class PieChartLegend extends PureComponent {
     }
 
     return (
-      <ul
-        className={cx('c-pie-chart-legend', className, sizeClass, { simple })}
+      <div
+        className={cx('c-pie-chart-legend', className)}
+        style={legend?.style}
       >
-        {data.map((item, index) => {
-          const value = `${formatNumber({
-            num: item[config.key],
-            unit: item.unit ? item.unit : config.unit
-          })}`;
-          return (
-            <li className="legend-item" key={index.toString()}>
-              <div className="legend-title">
-                <span style={{ backgroundColor: item.color }}>{}</span>
-                <p>
-                  {item.label}
-                  {data.length > 5 && ` - ${value}`}
-                </p>
-              </div>
-              <div className="legend-value" style={{ color: item.color }}>
-                {value}
-              </div>
-            </li>
-          );
-        })}
-      </ul>
+        <ul className={cx(sizeClass, { simple })}>
+          {data.map((item, index) => {
+            const value = `${formatNumber({
+              num: item[config.key],
+              unit: item.unit ? item.unit : config.unit,
+            })}`;
+            return (
+              <li className="legend-item" key={index.toString()}>
+                <div className="legend-title">
+                  <span style={{ backgroundColor: item.color }}>{}</span>
+                  <p>
+                    {item.label}
+                    {data.length > 5 && ` - ${value}`}
+                  </p>
+                </div>
+                <div className="legend-value" style={{ color: item.color }}>
+                  {value}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
     );
   }
 }
@@ -48,15 +53,15 @@ PieChartLegend.propTypes = {
   data: PropTypes.array,
   config: PropTypes.object,
   simple: PropTypes.bool,
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 PieChartLegend.defaultProps = {
   config: {
     unit: '',
     key: 'value',
-    format: '.3s'
-  }
+    format: '.3s',
+  },
 };
 
 export default PieChartLegend;

--- a/components/charts/components/pie-chart-legend/styles.scss
+++ b/components/charts/components/pie-chart-legend/styles.scss
@@ -38,7 +38,7 @@
     margin-bottom: rem(20px);
   }
 
-  &.small {
+  .small {
     .legend-value {
       padding: 0 0 0 rem(20px);
       font-size: rem(22px);
@@ -46,7 +46,7 @@
     }
   }
 
-  &.x-small {
+  .x-small {
     .legend-item {
       display: flex;
       flex-direction: row;
@@ -60,7 +60,7 @@
     }
   }
 
-  &.simple {
+  .simple {
     &.small {
       .legend-value {
         font-size: rem(18px);

--- a/components/charts/pie-chart/component.jsx
+++ b/components/charts/pie-chart/component.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
+import cx from 'classnames';
 import ChartToolTip from '../components/chart-tooltip';
 
 import './styles.scss';
@@ -17,11 +18,14 @@ class CustomPieChart extends PureComponent {
       endAngle,
       className,
       tooltip,
-      simple
+      simple,
+      config = {},
     } = this.props;
 
+    const { chart } = config;
+
     return (
-      <div className={`c-pie-chart ${className}`}>
+      <div className={cx('c-pie-chart', className)} style={chart?.style}>
         <ResponsiveContainer width="99%" height={maxSize}>
           <PieChart>
             <Pie
@@ -60,7 +64,8 @@ CustomPieChart.propTypes = {
   endAngle: PropTypes.number,
   className: PropTypes.string,
   simple: PropTypes.bool,
-  tooltip: PropTypes.array
+  tooltip: PropTypes.array,
+  config: PropTypes.object,
 };
 
 CustomPieChart.defaultProps = {
@@ -69,7 +74,7 @@ CustomPieChart.defaultProps = {
   innerRadius: '50%',
   outerRadius: '100%',
   startAngle: -270,
-  endAngle: -630
+  endAngle: -630,
 };
 
 export default CustomPieChart;

--- a/components/charts/pie-chart/component.jsx
+++ b/components/charts/pie-chart/component.jsx
@@ -19,10 +19,10 @@ class CustomPieChart extends PureComponent {
       className,
       tooltip,
       simple,
-      config = {},
+      chartSettings = {},
     } = this.props;
 
-    const { chart } = config;
+    const { chart } = chartSettings;
 
     return (
       <div className={cx('c-pie-chart', className)} style={chart?.style}>
@@ -65,7 +65,7 @@ CustomPieChart.propTypes = {
   className: PropTypes.string,
   simple: PropTypes.bool,
   tooltip: PropTypes.array,
-  config: PropTypes.object,
+  chartSettings: PropTypes.object,
 };
 
 CustomPieChart.defaultProps = {

--- a/components/widget/component.jsx
+++ b/components/widget/component.jsx
@@ -37,6 +37,7 @@ class Widget extends PureComponent {
     originalData: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     rawData: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     config: PropTypes.object,
+    chartSettings: PropTypes.object,
     sentence: PropTypes.object,
     proxy: PropTypes.bool,
     proxyOn: PropTypes.array,
@@ -96,6 +97,7 @@ class Widget extends PureComponent {
       locationLabel,
       locationLabelFull,
       data,
+      chartSettings,
       legendData,
       rawData,
       originalData,
@@ -200,6 +202,7 @@ class Widget extends PureComponent {
           rawData={rawData}
           originalData={originalData}
           settings={settings}
+          chartSettings={chartSettings}
           settingsConfig={settingsConfig}
           preventRenderKeys={preventRenderKeys}
           sentence={sentence}

--- a/components/widget/components/widget-pie-chart-legend/component.jsx
+++ b/components/widget/components/widget-pie-chart-legend/component.jsx
@@ -29,7 +29,10 @@ class WidgetPieChart extends PureComponent {
       settingsBtnConfig.shouldShowButton(this.props);
 
     const maxSize =
-      pathname.indexOf('dashboard') >= 0 && chartHeight ? chartHeight : 140;
+      (pathname.indexOf('dashboard') >= 0 || pathname.indexOf('embed')) &&
+      chartHeight
+        ? chartHeight
+        : 140;
 
     return (
       <div className="c-pie-chart-legend-widget">
@@ -80,6 +83,7 @@ class WidgetPieChart extends PureComponent {
                     },
                   ]
             }
+            config={settings}
             simple={simple}
           />
         </div>

--- a/components/widget/components/widget-pie-chart-legend/component.jsx
+++ b/components/widget/components/widget-pie-chart-legend/component.jsx
@@ -14,6 +14,7 @@ class WidgetPieChart extends PureComponent {
       data,
       legendData,
       settings,
+      chartSettings,
       simple,
       toggleSettingsMenu,
       settingsBtnConfig,
@@ -59,6 +60,7 @@ class WidgetPieChart extends PureComponent {
               ...settings,
             }}
             simple={simple}
+            chartSettings={chartSettings}
           />
           <PieChart
             className="cover-pie-chart"
@@ -83,7 +85,7 @@ class WidgetPieChart extends PureComponent {
                     },
                   ]
             }
-            config={settings}
+            chartSettings={chartSettings}
             simple={simple}
           />
         </div>
@@ -97,6 +99,7 @@ WidgetPieChart.propTypes = {
   legendData: PropTypes.array,
   simple: PropTypes.bool,
   settings: PropTypes.object.isRequired,
+  chartSettings: PropTypes.object,
   toggleSettingsMenu: PropTypes.func,
   settingsBtnConfig: PropTypes.object,
   widget: PropTypes.string,

--- a/components/widget/index.js
+++ b/components/widget/index.js
@@ -15,6 +15,9 @@ class WidgetContainer extends Component {
     location: PropTypes.object,
     getData: PropTypes.func,
     setWidgetData: PropTypes.func,
+    chartSettings: PropTypes.object,
+    getChartSettings: PropTypes.func,
+    setWidgetChartSettings: PropTypes.func,
     refetchKeys: PropTypes.array,
     settings: PropTypes.object,
     handleChangeSettings: PropTypes.func,
@@ -32,6 +35,8 @@ class WidgetContainer extends Component {
     location: {},
     getData: fetch,
     setWidgetData: () => {},
+    getChartSettings: () => {},
+    setWidgetChartSettings: () => {},
   };
 
   state = {
@@ -49,6 +54,7 @@ class WidgetContainer extends Component {
     const {
       location,
       settings,
+      chartSettings,
       meta,
       status,
       dashboard,
@@ -58,12 +64,14 @@ class WidgetContainer extends Component {
     const params = {
       ...location,
       ...settings,
+      ...chartSettings,
       status,
       dashboard,
       embed,
       analysis,
     };
 
+    this.handleGetWidgetChartSettings(params);
     this.handleGetWidgetData({ ...params, GFW_META: meta });
   }
 
@@ -71,6 +79,7 @@ class WidgetContainer extends Component {
     const {
       location,
       settings,
+      chartSettings,
       refetchKeys,
       status,
       meta,
@@ -94,11 +103,13 @@ class WidgetContainer extends Component {
       const params = {
         ...location,
         ...settings,
+        ...chartSettings,
         status,
         dashboard,
         embed,
         analysis,
       };
+      this.handleGetWidgetChartSettings(params);
       this.handleGetWidgetData({ ...params, GFW_META: meta });
     }
   }
@@ -181,13 +192,19 @@ class WidgetContainer extends Component {
     }
   };
 
+  handleGetWidgetChartSettings = (params) => {
+    const { getChartSettings, setWidgetChartSettings } = this.props;
+    setWidgetChartSettings(getChartSettings(params));
+  };
+
   handleRefetchData = () => {
-    const { settings, location, widget, meta } = this.props;
-    const params = { ...location, ...settings };
+    const { settings, location, widget, meta, chartSettings } = this.props;
+    const params = { ...location, ...settings, ...chartSettings };
     this.handleGetWidgetData({
       ...params,
       GFW_META: meta,
     });
+    this.handleGetWidgetChartSettings(params);
     trackEvent({
       category: 'Refetch data',
       action: 'Data failed to fetch, user clicks to refetch',

--- a/components/widget/index.js
+++ b/components/widget/index.js
@@ -22,6 +22,9 @@ class WidgetContainer extends Component {
     meta: PropTypes.object,
     status: PropTypes.string,
     maxDownloadSize: PropTypes.object,
+    dashboard: PropTypes.bool,
+    embed: PropTypes.bool,
+    analysis: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -43,14 +46,38 @@ class WidgetContainer extends Component {
 
   componentDidMount() {
     this._mounted = true;
-    const { location, settings, meta, status } = this.props;
-    const params = { ...location, ...settings, status };
+    const {
+      location,
+      settings,
+      meta,
+      status,
+      dashboard,
+      embed,
+      analysis,
+    } = this.props;
+    const params = {
+      ...location,
+      ...settings,
+      status,
+      dashboard,
+      embed,
+      analysis,
+    };
 
     this.handleGetWidgetData({ ...params, GFW_META: meta });
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { location, settings, refetchKeys, status, meta } = this.props;
+    const {
+      location,
+      settings,
+      refetchKeys,
+      status,
+      meta,
+      dashboard,
+      embed,
+      analysis,
+    } = this.props;
     const { error } = this.state;
     const hasLocationChanged =
       location && !isEqual(location, prevProps.location);
@@ -64,7 +91,14 @@ class WidgetContainer extends Component {
 
     // refetch data if error, settings, or location changes
     if (hasSettingsChanged || hasLocationChanged || hasErrorChanged) {
-      const params = { ...location, ...settings, status };
+      const params = {
+        ...location,
+        ...settings,
+        status,
+        dashboard,
+        embed,
+        analysis,
+      };
       this.handleGetWidgetData({ ...params, GFW_META: meta });
     }
   }
@@ -105,11 +139,25 @@ class WidgetContainer extends Component {
 
   handleGetWidgetData = (params) => {
     if (params?.type) {
-      const { getData, setWidgetData, geostore } = this.props;
+      const {
+        getData,
+        setWidgetData,
+        geostore,
+        dashboard,
+        embed,
+        analysis,
+      } = this.props;
       this.cancelWidgetDataFetch();
       this.widgetDataFetch = CancelToken.source();
       this.setState({ loading: true, error: false });
-      getData({ ...params, geostore, token: this.widgetDataFetch.token })
+      getData({
+        ...params,
+        geostore,
+        token: this.widgetDataFetch.token,
+        dashboard,
+        embed,
+        analysis,
+      })
         .then((data) => {
           setWidgetData(data);
           setTimeout(() => {
@@ -136,7 +184,10 @@ class WidgetContainer extends Component {
   handleRefetchData = () => {
     const { settings, location, widget, meta } = this.props;
     const params = { ...location, ...settings };
-    this.handleGetWidgetData({ ...params, GFW_META: meta });
+    this.handleGetWidgetData({
+      ...params,
+      GFW_META: meta,
+    });
     trackEvent({
       category: 'Refetch data',
       action: 'Data failed to fetch, user clicks to refetch',

--- a/components/widgets/actions.js
+++ b/components/widgets/actions.js
@@ -6,6 +6,7 @@ import { setDashboardPromptsSettings } from 'components/prompts/dashboard-prompt
 
 // widgets
 export const setWidgetsData = createAction('setWidgetsData');
+export const setWidgetsChartSettings = createAction('setWidgetsChartSettings');
 export const setWidgetsCategory = createAction('setWidgetsCategory');
 export const setWidgetSettingsByKey = createAction('setWidgetSettingsByKey');
 export const setWidgetInteractionByKey = createAction(

--- a/components/widgets/component.jsx
+++ b/components/widgets/component.jsx
@@ -23,6 +23,7 @@ class Widgets extends PureComponent {
     locationObj: PropTypes.object,
     locationData: PropTypes.object,
     setWidgetsData: PropTypes.func.isRequired,
+    setWidgetsChartSettings: PropTypes.func.isRequired,
     setWidgetSettings: PropTypes.func.isRequired,
     setWidgetInteractionByKey: PropTypes.func.isRequired,
     setActiveWidget: PropTypes.func.isRequired,
@@ -51,6 +52,7 @@ class Widgets extends PureComponent {
       loadingData,
       loadingMeta,
       setWidgetsData,
+      setWidgetsChartSettings,
       setWidgetSettings,
       setWidgetInteractionByKey,
       setActiveWidget,
@@ -114,8 +116,12 @@ class Widgets extends PureComponent {
                     geostore={geostore}
                     meta={meta}
                     metaLoading={loadingMeta || loadingData}
-                    setWidgetData={(data) =>
-                      setWidgetsData({ [w.widget]: data })}
+                    setWidgetData={(data) => {
+                      setWidgetsData({ [w.widget]: data });
+                    }}
+                    setWidgetChartSettings={(chartSettings) => {
+                      setWidgetsChartSettings({ [w.widget]: chartSettings });
+                    }}
                     handleSetInteraction={(payload) =>
                       setWidgetInteractionByKey({
                         key: w.widget,

--- a/components/widgets/component.jsx
+++ b/components/widgets/component.jsx
@@ -31,6 +31,7 @@ class Widgets extends PureComponent {
     setMapSettings: PropTypes.func.isRequired,
     handleClickWidget: PropTypes.func.isRequired,
     embed: PropTypes.bool,
+    dashboard: PropTypes.bool,
     groupBySubcategory: PropTypes.bool,
     modalClosing: PropTypes.bool,
     activeWidget: PropTypes.object,
@@ -57,6 +58,7 @@ class Widgets extends PureComponent {
       setShareModal,
       groupBySubcategory = false,
       embed,
+      dashboard,
       simple,
       modalClosing,
       noDataMessage,
@@ -106,6 +108,7 @@ class Widgets extends PureComponent {
                     authenticated={authenticated}
                     active={activeWidget && activeWidget.widget === w.widget}
                     embed={embed}
+                    dashboard={dashboard}
                     simple={simple}
                     location={location}
                     geostore={geostore}

--- a/components/widgets/forest-change/net-change/index.js
+++ b/components/widgets/forest-change/net-change/index.js
@@ -109,11 +109,12 @@ export default {
               style: {
                 display: 'flex',
                 justifyContent: 'center',
+                paddingRight: '5%',
               },
             },
             chart: {
               style: {
-                paddingRight: '14%',
+                paddingRight: '16%',
               },
             },
           }),

--- a/components/widgets/forest-change/net-change/index.js
+++ b/components/widgets/forest-change/net-change/index.js
@@ -76,7 +76,7 @@ export default {
     //   'Fires were responsible for {lossFiresPercentage} of tree cover loss in {location} between {startYear} and {endYear}.',
   },
   getData: (params = {}) => {
-    const { adm0, adm1, adm2, type } = params || {};
+    const { adm0, adm1, adm2, type, dashboard, embed } = params || {};
 
     const globalLocation = {
       adm0: type === 'global' ? null : adm0,
@@ -104,6 +104,19 @@ export default {
           endYear,
           yearsRange: range,
           chartHeight: 230,
+          ...((dashboard || embed) && {
+            legend: {
+              style: {
+                display: 'flex',
+                justifyContent: 'center',
+              },
+            },
+            chart: {
+              style: {
+                paddingRight: '14%',
+              },
+            },
+          }),
         },
         options: {
           years: range,

--- a/components/widgets/forest-change/net-change/index.js
+++ b/components/widgets/forest-change/net-change/index.js
@@ -75,8 +75,28 @@ export default {
     // noLoss:
     //   'Fires were responsible for {lossFiresPercentage} of tree cover loss in {location} between {startYear} and {endYear}.',
   },
+  getChartSettings: (params) => {
+    const { dashboard, embed } = params;
+
+    return {
+      ...((dashboard || embed) && {
+        legend: {
+          style: {
+            display: 'flex',
+            justifyContent: 'center',
+            paddingRight: '5%',
+          },
+        },
+        chart: {
+          style: {
+            paddingRight: '16%',
+          },
+        },
+      }),
+    };
+  },
   getData: (params = {}) => {
-    const { adm0, adm1, adm2, type, dashboard, embed } = params || {};
+    const { adm0, adm1, adm2, type } = params || {};
 
     const globalLocation = {
       adm0: type === 'global' ? null : adm0,
@@ -104,20 +124,6 @@ export default {
           endYear,
           yearsRange: range,
           chartHeight: 230,
-          ...((dashboard || embed) && {
-            legend: {
-              style: {
-                display: 'flex',
-                justifyContent: 'center',
-                paddingRight: '5%',
-              },
-            },
-            chart: {
-              style: {
-                paddingRight: '16%',
-              },
-            },
-          }),
         },
         options: {
           years: range,

--- a/components/widgets/forest-change/net-change/selectors.js
+++ b/components/widgets/forest-change/net-change/selectors.js
@@ -14,35 +14,42 @@ const getIndicator = (state) => state.indicator;
 const getColors = (state) => state.colors;
 const getSentence = (state) => state && state.sentence;
 
-const parseData = createSelector([getNetChange, getLocationLabel], (data, location) => {
-  if (!data || isEmpty(data)) return null;
+const parseData = createSelector(
+  [getNetChange, getLocationLabel],
+  (data, location) => {
+    if (!data || isEmpty(data)) return null;
 
-  const parsedData = data;
+    const parsedData = data;
 
-  if (isEmpty(parsedData)) return null;
+    if (isEmpty(parsedData)) return null;
 
-  if (location === 'global') {
+    if (location === 'global') {
+      return {
+        change: -2.44,
+        disturb: 307684115.641,
+        gain: 130855151.187,
+        loss: 231428936.133,
+        net: -100573784.946,
+        stable: 3582893990.354,
+        totalArea: sumBy(parsedData, 'gfw_area__ha'),
+      };
+    }
+
     return {
-      change: -2.44,
-      disturb: 307684115.641,
-      gain: 130855151.187,
-      loss: 231428936.133,
-      net: -100573784.946,
-      stable: 3582893990.354,
-      totalArea: sumBy(parsedData, 'gfw_area__ha'),
-    } 
+      change: meanBy(parsedData, 'change'),
+      disturb: sumBy(parsedData, 'disturb'),
+      gain: sumBy(parsedData, 'gain'),
+      loss: sumBy(parsedData, 'loss'),
+      net: sumBy(parsedData, 'net'),
+      stable: sumBy(parsedData, 'stable'),
+      totalArea:
+        sumBy(parsedData, 'disturb') +
+        sumBy(parsedData, 'gain') +
+        sumBy(parsedData, 'loss') +
+        sumBy(parsedData, 'stable'),
+    };
   }
-
-  return {
-    change: meanBy(parsedData, 'change'),
-    disturb: sumBy(parsedData, 'disturb'),
-    gain: sumBy(parsedData, 'gain'),
-    loss: sumBy(parsedData, 'loss'),
-    net: sumBy(parsedData, 'net'),
-    stable: sumBy(parsedData, 'stable'),
-    totalArea: sumBy(parsedData, 'disturb') + sumBy(parsedData, 'gain') + sumBy(parsedData, 'loss') + sumBy(parsedData, 'stable'),
-  };
-});
+);
 
 // Transform data for chart
 const transformData = createSelector([parseData, getColors], (data, colors) => {

--- a/components/widgets/reducers.js
+++ b/components/widgets/reducers.js
@@ -4,6 +4,7 @@ export const initialState = {
   loading: true,
   error: false,
   data: {},
+  chartSettings: {},
   settings: {},
   interactions: {},
   category: 'summary',
@@ -20,6 +21,14 @@ const setWidgetsData = (state, { payload }) => ({
   },
   loading: false,
   error: false,
+});
+
+const setWidgetsChartSettings = (state, { payload }) => ({
+  ...state,
+  chartSettings: {
+    ...state.chartSettings,
+    ...payload,
+  },
 });
 
 const setActiveWidget = (state, { payload }) => ({
@@ -73,6 +82,7 @@ const setWidgetsLoading = (state, { payload }) => ({
 
 export default {
   [actions.setWidgetsData]: setWidgetsData,
+  [actions.setWidgetsChartSettings]: setWidgetsChartSettings,
   [actions.setShowMap]: setShowMap,
   [actions.setWidgetsCategory]: setWidgetsCategory,
   [actions.setActiveWidget]: setActiveWidget,

--- a/components/widgets/selectors.js
+++ b/components/widgets/selectors.js
@@ -84,6 +84,8 @@ export const selectWidgetInteractions = (state) =>
 export const selectLocationSearch = (state) =>
   state.location && state.location.search;
 export const selectWidgetsData = (state) => state.widgets && state.widgets.data;
+export const selectWidgetsChartSettings = (state) =>
+  state.widgets && state.widgets.chartSettings;
 export const selectGeostore = (state) => state.geostore && state.geostore.data;
 export const selectLoadingFilterData = (state) =>
   state.countryData &&
@@ -407,6 +409,7 @@ export const getWidgets = createSelector(
     getLocationObj,
     getLocationData,
     selectWidgetsData,
+    selectWidgetsChartSettings,
     selectWidgetSettings,
     selectWidgetInteractions,
     selectLocationSearch,
@@ -422,6 +425,7 @@ export const getWidgets = createSelector(
     locationObj,
     locationData,
     widgetsData,
+    widgetsChartSettings,
     widgetSettings,
     interactions,
     search,
@@ -451,6 +455,8 @@ export const getWidgets = createSelector(
         (!activeWidgetKey && index === 0) || activeWidgetKey === widget;
 
       const rawData = widgetsData && widgetsData[widget];
+      const chartSettings =
+        widgetsChartSettings && widgetsChartSettings[widget];
 
       const { settings: dataSettings } = rawData || {};
 
@@ -554,6 +560,7 @@ export const getWidgets = createSelector(
         locationType: locationObj?.locationType,
         active,
         data: rawData,
+        chartSettings,
         settings,
         interaction: widgetInteraction,
         title: titleTemplate,

--- a/layouts/dashboards/component.jsx
+++ b/layouts/dashboards/component.jsx
@@ -202,6 +202,7 @@ class DashboardsPage extends PureComponent {
           <Widgets
             className="dashboard-widgets"
             groupBySubcategory={groupBySubcategory}
+            dashboard
           />
           {this.props.locationType === 'global' && <GFRBanner />}
         </div>


### PR DESCRIPTION
## Overview

This PR indents the net change widgets' pie chart's legend to the right, as well as moving the pie chart a bit to the left, as per open chosen in the JIRA task (see comments). 

**In this PR:**  
- `PieChart` component can now accept styles for the legend and pie chart.  
- `Widget` components are now aware of which page they are being loaded in
  (dashboard, analysis, embed)  
- NetChange widget spacing matches the option chosen (only for the dashboard and embed, when displayed in its "big" size)
- Added a new `chartType` setting where we can define custom settings on a per-widget basis  
- Added a new `getChartSettings` to allow us to define settings based on where the widget is being displayed  

## Tracking  

[FLAG-545](https://gfw.atlassian.net/browse/FLAG-545)

## Screenshot  

<img width="797" alt="Screenshot 2022-11-08 at 13 54 17" src="https://user-images.githubusercontent.com/6273795/200582823-c4604550-40a7-470d-a6ef-5c1a9c6cea2d.png">
