### PR TITLE
Change drivers widget from a graph to a donut chart

### DIFF
--- a/components/charts/components/pie-chart-legend/component.jsx
+++ b/components/charts/components/pie-chart-legend/component.jsx
@@ -8,21 +8,21 @@ import './styles.scss';
 class PieChartLegend extends PureComponent {
   render() {
     const { data, chartSettings = {}, config, className, simple } = this.props;
-    const { legend } = chartSettings;
+    const { size, legend } = chartSettings;
 
-    let sizeClass = '';
-    if (data.length > 5) {
-      sizeClass = 'x-small';
-    } else if (data.length > 3 || simple) {
-      sizeClass = 'small';
-    }
+    const sizeClass = (() => {
+      if (size) return size;
+      if (data.length > 5) return 'x-small';
+      if (data.length > 3) return 'small';
+      return '';
+    })();
 
     return (
       <div
         className={cx('c-pie-chart-legend', className)}
         style={legend?.style}
       >
-        <ul className={cx(sizeClass, { simple })}>
+        <ul className={cx({ simple, sizeClass })}>
           {data.map((item, index) => {
             const value = `${formatNumber({
               num: item[config.key],
@@ -34,12 +34,14 @@ class PieChartLegend extends PureComponent {
                   <span style={{ backgroundColor: item.color }}>{}</span>
                   <p>
                     {item.label}
-                    {data.length > 5 && ` - ${value}`}
+                    {sizeClass === 'x-small' && `- ${value}`}
                   </p>
                 </div>
-                <div className="legend-value" style={{ color: item.color }}>
-                  {value}
-                </div>
+                {sizeClass !== 'x-small' && (
+                  <div className="legend-value" style={{ color: item.color }}>
+                    {value}
+                  </div>
+                )}
               </li>
             );
           })}
@@ -52,7 +54,11 @@ class PieChartLegend extends PureComponent {
 PieChartLegend.propTypes = {
   data: PropTypes.array,
   config: PropTypes.object,
-  chartSettings: PropTypes.object,
+  chartSettings: PropTypes.shape({
+    size: PropTypes.oneOf(['small', 'x-small']),
+    legend: { style: PropTypes.object },
+    chart: { style: PropTypes.object },
+  }),
   simple: PropTypes.bool,
   className: PropTypes.string,
 };

--- a/components/widgets/forest-change/tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/tree-loss-drivers/index.js
@@ -8,11 +8,7 @@ import {
   TREE_COVER_LOSS_BY_DOMINANT_DRIVER,
 } from 'data/layers';
 
-import {
-  getTreeCoverLossByDriverType,
-  getExtent,
-  getLoss,
-} from 'services/analysis-cached';
+import { getTreeCoverLossByDriverType } from 'services/analysis-cached';
 
 import getWidgetProps from './selectors';
 
@@ -117,15 +113,13 @@ export default {
       }),
     };
   },
-  getData: (params) => {
-    return getTreeCoverLossByDriverType(params).then((response) => {
+  getData: (params) =>
+    getTreeCoverLossByDriverType(params).then((response) => {
       const { data } = (response && response.data) || {};
       return data;
-    });
-  },
+    }),
   getDataURL: (params) => [
-    getLoss({ ...params, landCategory: 'tsc', lossTsc: true, download: true }),
-    getExtent({ ...params, download: true }),
+    getTreeCoverLossByDriverType({ ...params, download: true }),
   ],
   getWidgetProps,
 };

--- a/components/widgets/forest-change/tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/tree-loss-drivers/index.js
@@ -25,12 +25,19 @@ export default {
   types: ['global', 'country'],
   admins: ['global', 'adm0'],
   caution: {
-    text:
-      'The methods behind this data have changed over time. Be cautious comparing old and new, data especially before/after 2015. {Read more here}.',
-    visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
-    linkText: 'Read more here',
-    link:
-      'https://www.globalforestwatch.org/blog/data-and-research/tree-cover-loss-satellite-data-trend-analysis/',
+    default: {
+      text:
+        'The methods behind this data have changed over time. Be cautious comparing old and new, data especially before/after 2015. {Read more here}.',
+      visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
+      linkText: 'Read more here',
+      link:
+        'https://www.globalforestwatch.org/blog/data-and-research/tree-cover-loss-satellite-data-trend-analysis/',
+    },
+    indonesia: {
+      text:
+        'Indonesia’s rates of deforestation have slowed significantly in recent years (2016-2021), largely due to reductions in commodity-driven expansion. Much of the primary forest loss from commodity-driven deforestation in Indonesia according to the GFW data actually took place in areas legally classified as secondary forests, not primary forests. Please note that ground verification is recommended before any hard conclusions are drawn about the type of forest affected, or cause of loss, in specific patches of loss on the GFW map.',
+      visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
+    },
   },
   categories: ['summary', 'forest-change'],
   subcategories: ['forest-loss'],

--- a/components/widgets/forest-change/tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/tree-loss-drivers/index.js
@@ -79,6 +79,7 @@ export default {
     startYear: 2001,
     endYear: 2021,
     chartHeight: 230,
+    extentYear: 2000,
   },
   sentences: {
     globalInitial:

--- a/components/widgets/forest-change/tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/tree-loss-drivers/index.js
@@ -91,16 +91,20 @@ export default {
 
     return {
       ...((dashboard || embed) && {
+        size: 'small',
         legend: {
           style: {
             display: 'flex',
             justifyContent: 'center',
-            paddingRight: '5%',
+            paddingLeft: '8%',
           },
         },
         chart: {
           style: {
-            paddingRight: '16%',
+            display: 'flex',
+            height: 'auto',
+            alignItems: 'center',
+            paddingRight: '14%',
           },
         },
       }),

--- a/components/widgets/forest-change/tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/tree-loss-drivers/index.js
@@ -11,7 +11,6 @@ import {
   TREE_COVER_LOSS_BY_DOMINANT_DRIVER,
 } from 'data/layers';
 
-import treeLoss from 'components/widgets/forest-change/tree-loss';
 import { getExtent, getLoss } from 'services/analysis-cached';
 
 import getWidgetProps from './selectors';
@@ -20,7 +19,6 @@ const MIN_YEAR = 2001;
 const MAX_YEAR = 2021;
 
 export default {
-  ...treeLoss,
   widget: 'treeLossTsc',
   title: {
     initial: 'Annual tree cover loss by dominant driver in {location}',
@@ -36,6 +34,14 @@ export default {
     link:
       'https://www.globalforestwatch.org/blog/data-and-research/tree-cover-loss-satellite-data-trend-analysis/',
   },
+  categories: ['summary', 'forest-change'],
+  subcategories: ['forest-loss'],
+  large: true,
+  visible: ['dashboard', 'analysis'],
+  colors: 'loss',
+  pendingKeys: ['threshold', 'years', 'extentYear'],
+  refetchKeys: ['forestType', 'landCategory', 'threshold', 'ifl', 'extentYear'],
+  dataType: 'loss',
   settingsConfig: [
     {
       key: 'tscDriverGroup',

--- a/components/widgets/forest-change/tree-loss-drivers/selectors.js
+++ b/components/widgets/forest-change/tree-loss-drivers/selectors.js
@@ -9,8 +9,9 @@ const getColors = (state) => state.colors;
 const getSettings = (state) => state.settings;
 const getTitle = (state) => state.title;
 const getSentences = (state) => state.sentences;
-const getLocationName = (state) => state.locationLabel;
+const getCaution = (state) => state.caution;
 const getLocationLabel = (state) => state.locationLabel;
+const getAdm0 = (state) => state.adm0;
 const getSortedCategories = () =>
   tscLossCategories.sort((a, b) => (a.position > b.position ? 1 : -1));
 
@@ -53,27 +54,30 @@ export const parseData = createSelector(
   }
 );
 
+export const parseTitle = createSelector(
+  [getTitle, getLocationLabel],
+  (title, location) => {
+    let selectedTitle = title.initial;
+    if (location === 'global') {
+      selectedTitle = title.global;
+    }
+    return selectedTitle;
+  }
+);
+
 export const parseSentence = createSelector(
   [
     getFilteredData,
     getSentences,
     getSettings,
     getLocationLabel,
-    getLocationName,
     getPermanentCategories,
   ],
-  (
-    filteredData,
-    sentences,
-    settings,
-    locationLabel,
-    location,
-    permanentCategories
-  ) => {
+  (filteredData, sentences, settings, location, permanentCategories) => {
     if (!filteredData) return null;
     const { globalInitial, initial } = sentences;
     const { startYear, endYear } = settings;
-    const sentence = locationLabel === 'global' ? globalInitial : initial;
+    const sentence = location === 'global' ? globalInitial : initial;
 
     const totalLoss = filteredData.reduce(
       (acc, { loss_area_ha }) => acc + loss_area_ha,
@@ -108,19 +112,14 @@ export const parseSentence = createSelector(
   }
 );
 
-export const parseTitle = createSelector(
-  [getTitle, getLocationName],
-  (title, name) => {
-    let selectedTitle = title.initial;
-    if (name === 'global') {
-      selectedTitle = title.global;
-    }
-    return selectedTitle;
-  }
+export const parseCaution = createSelector(
+  [getCaution, getAdm0],
+  (caution, adm0) => (adm0 === 'IDN' ? caution.indonesia : caution.default)
 );
 
 export default createStructuredSelector({
   data: parseData,
-  sentence: parseSentence,
   title: parseTitle,
+  sentence: parseSentence,
+  caution: parseCaution,
 });

--- a/data/colors.json
+++ b/data/colors.json
@@ -25,7 +25,8 @@
       "Shifting agriculture": "#efd31a",
       "Forestry": "#2FBF71",
       "Wildfire": "#ad6824",
-      "Urbanization": "#B235CC"
+      "Urbanization": "#B235CC",
+      "Unknown": "#555"
     }
   },
   "gain": {

--- a/data/tsc-loss-categories.json
+++ b/data/tsc-loss-categories.json
@@ -6,14 +6,20 @@
     "position": 0
   },
   {
-    "label": "Shifting Agriculture",
-    "value": "Shifting agriculture",
-    "position": 3
-  },
-  {
     "label": "Forestry",
     "value": "Forestry",
+    "position": 1
+  },
+  {
+    "label": "Shifting Agriculture",
+    "value": "Shifting agriculture",
     "position": 2
+  },
+  {
+    "label": "Urbanization",
+    "value": "Urbanization",
+    "permanent": true,
+    "position": 3
   },
   {
     "label": "Wildfire",
@@ -21,9 +27,8 @@
     "position": 4
   },
   {
-    "label": "Urbanization",
-    "value": "Urbanization",
-    "permanent": true,
-    "position": 1
+    "label": "Unknown",
+    "value": "Unknown",
+    "position": 5
   }
 ]

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -459,7 +459,7 @@ export const getWeeksFilter = ({ weeks, latest, isFirst }) => {
 //
 
 export const getTreeCoverLossByDriverType = (params) => {
-  const { forestType, landCategory, ifl, download } = params;
+  const { download } = params;
 
   const requestUrl = getRequestUrl({
     ...params,
@@ -477,11 +477,8 @@ export const getTreeCoverLossByDriverType = (params) => {
   );
 
   if (download) {
-    const indicator = getIndicator(forestType, landCategory, ifl);
     return {
-      name: `tree_cover_gain_by_plantation_type${
-        indicator ? `_in_${snakeCase(indicator.label)}` : ''
-      }__ha`,
+      name: 'tree_cover_loss_by_driver_type__ha',
       url: getDownloadUrl(url),
     };
   }

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -20,6 +20,8 @@ const ENVIRONMENT = process.env.NEXT_PUBLIC_FEATURE_ENV;
 const GFW_API = ENVIRONMENT === 'staging' ? GFW_STAGING_DATA_API : GFW_DATA_API;
 
 const SQL_QUERIES = {
+  treeCoverLossByDriver:
+    'SELECT tsc_tree_cover_loss_drivers__type as driver_type, SUM(umd_tree_cover_loss__ha) AS loss_area_ha FROM data {WHERE} AND tsc_tree_cover_loss_drivers__type IS NOT NULL GROUP BY tsc_tree_cover_loss_drivers__type',
   lossTsc:
     'SELECT tsc_tree_cover_loss_drivers__type, umd_tree_cover_loss__year, SUM(umd_tree_cover_loss__ha) AS umd_tree_cover_loss__ha, SUM("gfw_gross_emissions_co2e_all_gases__Mg") AS "gfw_gross_emissions_co2e_all_gases__Mg" FROM data {WHERE} GROUP BY tsc_tree_cover_loss_drivers__type, umd_tree_cover_loss__year',
   loss:
@@ -455,6 +457,44 @@ export const getWeeksFilter = ({ weeks, latest, isFirst }) => {
 //
 // data fetches
 //
+
+export const getTreeCoverLossByDriverType = (params) => {
+  const { forestType, landCategory, ifl, download } = params;
+
+  const requestUrl = getRequestUrl({
+    ...params,
+    dataset: 'annual',
+    datasetType: 'summary',
+    version: 'v20220721',
+  });
+
+  if (!requestUrl) return new Promise(() => {});
+
+  const sqlQuery = SQL_QUERIES.treeCoverLossByDriver;
+
+  const url = encodeURI(
+    `${requestUrl}${sqlQuery}`.replace('{WHERE}', getWHEREQuery({ ...params }))
+  );
+
+  if (download) {
+    const indicator = getIndicator(forestType, landCategory, ifl);
+    return {
+      name: `tree_cover_gain_by_plantation_type${
+        indicator ? `_in_${snakeCase(indicator.label)}` : ''
+      }__ha`,
+      url: getDownloadUrl(url),
+    };
+  }
+
+  return apiRequest.get(url).then((response) => ({
+    ...response,
+    data: {
+      data: response.data.data.map((d) => ({
+        ...d,
+      })),
+    },
+  }));
+};
 
 // summed loss for single location
 export const getLoss = (params) => {


### PR DESCRIPTION
# IMPORTANT

Merge _just_ prior to #4469.  

We would like to keep this code; the feature is just paused. #4469 takes these changes and reverts them in a single easy to revert commit. 

## Overview

**In this PR:**  

- Change `treeLossTsc` widget from a bar chart to a pie chart  
- Change the SQL query used to fetch the chart's (as well as CSV download) data  
- Added the ability to specify a pie chart's legend sizing via prop  
- Simplified selectable settings  
- Added the _Unknown_ category  
- Custom alert for Indonesia only  

## Screenshot

<img width="750" alt="Screenshot 2022-11-14 at 13 44 55" src="https://user-images.githubusercontent.com/6273795/201675644-83b8f867-4a92-470e-97c9-4c1f0c4f90e9.png">



## Tracking  

[FLAG-556](https://gfw.atlassian.net/browse/FLAG-556)

