### PR TITLE
Change the treeCover widget's title

### DIFF
--- a/components/widgets/land-cover/tree-cover/index.js
+++ b/components/widgets/land-cover/tree-cover/index.js
@@ -41,9 +41,9 @@ const getOTFAnalysis = async (params) => {
 export default {
   widget: 'treeCover',
   title: {
-    default: 'Tree cover in {location}',
-    global: 'Global tree cover',
-    withPlantations: 'Forest cover in {location}',
+    default: 'Tree Cover by type in {location}',
+    global: 'Global tree cover by type',
+    withPlantations: 'Forest cover by type in {location}',
   },
   sentence: {
     globalInitial:


### PR DESCRIPTION
## Overview

This PR changes the treeCover widget's title from `Tree Cover in {country}` to `Tree Cover by Type in {country}`

## Screenshot

<img width="386" alt="Screenshot 2022-11-15 at 14 13 27" src="https://user-images.githubusercontent.com/6273795/201941139-beda2a2f-49c4-4dc6-bd7a-d4af3d68af6a.png">

## Tracking  

[FLAG-553](https://gfw.atlassian.net/browse/FLAG-553)



