### PR TITLE
[FLAG-499] Update GFW User data API to v2

### DIFF
--- a/components/forms/profile/actions.js
+++ b/components/forms/profile/actions.js
@@ -6,35 +6,66 @@ import { setMyGFW } from 'providers/mygfw-provider/actions';
 
 export const saveProfile = createThunkAction(
   'saveProfile',
-  ({
-    id,
-    signUpForNewsletter,
-    subsector,
-    subsector_otherInput,
-    howDoYouUse,
-    howDoYouUse_otherInput,
-    ...rest
-  }) => (dispatch) => {
-    const postData = {
+  (fields) => (dispatch) => {
+    const {
       id,
-      ...rest,
-      subsector:
-        subsector && subsector.includes('Other')
-          ? `Other: ${subsector_otherInput || ''}`
-          : subsector,
-      howDoYouUse:
-        howDoYouUse && howDoYouUse.includes('Other')
-          ? [
-              ...howDoYouUse.filter((use) => use !== 'Other'),
-              `Other: ${howDoYouUse_otherInput || ''}`,
-            ]
-          : howDoYouUse,
-      signUpForNewsletter:
-        !!signUpForNewsletter &&
-        signUpForNewsletter.length &&
-        signUpForNewsletter.includes('newsletter')
-          ? 'true'
-          : false,
+      signUpForNewsletter,
+      subsector,
+      subsector_otherInput,
+      howDoYouUse,
+      howDoYouUse_otherInput,
+      firstName,
+      lastName,
+      email,
+      country,
+      city,
+      state,
+      sector,
+      company,
+      interests,
+      topics,
+      aoiCity,
+      aoiCountry,
+      aoiState,
+      jobTitle,
+    } = fields;
+
+    const postData = {
+      firstName,
+      lastName,
+      email,
+      applicationData: {
+        gfw: {
+          country,
+          city,
+          state,
+          sector,
+          company,
+          interests,
+          topics,
+          aoiCity,
+          aoiCountry,
+          aoiState,
+          jobTitle,
+          subsector:
+            subsector && subsector.includes('Other')
+              ? `Other: ${subsector_otherInput || ''}`
+              : subsector,
+          howDoYouUse:
+            howDoYouUse && howDoYouUse.includes('Other')
+              ? [
+                  ...howDoYouUse.filter((use) => use !== 'Other'),
+                  `Other: ${howDoYouUse_otherInput || ''}`,
+                ]
+              : howDoYouUse,
+          signUpForNewsletter:
+            !!signUpForNewsletter &&
+            signUpForNewsletter.length &&
+            signUpForNewsletter.includes('newsletter')
+              ? 'true'
+              : false,
+        },
+      },
     };
 
     return updateProfile(id, postData)
@@ -46,6 +77,7 @@ export const saveProfile = createThunkAction(
               loggedIn: true,
               id: response.data.data.id,
               ...attributes,
+              ...attributes.applicationData.gfw,
             })
           );
         }

--- a/providers/mygfw-provider/actions.js
+++ b/providers/mygfw-provider/actions.js
@@ -24,6 +24,7 @@ export const getUserProfile = createThunkAction(
                     loggedIn: true,
                     id: authResponse.data.id,
                     ...(data && data.attributes),
+                    ...(data && data.attributes.applicationData.gfw),
                   })
                 );
               }

--- a/services/user.js
+++ b/services/user.js
@@ -51,7 +51,7 @@ export const updateProfile = (id, data) =>
   apiAuthRequest({
     method: 'PATCH',
     data,
-    url: `/user/${id}`,
+    url: `/v2/user/${id}`,
   });
 
 export const checkLoggedIn = (token) => {
@@ -65,7 +65,7 @@ export const checkLoggedIn = (token) => {
   return apiAuthRequest.get('/auth/check-logged');
 };
 
-export const getProfile = (id) => apiAuthRequest.get(`/user/${id}`);
+export const getProfile = (id) => apiAuthRequest.get(`/v2/user/${id}`);
 
 export const logout = () =>
   apiAuthRequest.get('/auth/logout').then((response) => {


### PR DESCRIPTION
## In this PR:

The `user` endpoint of the RW API has been updated to version 2. 
The structure changes a little bit, but I didn't want to change the behaviour of the Forms/Inputs, so I deconstructed the object when fetching and when sending it.

If you know how to clean up the construction of the object before sending to the API, I'd love to learn how! It's a bit... cumbersome.

## Testing

- Open your profile, and change stuff on the Update Profile modal window.