### PR TITLE
Set up http/https and non-www/www redirects

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,14 +24,26 @@ function handleRedirectFor(urls, url, res) {
   }
 }
 
+function handleNonWwwToWwwRedirect(req, res) {
+  try {
+    const host = req.header('host');
+    if (!host.match(/^www\..*/i)) {
+      res.redirect(301, `https://www.${host}${req.url}`);
+    }
+  } catch (_i) {
+    // Ignore by default
+  }
+}
+
 app.prepare().then(() => {
   const server = express();
 
   server.use(sslRedirect(['production'], 301));
 
-  server.all('*', (req, res) => {
-    // Handle water redirects
+  server.all(/.*/, (req, res) => {
+    handleNonWwwToWwwRedirect(req, res);
     handleRedirectFor(waterUrls, req.url, res);
+
     return handle(req, res);
   });
 

--- a/server.js
+++ b/server.js
@@ -27,7 +27,7 @@ function handleRedirectFor(urls, url, res) {
 app.prepare().then(() => {
   const server = express();
 
-  server.use(sslRedirect());
+  server.use(sslRedirect(['production'], 301));
 
   server.all('*', (req, res) => {
     // Handle water redirects

--- a/server.js
+++ b/server.js
@@ -41,7 +41,10 @@ app.prepare().then(() => {
   server.use(sslRedirect(['production'], 301));
 
   server.all(/.*/, (req, res) => {
-    handleNonWwwToWwwRedirect(req, res);
+    if (process.env.NEXT_PUBLIC_FEATURE_ENV === 'production') {
+      handleNonWwwToWwwRedirect(req, res);
+    }
+
     handleRedirectFor(waterUrls, req.url, res);
 
     return handle(req, res);


### PR DESCRIPTION
## Overview

This PR sets up `301` (permanent) redirects from all `non-www` or `http` urls to their `https://www.` versions. 

**In this PR:** 
  - Changed the `http` to `https` redirect from a `302` (temporary) to a `301` (permanent)  
  - Added a `301` (permanent) redirect from `non-www` to `www` for all pages  
  - Improved the `server.js` (custom `express` server file responsible for the redirects) code documentation on everything redirect related  

## Notes

  - The `http` to `https` redirects work on `staging`, `preproduction` and `production` environments.  
    This is set up by the `NODE_ENV` environment variable (which is set to `production` in those environments)
  - The `non-www` to `www` redirects **only** work on `production`. 
    This is because `staging` and `preproduction` don't support `www` urls
    This is set up by the `NEXT_PUBLIC_FEATURE_ENV` environment variable (which is set to `production` only on the `production` environment)

## Tracking

[FLAG-511](https://gfw.atlassian.net/browse/FLAG-511)

## Testing

**IMPORTANT NOTES:**  

- One may have to clear the browser cache and reload between tests in order for the redirects to work properly.
- `non-www` to `www` redirects will not be applied in `staging` or `preproduction`. This is because our current setup doesn't allow `www` URLs in those environments. `http` to `https` is supported though. 

**Local environment**  

1. Run `yarn dev` 
    - Ensure that the local development environment boots up normally  
2. Set `NEXT_PUBLIC_FEATURE_ENV` to `production` locally  
3. Run `yarn build` _to build a production version of the website_  
4. Run `yarn start` _to spin up our custom `nextjs/express` server_
    - Ensure the redirects work as expected   
      _The pages will not load, but one can verify the redirects work in the browser's address bar_  

**Staging environment**  

1.  Set `NEXT_PUBLIC_FEATURE_ENV` _(in the Heroku Config Vars)_ to `staging` or `preproduction`, if not set  
    - Ensure the pages load correctly  
    - Ensure the `http` to `https` redirects work as expected  
2. Set `NEXT_PUBLIC_FEATURE_ENV` _(in the Heroku Config Vars)_ to `production`
    - Ensure the redirects work as expected   
      _The pages will not load, but one can verify the redirects work in the browser's address bar_  