### PR TITLE
[FLAG-538] Improve Map Popup size and text handling

### DIFF
--- a/components/map/components/popup/component.jsx
+++ b/components/map/components/popup/component.jsx
@@ -145,6 +145,7 @@ class Popup extends Component {
         longitude={longitude}
         onClose={clearMapInteractions}
         closeOnClick={false}
+        captureScroll
       >
         <div className="c-popup">{this.renderPopupBody()}</div>
       </MapPopup>

--- a/components/map/components/popup/components/data-table/styles.scss
+++ b/components/map/components/popup/components/data-table/styles.scss
@@ -18,6 +18,7 @@
         flex-direction: column;
         justify-content: center;
         align-items: flex-start;
+        word-break: break-word;
       }
 
       .table-link {

--- a/components/map/components/popup/styles.scss
+++ b/components/map/components/popup/styles.scss
@@ -3,8 +3,9 @@
 .c-popup {
   font-family: $font-family-1;
   border-radius: 2px;
-  max-width: rem(290px);
+  max-width: rem(360px);
   min-width: rem(200px);
+  max-height: calc(100vh - 100px);
 
   .close-btn {
     position: absolute;
@@ -27,6 +28,8 @@
 
   .popup-body {
     padding: rem(25px);
+    height: 100%;
+    overflow: hidden;
 
     .title {
       font-size: rem(16px);
@@ -46,6 +49,7 @@
   padding: 0 !important;
   box-shadow: 0 3px 14px rgba(0, 0, 0, 0.4);
   border-radius: 0 !important;
+  overflow: auto;
 
   .mapboxgl-popup-close-button {
     top: 5px;


### PR DESCRIPTION
## Overview

There was a bug related to "Alliance for Zero Extinction sites - 2019" pop-up box in which the text would overflow outside the modal window. This has been fixed and with that, the popup was also made a big wider and not ever higher than the viewport and will add scroll if the content doesn't fit.