### PR TITLE
[FLAG-599] Fix Dashboard Nav links ignoring admin areas

### DIFF
--- a/layouts/dashboards/selectors.js
+++ b/layouts/dashboards/selectors.js
@@ -47,7 +47,7 @@ export const getLinks = createSelector(
   [getWidgetCategories, getActiveCategory, selectLocation],
   (widgetCats, activeCategory, location) => {
     const serializePayload = Object.values(location.payload).filter(
-      (p) => p && p.length
+      (p) => p && p.toString().length
     );
 
     function formatQuery(category) {


### PR DESCRIPTION
## Overview

Silly bug that made Nav links in Dashboard not take admin areas into account, only country.