### PR TITLE
[FLAG-516] Update to node v14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.16.2'
+          node-version: '14.19.0'
       - name: Install modules
         run: yarn
       - name: Run ESLint
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.16.2'
+          node-version: '14.19.0'
       - name: Cache Cypress binary
         uses: actions/cache@v2
         with:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.4.5",
   "description": "Global Forest Watch",
   "engines": {
-    "node": "12.16.2"
+    "node": "14.19.0"
   },
   "scripts": {
     "dev": "next",


### PR DESCRIPTION
## Overview

Update node to v14 through package.json version bump.

## Testing

- Check that heroku actually uses node 14 (for Pedro)
- Check that everything works correctly (maps, dashboards, analysis, login to MyGFW, internal links, external links) (for everyone involved)