### PR TITLE
Fix issues with file uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# vscode
+.vscode

--- a/pages/api/data/[...params].js
+++ b/pages/api/data/[...params].js
@@ -12,6 +12,7 @@ const DATA_API_URL =
 export const config = {
   api: {
     externalResolver: true,
+    bodyParser: false,
   },
 };
 

--- a/pages/api/gfw/[...params].js
+++ b/pages/api/gfw/[...params].js
@@ -11,6 +11,7 @@ const GFW_API_URL = ENVIRONMENT === 'staging' ? GFW_STAGING_API : GFW_API;
 export const config = {
   api: {
     externalResolver: true,
+    bodyParser: false,
   },
 };
 

--- a/pages/api/metadata/[...params].js
+++ b/pages/api/metadata/[...params].js
@@ -12,6 +12,7 @@ const GFW_METADATA_API_URL =
 export const config = {
   api: {
     externalResolver: true,
+    bodyParser: false,
   },
 };
 


### PR DESCRIPTION
## Overview

This PR aims to solve the issue with geostore file uploads failing due to a size limit. 

It looks like the issue is that, in our proxied api implementation, the body of the requests is parsed. In the case of file uploads in particular, this inflates the request body, exceeding the default limit. Since we're only proxying the requests, we don't need to parse anything and the [bodyparser](https://nextjs.org/docs/api-routes/request-helpers#custom-config) can be disabled completely. 


## Tracking

[FLAG-675](https://gfw.atlassian.net/browse/FLAG-675)

