### PR TITLE
[FLG-627] Grants and fellowships projets pagination

### DIFF
--- a/components/load-more/component.jsx
+++ b/components/load-more/component.jsx
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+import { Row, Column, Button } from 'gfw-components';
+
+import './styles.scss';
+
+export const LoadMoreButton = ({ onClickHandle }) => (
+  <Column className="c-load-more">
+    <Row nested>
+      <Column width={[1 / 12, 1 / 3]} />
+      <Column width={[5 / 6, 1 / 3]} className="button-wrapper">
+        <Button onClick={() => onClickHandle()}>Load more articles</Button>
+      </Column>
+    </Row>
+  </Column>
+);
+
+LoadMoreButton.propTypes = {
+  onClickHandle: PropTypes.func,
+};
+
+export default LoadMoreButton;

--- a/components/load-more/component.jsx
+++ b/components/load-more/component.jsx
@@ -1,20 +1,33 @@
 import PropTypes from 'prop-types';
-import { Row, Column, Button } from 'gfw-components';
+import { Row, Column, Button, Loader } from 'gfw-components';
 
 import './styles.scss';
 
-export const LoadMoreButton = ({ onClickHandle }) => (
+export const LoadMoreButton = ({
+  isLoading = false,
+  isVisible = true,
+  onClickHandle,
+}) => (
   <Column className="c-load-more">
     <Row nested>
       <Column width={[1 / 12, 1 / 3]} />
       <Column width={[5 / 6, 1 / 3]} className="button-wrapper">
-        <Button onClick={() => onClickHandle()}>Load more articles</Button>
+        {isLoading && (
+          <div className="c-load-more-loader">
+            <Loader />
+          </div>
+        )}
+        {!isLoading && isVisible && (
+          <Button onClick={() => onClickHandle()}>Load more articles</Button>
+        )}
       </Column>
     </Row>
   </Column>
 );
 
 LoadMoreButton.propTypes = {
+  isLoading: PropTypes.bool,
+  isVisible: PropTypes.bool,
   onClickHandle: PropTypes.func,
 };
 

--- a/components/load-more/index.js
+++ b/components/load-more/index.js
@@ -1,0 +1,3 @@
+import Component from './component';
+
+export default Component;

--- a/components/load-more/styles.scss
+++ b/components/load-more/styles.scss
@@ -5,4 +5,10 @@
     justify-content: center;
     width: 100%;
   }
+
+  &-loader {
+    position: relative;
+    width: 50px;
+    height: 50px;
+  }
 }

--- a/components/load-more/styles.scss
+++ b/components/load-more/styles.scss
@@ -1,0 +1,8 @@
+.c-load-more {
+  .button-wrapper {
+    margin: 20px 0 50px;
+    display: flex;
+    justify-content: center;
+    width: 100%;
+  }
+}

--- a/layouts/grants-and-fellowships/projects/component.jsx
+++ b/layouts/grants-and-fellowships/projects/component.jsx
@@ -178,7 +178,11 @@ const GrantsProjectsSection = ({
               message="No projects for that search"
             />
           )}
-          <LoadMoreButton onClickHandle={() => {}} />
+          <LoadMoreButton
+            isLoading={false}
+            isVisible
+            onClickHandle={() => {}}
+          />
         </Row>
       </div>
       <ProjectsModal

--- a/layouts/grants-and-fellowships/projects/component.jsx
+++ b/layouts/grants-and-fellowships/projects/component.jsx
@@ -15,7 +15,6 @@ import { getSGFProjects } from 'services/projects';
 import ProjectsModal from './projects-modal';
 import { getProjectsProps } from './selectors';
 
-
 import './styles.scss';
 
 const GrantsProjectsSection = ({
@@ -24,6 +23,7 @@ const GrantsProjectsSection = ({
   images,
   countries: allCountries,
   country: countryQueryParam,
+  totalPages,
 }) => {
   const [projectsList, setProjects] = useState(allProjects);
   const [country, setCountry] = useState(countryQueryParam);
@@ -92,10 +92,12 @@ const GrantsProjectsSection = ({
       const getMoreProjects = async () => {
         try {
           setLoading(true);
-          const posts = await getSGFProjects({ params: { page: pageNumber } });
+          const { sgfProjects } = await getSGFProjects({
+            params: { page: pageNumber },
+          });
           setLoading(false);
 
-          return posts;
+          return sgfProjects;
         } catch (error) {
           setLoading(false);
           setVisible(false);
@@ -107,6 +109,10 @@ const GrantsProjectsSection = ({
       getMoreProjects().then((projectItems) => {
         if (projectItems) {
           setProjects([...projectsList, ...projectItems]);
+        }
+
+        if (pageNumber === totalPages) {
+          setVisible(false);
         }
       });
     }
@@ -231,6 +237,7 @@ GrantsProjectsSection.propTypes = {
   projects: PropTypes.array,
   projectsTexts: PropTypes.object,
   images: PropTypes.object,
+  totalPages: PropTypes.number,
 };
 
 export default GrantsProjectsSection;

--- a/layouts/grants-and-fellowships/projects/component.jsx
+++ b/layouts/grants-and-fellowships/projects/component.jsx
@@ -9,6 +9,7 @@ import { Search, NoContent, Row, Column } from 'gfw-components';
 import Card from 'components/ui/card';
 import Dropdown from 'components/ui/dropdown';
 import TagsList from 'components/tags-list';
+import LoadMoreButton from 'components/load-more';
 
 import ProjectsModal from './projects-modal';
 import { getProjectsProps } from './selectors';
@@ -177,6 +178,7 @@ const GrantsProjectsSection = ({
               message="No projects for that search"
             />
           )}
+          <LoadMoreButton onClickHandle={() => {}} />
         </Row>
       </div>
       <ProjectsModal

--- a/layouts/grants-and-fellowships/projects/component.jsx
+++ b/layouts/grants-and-fellowships/projects/component.jsx
@@ -41,10 +41,7 @@ const GrantsProjectsSection = ({
 
   const getMoreProjects = useCallback(async (params) => {
     try {
-      setLoading(true);
-      const { sgfProjects } = await getSGFProjects({
-        params,
-      });
+      const { sgfProjects } = await getSGFProjects({ params });
       setLoading(false);
 
       return sgfProjects;
@@ -179,9 +176,15 @@ const GrantsProjectsSection = ({
     setQueryParams({ projectId: null });
   };
 
+  const resetProjectsList = () => {
+    setProjects([]);
+    setLoading(true);
+  };
+
   const handleCountrySelected = (option) => {
     const params = createParameters(searchKeyword, option);
 
+    resetProjectsList();
     setQueryParams({ country: option });
     getMoreProjects(params).then((projectItems) =>
       setMoreProjects(projectItems, option, searchKeyword)
@@ -191,11 +194,12 @@ const GrantsProjectsSection = ({
   const handleSearchOnChange = debounce((searchItem) => {
     const params = createParameters(searchItem, country);
 
+    resetProjectsList();
     setSearchKeyword(searchItem);
-    getMoreProjects(params).then((projectItems) =>
-      setMoreProjects(projectItems, searchItem, country)
-    );
-  }, 500);
+    getMoreProjects(params).then((projectItems) => {
+      setMoreProjects(projectItems, searchItem, country);
+    });
+  }, 1000);
 
   const handleOnLoadMore = debounce(() => {
     getMoreProjects({ page: pageNumber + 1, per_page: 21 }).then(
@@ -243,7 +247,11 @@ const GrantsProjectsSection = ({
             <TagsList title="Categories" tags={tags} onClick={setCategory} />
           </Column>
           <Column width={[1, 1 / 2, 1 / 3]}>
-            <Search placeholder="Search" onChange={handleSearchOnChange} />
+            <Search
+              placeholder="Search"
+              onChange={handleSearchOnChange}
+              onSubmit={handleSearchOnChange}
+            />
           </Column>
         </Row>
         <Row className="project-cards">

--- a/layouts/grants-and-fellowships/projects/component.jsx
+++ b/layouts/grants-and-fellowships/projects/component.jsx
@@ -4,6 +4,8 @@ import { useRouter } from 'next/router';
 
 import omitBy from 'lodash/omitBy';
 import orderBy from 'lodash/orderBy';
+import debounce from 'lodash/debounce';
+
 import { Search, NoContent, Row, Column } from 'gfw-components';
 
 import Card from 'components/ui/card';
@@ -29,7 +31,6 @@ const GrantsProjectsSection = ({
   const [projectsList, setProjects] = useState(allProjects);
   const [country, setCountry] = useState(countryQueryParam);
   const [category, setCategory] = useState('All');
-  const [search, setSearch] = useState('');
   const [pageNumber, setPageNumber] = useState(1);
   const [isLoading, setLoading] = useState(false);
   const [isVisible, setVisible] = useState(true);
@@ -48,7 +49,6 @@ const GrantsProjectsSection = ({
       getProjectsProps({
         projects: projectsListOrdered,
         images,
-        search,
         category,
         country,
       }),
@@ -153,7 +153,7 @@ const GrantsProjectsSection = ({
     });
   };
 
-  const handleOnLoadMore = () => {
+  const handleOnLoadMore = debounce(() => {
     getMoreProjects({ page: pageNumber + 1, per_page: 21 }).then(
       (projectItems) => {
         if (projectItems) {
@@ -166,11 +166,9 @@ const GrantsProjectsSection = ({
         }
       }
     );
-  };
+  }, 100);
 
-  const handleSearchOnChange = (searchItem) => {
-    setSearch(searchItem);
-
+  const handleSearchOnChange = debounce((searchItem) => {
     let params = { search: searchItem, per_page: 100 };
 
     if (searchItem === '') {
@@ -190,7 +188,7 @@ const GrantsProjectsSection = ({
         }
       }
     });
-  };
+  }, 500);
 
   return (
     <Fragment>
@@ -223,11 +221,7 @@ const GrantsProjectsSection = ({
             <TagsList title="Categories" tags={tags} onClick={setCategory} />
           </Column>
           <Column width={[1, 1 / 2, 1 / 3]}>
-            <Search
-              placeholder="Search"
-              input={search}
-              onChange={handleSearchOnChange}
-            />
+            <Search placeholder="Search" onChange={handleSearchOnChange} />
           </Column>
         </Row>
         <Row className="project-cards">

--- a/layouts/grants-and-fellowships/projects/component.jsx
+++ b/layouts/grants-and-fellowships/projects/component.jsx
@@ -23,7 +23,7 @@ const GrantsProjectsSection = ({
   images,
   allCountries,
   country: countryQueryParam,
-  countries,
+  projectCountries,
   totalPages,
 }) => {
   const [projectsList, setProjects] = useState(allProjects);
@@ -64,10 +64,10 @@ const GrantsProjectsSection = ({
     () => [
       { label: 'All', value: '' },
       ...allCountries
-        .filter(({ iso }) => countries.includes(iso))
+        .filter(({ iso }) => projectCountries.includes(iso))
         .map(({ iso, name }) => ({ label: name, value: iso })),
     ],
-    [allCountries, countries]
+    [allCountries, projectCountries]
   );
 
   const tags = useMemo(
@@ -283,7 +283,7 @@ const GrantsProjectsSection = ({
 
 GrantsProjectsSection.propTypes = {
   country: PropTypes.string,
-  countries: PropTypes.array,
+  projectCountries: PropTypes.array,
   allCountries: PropTypes.array,
   projects: PropTypes.array,
   projectsTexts: PropTypes.object,

--- a/layouts/grants-and-fellowships/projects/component.jsx
+++ b/layouts/grants-and-fellowships/projects/component.jsx
@@ -21,8 +21,9 @@ const GrantsProjectsSection = ({
   projects: allProjects,
   projectsTexts,
   images,
-  countries: allCountries,
+  allCountries,
   country: countryQueryParam,
+  countries,
   totalPages,
 }) => {
   const [projectsList, setProjects] = useState(allProjects);
@@ -42,7 +43,7 @@ const GrantsProjectsSection = ({
     [projectsList]
   );
 
-  const { projects, categories, countries } = useMemo(
+  const { projects, categories } = useMemo(
     () =>
       getProjectsProps({
         projects: projectsListOrdered,
@@ -63,7 +64,7 @@ const GrantsProjectsSection = ({
     () => [
       { label: 'All', value: '' },
       ...allCountries
-        ?.filter(({ iso }) => countries.includes(iso))
+        .filter(({ iso }) => countries.includes(iso))
         .map(({ iso, name }) => ({ label: name, value: iso })),
     ],
     [allCountries, countries]
@@ -82,7 +83,7 @@ const GrantsProjectsSection = ({
   useEffect(() => setCountry(countryIso), [countryIso, setCountry]);
 
   useEffect(() => {
-    if (!categories.map(({ label }) => label).includes(category)) {
+    if (!categories?.map(({ label }) => label).includes(category)) {
       setCategory('All');
     }
   }, [country]);
@@ -283,6 +284,7 @@ const GrantsProjectsSection = ({
 GrantsProjectsSection.propTypes = {
   country: PropTypes.string,
   countries: PropTypes.array,
+  allCountries: PropTypes.array,
   projects: PropTypes.array,
   projectsTexts: PropTypes.object,
   images: PropTypes.object,

--- a/layouts/grants-and-fellowships/projects/selectors.js
+++ b/layouts/grants-and-fellowships/projects/selectors.js
@@ -49,13 +49,6 @@ const getFilteredProjects = createSelector(
   }
 );
 
-const getCountriesList = createSelector(getProjects, (projects) => {
-  if (!projects?.length) return null;
-  return uniq(
-    flatten(projects.map((p) => p.countries.split(',').map((c) => c.trim())))
-  );
-});
-
 const getCategories = createSelector(getProjectsByCountry, (projects) => {
   if (!projects?.length) return null;
   return [
@@ -95,5 +88,4 @@ const getCategoriesList = createSelector(
 export const getProjectsProps = createStructuredSelector({
   projects: getFilteredProjects,
   categories: getCategoriesList,
-  countries: getCountriesList,
 });

--- a/layouts/grants-and-fellowships/projects/selectors.js
+++ b/layouts/grants-and-fellowships/projects/selectors.js
@@ -49,6 +49,13 @@ const getFilteredProjects = createSelector(
   }
 );
 
+const getCountriesList = createSelector(getProjects, (projects) => {
+  if (!projects?.length) return null;
+  return uniq(
+    flatten(projects.map((p) => p.countries.split(',').map((c) => c.trim())))
+  );
+});
+
 const getCategories = createSelector(getProjectsByCountry, (projects) => {
   if (!projects?.length) return null;
   return [
@@ -88,4 +95,5 @@ const getCategoriesList = createSelector(
 export const getProjectsProps = createStructuredSelector({
   projects: getFilteredProjects,
   categories: getCategoriesList,
+  countries: getCountriesList,
 });

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "fast-redux": "^0.7.1",
     "file-saver": "^2.0.2",
     "final-form": "^4.18.7",
-    "gfw-components": "1.8.10",
+    "gfw-components": "1.8.11",
     "heroku-ssl-redirect": "^0.1.1",
     "html-react-parser": "^3.0.6",
     "image-trace-loader": "^1.0.2",

--- a/pages/about.js
+++ b/pages/about.js
@@ -14,7 +14,7 @@ const AboutPage = (props) => (
 );
 
 export const getStaticProps = async () => {
-  const sgfProjects = await getSGFProjects();
+  const { sgfProjects } = await getSGFProjects();
   const impactProjects = await getImpactProjects();
   const countries = await getCountriesProvider();
 

--- a/pages/about.js
+++ b/pages/about.js
@@ -14,7 +14,7 @@ const AboutPage = (props) => (
 );
 
 export const getStaticProps = async () => {
-  const { sgfProjects } = await getSGFProjects();
+  const { sgfProjects } = await getSGFProjects({ params: { per_page: 100 } });
   const impactProjects = await getImpactProjects();
   const countries = await getCountriesProvider();
 

--- a/pages/grants-and-fellowships/[section].js
+++ b/pages/grants-and-fellowships/[section].js
@@ -28,10 +28,10 @@ export const getServerSideProps = async ({ query }) => {
 
   if (query?.section === 'projects') {
     const pageTexts = await getSGFPage();
-    const projects = await getSGFProjects();
+    const { sgfProjects, totalPages } = await getSGFProjects();
     const countries = await getCountriesProvider();
 
-    const parsedProjects = projects.map((p) => ({
+    const parsedProjects = sgfProjects.map((p) => ({
       ...p,
       title: ReactHtmlParser(p.title),
     }));
@@ -45,6 +45,7 @@ export const getServerSideProps = async ({ query }) => {
         country: query?.country || '',
         projectsTexts: pageTexts?.[0]?.acf,
         header: pageTexts[0],
+        totalPages,
       },
     };
   }

--- a/pages/grants-and-fellowships/[section].js
+++ b/pages/grants-and-fellowships/[section].js
@@ -28,7 +28,9 @@ export const getServerSideProps = async ({ query }) => {
 
   if (query?.section === 'projects') {
     const pageTexts = await getSGFPage();
-    const { sgfProjects, totalPages } = await getSGFProjects();
+    const { sgfProjects, totalPages } = await getSGFProjects({
+      params: { per_page: 21 },
+    });
     const countries = await getCountriesProvider();
 
     const parsedProjects = sgfProjects.map((p) => ({

--- a/pages/grants-and-fellowships/[section].js
+++ b/pages/grants-and-fellowships/[section].js
@@ -5,7 +5,7 @@ import PageLayout from 'wrappers/page';
 import GrantsAndFellowships from 'layouts/grants-and-fellowships';
 
 import { getSGFPage } from 'services/grants-and-fellowships';
-import { getSGFProjects , getSGFCountries } from 'services/projects';
+import { getSGFProjects, getSGFCountries } from 'services/projects';
 
 import { getCountriesProvider } from 'services/country';
 
@@ -56,7 +56,7 @@ export const getServerSideProps = async ({ query }) => {
         section: query?.section,
         projects: parsedProjects || [],
         allCountries: allCountries?.data?.rows || [],
-        countries: uniqCountries || [],
+        projectCountries: uniqCountries || [],
         country: query?.country || '',
         projectsTexts: pageTexts?.[0]?.acf,
         header: pageTexts[0],

--- a/services/projects.js
+++ b/services/projects.js
@@ -43,7 +43,7 @@ export async function getSGFProjects({
 } = {}) {
   const projectsData = await Promise.all([
     apiFetch({
-      url: `${process.env.NEXT_PUBLIC_WORDPRESS_URL}/wp/v2/gaf_projects?per_page=100`,
+      url: `${process.env.NEXT_PUBLIC_WORDPRESS_URL}/wp/v2/gaf_projects?per_page=21`,
       params: {
         ...params,
         _embed: true,

--- a/services/projects.js
+++ b/services/projects.js
@@ -99,6 +99,7 @@ export async function getSGFProjects({
   ]);
 
   const formattedProjects = formatProjects(projectsData);
+  const totalPages = parseInt(projectsData[0].headers['x-wp-totalpages'], 10);
 
-  return formattedProjects;
+  return { sgfProjects: formattedProjects, totalPages };
 }

--- a/services/projects.js
+++ b/services/projects.js
@@ -103,3 +103,23 @@ export async function getSGFProjects({
 
   return { sgfProjects: formattedProjects, totalPages };
 }
+
+export async function getSGFCountries({
+  cancelToken,
+  params,
+  allLanguages,
+} = {}) {
+  const countries = await apiFetch({
+    url: `${process.env.NEXT_PUBLIC_WORDPRESS_URL}/wp/v2/gaf_projects?&_fields[]=acf.country&per_page=100`,
+    params: {
+      ...params,
+      _embed: true,
+      ...(!allLanguages && {
+        lang: 'en',
+      }),
+    },
+    cancelToken,
+  });
+
+  return countries;
+}

--- a/services/projects.js
+++ b/services/projects.js
@@ -85,7 +85,7 @@ export async function getSGFProjects({
 } = {}) {
   const projectsData = await Promise.all([
     apiFetch({
-      url: `${process.env.NEXT_PUBLIC_WORDPRESS_URL}/wp/v2/gaf_projects?per_page=21`,
+      url: `${process.env.NEXT_PUBLIC_WORDPRESS_URL}/wp/v2/gaf_projects`,
       params: {
         ...params,
         _embed: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8273,10 +8273,10 @@ gettext-parser@^1.3.1:
     encoding "^0.1.12"
     safe-buffer "^5.1.1"
 
-gfw-components@1.8.10:
-  version "1.8.10"
-  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.10.tgz#1c7fd9033557d8b47dd5eeaa075bcb0e37590f67"
-  integrity sha512-5+mPaqI3gJZN5899YyZZWGUP3noaSEwC7zrl6zd2nbP11pS5a+PVHECQ3haUf6F9hG74EoZ/pD7D4A52gxjWqg==
+gfw-components@1.8.11:
+  version "1.8.11"
+  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.11.tgz#db5b3882bb286b62f12df0e19d1ffc1e9e086625"
+  integrity sha512-OU+o5wpBUTg0pKE2N4aghNOIUDXYz4umQ8R5m1XRRwa/KG3dOg5nvUS+mDql8nSHCoxXLzpFuy6L2Z1YnihhLw==
   dependencies:
     "@artsy/fresnel" "^1.1.0"
     "@tippyjs/react" "^4.0.2"


### PR DESCRIPTION
## Overview

Wordpress by default only lets us get 100 posts at once. If G&F gets more Projects (it’s now at 94), they won’t load.

Instead of editing things so that the page fetches more project cards at a time, we’ve opted to paginate and load 21 posts at a time. We’ll follow the same styling that’s done on the GFW Blog (image below). Pagination should improve the loading speed of this page and probably help SEO-wise.

## Demo

![grants-and-fellowships](https://user-images.githubusercontent.com/23243868/220932925-21a66d38-8308-4a96-9e42-976fcb9d606f.png)

## Notes
To meet the criteria we had to change the way we provide filters/search in this page.

- From now on, both search and filter are requesting WP Rest API for new items instead just order/omit items on front. 
- Countries filter logic was moved to SSR to avoid these computation on frontend side. 
- WP Rest API was changed and its code is on Pantheon. We should deploy it after that deploy.

## Testing

- Connect to WordPress locally and make sure you have all changes to get the advanced search feature.
- Visit /grants-and-fellowships/projects/

