### PR TITLE
Fix trase api endpoint url

### DIFF
--- a/utils/apis.js
+++ b/utils/apis.js
@@ -30,4 +30,4 @@ export const MAPBOX_API = 'https://api.mapbox.com/';
 export const CLIMATE_WATCH_API = 'https://www.climatewatchdata.org/api/v1';
 
 // TRASE API
-export const TRASE_API = 'https://trase.earth/api/v3';
+export const TRASE_API = 'https://supplychains.trase.earth/api/v3';


### PR DESCRIPTION
## Overview

This PR updates the Trase API endpoint URL to the current one. 

It looks like the Trase project changed their API endpoint urls a bit over 2 years ago. I was able to [track down the change](https://github.com/Vizzuality/trase/pull/1638/files#diff-4a38e8d9b6b0304b07f9103364921ba3268379d70eeb6c2fd5c540af53687420R3) and obtain the current url. 

## Testing

1. Visit the dashboard  
2. Choose the country _"Peru"_   
3. Select the _"Land Use"_ category
4. Verify that the _"Commodities flow"_ widget works
  _It will be the first one_

## Tracking  

[FLAG-458](https://gfw.atlassian.net/browse/FLAG-458)