### PR TITLE
Fix issues where, on the /map, switching from mobile to desktop duplicates the widgets/charts

### DIFF
--- a/components/map-menu/component.jsx
+++ b/components/map-menu/component.jsx
@@ -90,6 +90,13 @@ class MapMenu extends PureComponent {
     }
   };
 
+  // On Mobile, the <MenuPanel /> component is also used to display the legend and analysis.
+  // On Desktop, the <DataAnalysisMenu /> is used instead. This causes issues when a user is on the
+  // mobile version on a panel that does not exist on desktop, and switches to the desktop version;
+  // because if a panel does not exist, it'll either be displayed as a blank panel (layer category
+  // selection), or duplicate items (analysis).
+  // Here we verify that the the panel in question does exist on the desktop version, and if not, we
+  // switch the user to the more relevant panel.
   verifyMenuSettings = () => {
     const {
       menuSection,
@@ -101,32 +108,27 @@ class MapMenu extends PureComponent {
     if (!activeSection) return null;
     if (!isDesktop || !menuSection) return null;
 
-    const clearMenuSettings = () => {
+    const clearMenuSettings = () =>
       setMenuSettings({ menuSection: null, datasetCategory: null });
-    };
 
-    if (['analysis', 'legend'].includes(menuSection)) {
+    if (['analysis', 'legend'].includes(menuSection)) clearMenuSettings();
+    if (menuSection === 'datasets' && !activeSection?.category)
       clearMenuSettings();
-    }
-
-    if (menuSection === 'datasets' && !activeSection?.category) {
-      clearMenuSettings();
-    }
 
     return null;
   };
 
+  // When the user is on mobile, on the legend panel, upon switching to a desktop the "analysis"
+  // one is displayed instead. Here we try to sync the current selection. Note that this is not
+  // possible the other way around; on desktop we display multiple panels.
   syncMapMenuSettings = () => {
     const { menuSection, setMainMapSettings, isDesktop } = this.props;
 
     if (isDesktop) return null;
     if (!['analysis', 'legend'].includes(menuSection)) return null;
 
-    if (menuSection === 'analysis') {
-      setMainMapSettings({ showAnalysis: true });
-    } else {
-      setMainMapSettings({ showAnalysis: false });
-    }
+    const showAnalysis = menuSection === 'analysis';
+    setMainMapSettings({ showAnalysis });
 
     return null;
   };

--- a/components/map-menu/component.jsx
+++ b/components/map-menu/component.jsx
@@ -116,8 +116,24 @@ class MapMenu extends PureComponent {
     return null;
   };
 
+  syncMapMenuSettings = () => {
+    const { menuSection, setMainMapSettings, isDesktop } = this.props;
+
+    if (isDesktop) return null;
+    if (!['analysis', 'legend'].includes(menuSection)) return null;
+
+    if (menuSection === 'analysis') {
+      setMainMapSettings({ showAnalysis: true });
+    } else {
+      setMainMapSettings({ showAnalysis: false });
+    }
+
+    return null;
+  };
+
   render() {
     this.verifyMenuSettings();
+    this.syncMapMenuSettings();
 
     const {
       className,
@@ -227,6 +243,7 @@ MapMenu.propTypes = {
   isDesktop: PropTypes.bool,
   embed: PropTypes.bool,
   recentActive: PropTypes.bool,
+  setMainMapSettings: PropTypes.func,
   setMapPromptsSettings: PropTypes.func,
 };
 

--- a/components/map-menu/component.jsx
+++ b/components/map-menu/component.jsx
@@ -90,7 +90,35 @@ class MapMenu extends PureComponent {
     }
   };
 
+  verifyMenuSettings = () => {
+    const {
+      menuSection,
+      activeSection,
+      isDesktop,
+      setMenuSettings,
+    } = this.props;
+
+    if (!activeSection) return null;
+    if (!isDesktop || !menuSection) return null;
+
+    const clearMenuSettings = () => {
+      setMenuSettings({ menuSection: null, datasetCategory: null });
+    };
+
+    if (['analysis', 'legend'].includes(menuSection)) {
+      clearMenuSettings();
+    }
+
+    if (menuSection === 'datasets' && !activeSection?.category) {
+      clearMenuSettings();
+    }
+
+    return null;
+  };
+
   render() {
+    this.verifyMenuSettings();
+
     const {
       className,
       datasetSections,
@@ -109,6 +137,7 @@ class MapMenu extends PureComponent {
     const {
       Component,
       label,
+      slug,
       category,
       large,
       icon,

--- a/components/map-menu/index.js
+++ b/components/map-menu/index.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import reducerRegistry from 'redux/registry';
 
 import { setMapSettings } from 'components/map/actions';
+import { setMainMapSettings } from 'layouts/map/actions';
 import { setMapPromptsSettings } from 'components/prompts/map-prompts/actions';
 
 import * as actions from './actions';
@@ -18,5 +19,6 @@ reducerRegistry.registerModule('mapMenu', {
 export default connect(getMenuProps, {
   ...actions,
   setMapSettings,
+  setMainMapSettings,
   setMapPromptsSettings,
 })(MenuComponent);


### PR DESCRIPTION
## Overview

When the user is on mobile, and enables the "Analysis" tab, if they switch to the desktop version the charts/widgets are duplicated. If they are on the base layer selection tab, a blank tab will appear on desktop. In addition, if the user is on the "Legend" tab, upon switching to Desktop the "Analysis" one selected by default. This PR aims to fix these issues. 

## Testing

Verify that the issues described above no longer happen. 
