### PR TITLE
Fix primary forest loss widget not appearing on country/region/subregion/custom dashboards

### DIFF
--- a/providers/whitelists-provider/actions.js
+++ b/providers/whitelists-provider/actions.js
@@ -35,23 +35,12 @@ export const getWhitelist = createThunkAction(
     ])
       .then(
         spread((annualResponse, gladResponse, viirsResponse, modisResponse) => {
-          const annual =
-            annualResponse &&
-            annualResponse.data &&
-            annualResponse.data.data[0];
-          const glad =
-            gladResponse && gladResponse.data && gladResponse.data.data[0];
-          const viirs =
-            viirsResponse && viirsResponse.data && viirsResponse.data.data[0];
-          const modis =
-            modisResponse && modisResponse.data && modisResponse.data.data[0];
-
           dispatch(
             setWhitelist({
-              annual: parseWhitelist(annual),
-              glad: parseWhitelist(glad),
-              viirs: parseWhitelist(viirs),
-              modis: parseWhitelist(modis),
+              annual: parseWhitelist(annualResponse?.data?.[0]),
+              glad: parseWhitelist(gladResponse?.data?.[0]),
+              viirs: parseWhitelist(viirsResponse.data?.[0]),
+              modis: parseWhitelist(modisResponse?.data?.[0]),
             })
           );
         })


### PR DESCRIPTION
## Overview

Fix primary forest loss widget not appearing on country/region/subregion/custom dashboards

## Notes

I was not able to place exactly _where_ this bug has been introduced, but it seems to be have introduced about a month ago. The issue described isn't specific to this widget; it turned out any widgets with custom whitelists (in this case, for primary forest type) could potentially be failing. 

The problem was that when fetching the whitelists, the frontend wasn't parsing them correctly and would fail silently

## Testing

1. Open the Dashboard  
2. Select a country (eg: _Brazil_)  
3. Visit the _"Forest change"_ section  

- Verify that the `treeLossTsc` widget appears (titled: _PRIMARY FOREST LOSS IN BRAZIL_)  
- Verify that the widget appears for country, region, subregion, custom dashboards

## Tracking  

[FLAG-683](https://gfw.atlassian.net/browse/FLAG-683)

