### PR TITLE
Fix typo in error message that occurs when a widget cannot load

### DIFF
--- a/components/ui/refresh-button/component.jsx
+++ b/components/ui/refresh-button/component.jsx
@@ -8,7 +8,10 @@ import './styles.scss';
 
 const RefreshButton = ({ refetchFn }) => (
   <NoContent className="c-refresh-button">
-    <span>An error occured while fetching data. You can try again, or save the shape and check back tomorrow.</span>
+    <span>
+      An error occurred while fetching data. You can try again, or save the
+      shape and check back tomorrow.
+    </span>
     <Button
       className="refresh-btn"
       onClick={refetchFn}
@@ -20,11 +23,11 @@ const RefreshButton = ({ refetchFn }) => (
 );
 
 RefreshButton.propTypes = {
-  refetchFn: PropTypes.func
+  refetchFn: PropTypes.func,
 };
 
 RefreshButton.defaultProps = {
-  refetchFn: () => {}
+  refetchFn: () => {},
 };
 
 export default RefreshButton;


### PR DESCRIPTION
## Overview

Fix a typo (`occured` > `occured`) in error messages that _occur_ when a widget fails to fetch data. 

## Tracking

[FLAG-603](https://gfw.atlassian.net/browse/FLAG-603)

