### PR TITLE
Fix incorrect units in the Forestry employment donut chart

### DIFF
--- a/components/widgets/land-use/forestry-employment/index.js
+++ b/components/widgets/land-use/forestry-employment/index.js
@@ -12,28 +12,29 @@ export default {
     {
       key: 'year',
       label: 'year',
-      options: [1990, 2000, 2005, 2010].map(y => ({ label: y, value: y })),
-      type: 'select'
-    }
+      options: [1990, 2000, 2005, 2010].map((y) => ({ label: y, value: y })),
+      type: 'select',
+    },
   ],
   chartType: 'pieChart',
   dataType: 'fao',
   metaKey: 'widget_forestry_employment',
   sortOrder: {
-    landUse: 3
+    landUse: 3,
   },
   settings: {
-    year: 2010
+    year: 2010,
+    unit: 'countsK',
   },
   colors: 'employment',
   sentences: {
     initial:
       'According to the FAO there were {value} people employed in {location} Forestry sector in {year}.',
     withFemales:
-      'According to the FAO there were {value} people employed in {location} Forestry sector in {year}, of which {percent} were female.'
+      'According to the FAO there were {value} people employed in {location} Forestry sector in {year}, of which {percent} were female.',
   },
-  getData: params =>
-    getFAOEcoLive(params.token).then(response => response.data.rows),
+  getData: (params) =>
+    getFAOEcoLive(params.token).then((response) => response.data.rows),
   getDataURL: () => [getFAOEcoLive({ download: true })],
-  getWidgetProps
+  getWidgetProps,
 };

--- a/utils/format.js
+++ b/utils/format.js
@@ -24,7 +24,8 @@ export const formatNumber = ({ num, unit, precision, returnUnit = true }) => {
   } else if (num > 0 && num < 0.01 && unit !== '%') {
     formattedNum = '<0.01';
   }
+
   return `${formattedNum}${
-    returnUnit && unit && unit !== 'counts' ? unit : ''
+    returnUnit && unit && unit !== 'counts' && unit !== 'countsK' ? unit : ''
   }`;
 };


### PR DESCRIPTION
## Overview

This PR fixes the incorrect units in the Forestry employment donut chart. 
The number of people employed should was in `kha` when it should be in `k`. 

## Testing

TODO

## Tracking

[FLAG-534](https://gfw.atlassian.net/browse/FLAG-534)
