### PR TITLE
Updated tropical tree cover layer | Toggle switch implementation

### DIFF
--- a/components/map/components/legend/component.jsx
+++ b/components/map/components/legend/component.jsx
@@ -228,7 +228,6 @@ const MapLegend = ({
                       layerGroup={lg}
                       name={name}
                       multi={isMultiSelectorLayer}
-                      toggle={isToggleLayer}
                       onChange={onChangeLayer}
                       {...selectorLayerConfig}
                     />

--- a/components/map/components/legend/component.jsx
+++ b/components/map/components/legend/component.jsx
@@ -168,6 +168,18 @@ const MapLegend = ({
                   />
                 )}
 
+                {isToggleLayer && selectorLayerConfig && (
+                  <LayerSelectorMenu
+                    className="layer-selector"
+                    layerGroup={lg}
+                    name={name}
+                    multi={isMultiSelectorLayer}
+                    toggle={isToggleLayer}
+                    onChange={onChangeLayer}
+                    {...selectorLayerConfig}
+                  />
+                )}
+
                 {activeLayer &&
                   paramsSelectorConfig &&
                   params &&
@@ -209,6 +221,7 @@ const MapLegend = ({
                     ) : null
                   )}
                 {(isSelectorLayer || isMultiSelectorLayer) &&
+                  !isToggleLayer &&
                   selectorLayerConfig && (
                     <LayerSelectorMenu
                       className="layer-selector"

--- a/components/map/components/legend/component.jsx
+++ b/components/map/components/legend/component.jsx
@@ -65,6 +65,7 @@ const MapLegend = ({
               isSelectorLayer,
               isMultiLayer,
               isMultiSelectorLayer,
+              isToggleLayer,
               selectorLayerConfig,
               color,
               metadata,
@@ -212,6 +213,7 @@ const MapLegend = ({
                       layerGroup={lg}
                       name={name}
                       multi={isMultiSelectorLayer}
+                      toggle={isToggleLayer}
                       onChange={onChangeLayer}
                       {...selectorLayerConfig}
                     />

--- a/components/map/components/legend/component.jsx
+++ b/components/map/components/legend/component.jsx
@@ -179,10 +179,11 @@ const MapLegend = ({
                         className="param-selector"
                         {...paramConfig}
                         value={params[paramConfig.key] || paramConfig.default}
-                        onChange={(e) =>
+                        onChange={(e) => {
                           onChangeParam(activeLayer, {
                             [paramConfig.key]: e,
-                          })}
+                          });
+                        }}
                       />
                     ) : null
                   )}
@@ -199,10 +200,11 @@ const MapLegend = ({
                         value={
                           decodeParams[paramConfig.key] || paramConfig.default
                         }
-                        onChange={(e) =>
+                        onChange={(e) => {
                           onChangeDecodeParam(activeLayer, {
                             [paramConfig.key]: parseInt(e, 10),
-                          })}
+                          });
+                        }}
                       />
                     ) : null
                   )}

--- a/components/map/components/legend/component.jsx
+++ b/components/map/components/legend/component.jsx
@@ -71,7 +71,6 @@ const MapLegend = ({
               metadata,
               id,
               layers,
-              statementConfig,
               alerts,
               caution,
               caution_gladL,
@@ -111,6 +110,7 @@ const MapLegend = ({
               decodeParamsSelectorConfig,
               moreInfo,
               timelineParams,
+              statementConfig,
             } = activeLayer || {};
             return (
               <LegendListItem

--- a/components/map/components/legend/components/layer-selector-menu/component.jsx
+++ b/components/map/components/legend/components/layer-selector-menu/component.jsx
@@ -1,12 +1,12 @@
-import React, { PureComponent } from "react";
-import PropTypes from "prop-types";
-import sortBy from "lodash/sortBy";
-import Switch from "components/ui/switch";
-import cx from "classnames";
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import sortBy from 'lodash/sortBy';
+import Switch from 'components/ui/switch';
+import cx from 'classnames';
 
-import SentenceSelector from "components/sentence-selector";
+import SentenceSelector from 'components/sentence-selector';
 
-import "./styles.scss";
+import './styles.scss';
 
 class LayerSelectorMenu extends PureComponent {
   render() {
@@ -29,23 +29,23 @@ class LayerSelectorMenu extends PureComponent {
     const selectorName = selected?.group || name;
     const selectorOptions = isGroupsSelector
       ? groups
-      : sortBy(options, "position");
+      : sortBy(options, 'position');
     const selectorValue = isGroupsSelector
       ? selectedGroup && selectedGroup.value
       : selected;
     const selectorSentence = isGroupsSelector ? groupSentence : sentence;
 
     return (
-      <div className={`c-layer-selector-menu ${className || ""}`}>
+      <div className={`c-layer-selector-menu ${className || ''}`}>
         <div
-          className={cx("menu-wrapper", {
-            "-group": isGroupsSelector,
-            "-toggle": isToggleSelector,
+          className={cx('menu-wrapper', {
+            '-group': isGroupsSelector,
+            '-toggle': isToggleSelector,
           })}
         >
           {isToggleSelector ? (
             <Switch
-              theme="theme-switch-light"
+              theme="theme-switch-light-alternate"
               value={selected?.value}
               options={options}
               name={selectorName}

--- a/components/map/components/legend/components/layer-selector-menu/component.jsx
+++ b/components/map/components/legend/components/layer-selector-menu/component.jsx
@@ -1,11 +1,12 @@
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import sortBy from 'lodash/sortBy';
-import Switch from 'components/ui/switch';
+import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
+import sortBy from "lodash/sortBy";
+import Switch from "components/ui/switch";
+import cx from "classnames";
 
-import SentenceSelector from 'components/sentence-selector';
+import SentenceSelector from "components/sentence-selector";
 
-import './styles.scss';
+import "./styles.scss";
 
 class LayerSelectorMenu extends PureComponent {
   render() {
@@ -22,47 +23,44 @@ class LayerSelectorMenu extends PureComponent {
       groupSentence,
       toggle,
     } = this.props;
-    const optionName = selected?.group || name;
+    const isToggleSelector = !!toggle;
+    const isGroupsSelector = groups && !!groups.length;
+
+    const selectorName = selected?.group || name;
+    const selectorOptions = isGroupsSelector
+      ? groups
+      : sortBy(options, "position");
+    const selectorValue = isGroupsSelector
+      ? selectedGroup && selectedGroup.value
+      : selected;
+    const selectorSentence = isGroupsSelector ? groupSentence : sentence;
 
     return (
-      <div className={`c-layer-selector-menu ${className || ''}`}>
-        {!toggle && (
-          <>
-            {groups && !!groups.length && (
-              <div className="menu-wrapper -group">
-                <SentenceSelector
-                  options={groups}
-                  value={selectedGroup && selectedGroup.value}
-                  onChange={(e) => onChange(layerGroup, e)}
-                  name={optionName}
-                  sentence={groupSentence}
-                />
-              </div>
-            )}
-            {options && !!options.length && (
-              <div className="menu-wrapper">
-                <SentenceSelector
-                  options={sortBy(options, 'position')}
-                  value={selected}
-                  onChange={(e) => onChange(layerGroup, e)}
-                  name={optionName}
-                  sentence={sentence}
-                />
-              </div>
-            )}
-          </>
-        )}
-        {toggle && (
-          <div className="menu-wrapper - switch">
+      <div className={`c-layer-selector-menu ${className || ""}`}>
+        <div
+          className={cx("menu-wrapper", {
+            "-group": isGroupsSelector,
+            "-toggle": isToggleSelector,
+          })}
+        >
+          {isToggleSelector ? (
             <Switch
-              className="widget-settings-selector"
               theme="theme-switch-light"
               value={selected?.value}
               options={options}
+              name={selectorName}
               onChange={(e) => onChange(layerGroup, e)}
             />
-          </div>
-        )}
+          ) : (
+            <SentenceSelector
+              options={selectorOptions}
+              value={selectorValue}
+              name={selectorName}
+              sentence={selectorSentence}
+              onChange={(e) => onChange(layerGroup, e)}
+            />
+          )}
+        </div>
       </div>
     );
   }

--- a/components/map/components/legend/components/layer-selector-menu/component.jsx
+++ b/components/map/components/legend/components/layer-selector-menu/component.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import sortBy from 'lodash/sortBy';
+import Switch from 'components/ui/switch';
 
 import SentenceSelector from 'components/sentence-selector';
 
@@ -25,25 +26,40 @@ class LayerSelectorMenu extends PureComponent {
 
     return (
       <div className={`c-layer-selector-menu ${className || ''}`}>
-        {groups && !!groups.length && (
-          <div className="menu-wrapper -group">
-            <SentenceSelector
-              options={groups}
-              value={selectedGroup && selectedGroup.value}
-              onChange={(e) => onChange(layerGroup, e)}
-              name={optionName}
-              sentence={groupSentence}
-            />
-          </div>
+        {!toggle && (
+          <>
+            {groups && !!groups.length && (
+              <div className="menu-wrapper -group">
+                <SentenceSelector
+                  options={groups}
+                  value={selectedGroup && selectedGroup.value}
+                  onChange={(e) => onChange(layerGroup, e)}
+                  name={optionName}
+                  sentence={groupSentence}
+                />
+              </div>
+            )}
+            {options && !!options.length && (
+              <div className="menu-wrapper">
+                <SentenceSelector
+                  options={sortBy(options, 'position')}
+                  value={selected}
+                  onChange={(e) => onChange(layerGroup, e)}
+                  name={optionName}
+                  sentence={sentence}
+                />
+              </div>
+            )}
+          </>
         )}
-        {options && !!options.length && (
-          <div className="menu-wrapper">
-            <SentenceSelector
-              options={sortBy(options, 'position')}
-              value={selected}
+        {toggle && (
+          <div className="menu-wrapper - switch">
+            <Switch
+              className="widget-settings-selector"
+              theme="theme-switch-light"
+              value={selected?.value}
+              options={options}
               onChange={(e) => onChange(layerGroup, e)}
-              name={optionName}
-              sentence={sentence}
             />
           </div>
         )}

--- a/components/map/components/legend/components/layer-selector-menu/component.jsx
+++ b/components/map/components/legend/components/layer-selector-menu/component.jsx
@@ -19,6 +19,7 @@ class LayerSelectorMenu extends PureComponent {
       className,
       sentence,
       groupSentence,
+      toggle,
     } = this.props;
     const optionName = selected?.group || name;
 
@@ -62,6 +63,7 @@ LayerSelectorMenu.propTypes = {
   sentence: PropTypes.string,
   groupSentence: PropTypes.string,
   selectedGroup: PropTypes.object,
+  toggle: PropTypes.bool,
 };
 
 export default LayerSelectorMenu;

--- a/components/map/components/legend/components/layer-selector-menu/component.jsx
+++ b/components/map/components/legend/components/layer-selector-menu/component.jsx
@@ -45,7 +45,7 @@ class LayerSelectorMenu extends PureComponent {
         >
           {isToggleSelector ? (
             <Switch
-              theme="theme-switch-light-alternate"
+              theme="theme-switch-light-alternate theme-switch-small"
               value={selected?.value}
               options={options}
               name={selectorName}

--- a/components/map/components/legend/components/layer-selector-menu/component.jsx
+++ b/components/map/components/legend/components/layer-selector-menu/component.jsx
@@ -47,7 +47,7 @@ class LayerSelectorMenu extends PureComponent {
             <Switch
               theme="theme-switch-light-alternate theme-switch-small"
               value={selected?.value}
-              options={options}
+              options={selectorOptions}
               name={selectorName}
               onChange={(e) => onChange(layerGroup, e)}
             />

--- a/components/map/components/legend/components/layer-selector-menu/styles.scss
+++ b/components/map/components/legend/components/layer-selector-menu/styles.scss
@@ -9,5 +9,9 @@
     &.-group {
       margin-bottom: rem(10px);
     }
+
+    &.-toggle {
+      max-width: rem(180px);
+    }
   }
 }

--- a/components/map/components/legend/components/layer-statement/component.jsx
+++ b/components/map/components/legend/components/layer-statement/component.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { Tooltip } from 'react-tippy';
 import Tip from 'components/ui/tip';
 
+import cx from 'classnames';
+
 import './styles.scss';
 
 class LayerStatement extends PureComponent {
@@ -25,13 +27,13 @@ class LayerStatement extends PureComponent {
         followCursor
         animateFill={false}
       >
-        <div className={`c-layer-statement ${className || ''}`}>
+        <div className={cx('c-layer-statement', className)}>
           {statementPlain}
           <span>{statementHighlight}</span>
         </div>
       </Tooltip>
     ) : (
-      <div>{statementPlain}</div>
+      <div className={cx('c-layer-statement', className)}>{statementPlain}</div>
     );
   }
 }

--- a/components/map/components/legend/components/layer-statement/styles.scss
+++ b/components/map/components/legend/components/layer-statement/styles.scss
@@ -2,7 +2,7 @@
 
 .c-layer-statement {
   cursor: help;
-  padding-top: rem(5px);
+  margin-top: rem(5px);
 
   span {
     border-bottom: dashed 1px $hot-grey;

--- a/components/map/components/legend/index.js
+++ b/components/map/components/legend/index.js
@@ -90,13 +90,10 @@ class Legend extends PureComponent {
   onChangeLayer = (layerGroup, newLayerKey) => {
     const { setMapSettings, activeDatasets } = this.props;
     setMapSettings({
-      datasets: activeDatasets.map((l) => {
-        const dataset = l;
-        if (l.dataset === layerGroup.dataset) {
-          dataset.layers = [newLayerKey];
-        }
-        return dataset;
-      }),
+      datasets: activeDatasets.map((l) => ({
+        ...l,
+        layers: l.dataset === layerGroup.dataset ? [newLayerKey] : l.layers,
+      })),
     });
     trackEvent({
       category: 'Map data',

--- a/components/ui/switch/component.jsx
+++ b/components/ui/switch/component.jsx
@@ -5,6 +5,7 @@ import Toggle from 'react-toggle';
 import './react-toggle.scss';
 import './styles.scss';
 import './themes/switch-light.scss';
+import './themes/switch-light-alternate.scss';
 
 class Switch extends PureComponent {
   render() {
@@ -16,10 +17,10 @@ class Switch extends PureComponent {
         <Toggle
           icons={{
             checked: options[0].label,
-            unchecked: options[1].label
+            unchecked: options[1].label,
           }}
           defaultChecked={options[1].value === value}
-          onChange={e => {
+          onChange={(e) => {
             const result = e.target.checked
               ? options[1].value
               : options[0].value;
@@ -37,7 +38,7 @@ Switch.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   options: PropTypes.array,
   onChange: PropTypes.func,
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default Switch;

--- a/components/ui/switch/component.jsx
+++ b/components/ui/switch/component.jsx
@@ -4,6 +4,7 @@ import Toggle from 'react-toggle';
 
 import './react-toggle.scss';
 import './styles.scss';
+import './themes/switch-small.scss';
 import './themes/switch-light.scss';
 import './themes/switch-light-alternate.scss';
 

--- a/components/ui/switch/styles.scss
+++ b/components/ui/switch/styles.scss
@@ -9,4 +9,8 @@
     font-weight: 400;
     font-size: 13px;
   }
+
+  .react-toggle-track {
+    height: rem(34px);
+  }
 }

--- a/components/ui/switch/themes/switch-light-alternate.scss
+++ b/components/ui/switch/themes/switch-light-alternate.scss
@@ -16,13 +16,11 @@
     }
 
     .react-toggle-track-check {
-      transition: color 1s ease-out;
       color: $white;
       z-index: 10;
     }
 
     .react-toggle-track-x {
-      transition: color 1s ease-out;
       color: $slate;
     }
 

--- a/components/ui/switch/themes/switch-light-alternate.scss
+++ b/components/ui/switch/themes/switch-light-alternate.scss
@@ -42,7 +42,6 @@
 
   .react-toggle-track {
     width: 100%;
-    height: rem(34px);
     background-color: transparent !important;
     border: solid 1px $green-gfw;
 

--- a/components/ui/switch/themes/switch-light-alternate.scss
+++ b/components/ui/switch/themes/switch-light-alternate.scss
@@ -16,11 +16,13 @@
     }
 
     .react-toggle-track-check {
+      transition: color 1s ease-out;
       color: $white;
       z-index: 10;
     }
 
     .react-toggle-track-x {
+      transition: color 1s ease-out;
       color: $slate;
     }
 

--- a/components/ui/switch/themes/switch-light-alternate.scss
+++ b/components/ui/switch/themes/switch-light-alternate.scss
@@ -1,0 +1,68 @@
+@import '~styles/settings.scss';
+
+.theme-switch-light-alternate {
+  .react-toggle {
+    width: 100%;
+
+    .react-toggle-thumb {
+      top: 0;
+      left: 0;
+      width: 50%;
+      height: 100%;
+      background-color: $green-gfw;
+      border-radius: 30px;
+      border: solid 1px $green-gfw;
+      box-shadow: none !important;
+    }
+
+    .react-toggle-track-check {
+      color: $white;
+      z-index: 10;
+    }
+
+    .react-toggle-track-x {
+      color: $slate;
+    }
+
+    &--checked {
+      .react-toggle-thumb {
+        left: 50%;
+      }
+
+      .react-toggle-track-check {
+        color: $slate;
+      }
+
+      .react-toggle-track-x {
+        color: $white;
+        z-index: 10;
+      }
+    }
+  }
+
+  .react-toggle-track {
+    width: 100%;
+    height: rem(34px);
+    background-color: transparent !important;
+    border: solid 1px $green-gfw;
+
+    > div {
+      width: 50%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      opacity: 1;
+      font-size: 13px;
+      color: $green-gfw;
+    }
+
+    .react-toggle-track-check {
+      left: 0;
+      z-index: 10;
+    }
+
+    .react-toggle-track-x {
+      right: 0;
+    }
+  }
+}

--- a/components/ui/switch/themes/switch-small.scss
+++ b/components/ui/switch/themes/switch-small.scss
@@ -1,0 +1,7 @@
+@import '~styles/settings.scss';
+
+.theme-switch-small {
+  .react-toggle-track {
+    height: rem(20px);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "fast-redux": "^0.7.1",
     "file-saver": "^2.0.2",
     "final-form": "^4.18.7",
-    "gfw-components": "1.8.10",
+    "gfw-components": "1.8.11",
     "heroku-ssl-redirect": "^0.1.1",
     "html-react-parser": "^3.0.6",
     "image-trace-loader": "^1.0.2",

--- a/providers/datasets-provider/actions.js
+++ b/providers/datasets-provider/actions.js
@@ -20,7 +20,7 @@ const handleFeatureEnvLock = (env) => {
     return true;
   }
   if (currEnv === 'preproduction') {
-    return ['preproduction', 'production'].includes(env);
+    return ['preproduction', 'production', 'staging'].includes(env);
   }
   return env === currEnv;
 };

--- a/providers/datasets-provider/actions.js
+++ b/providers/datasets-provider/actions.js
@@ -71,34 +71,6 @@ export const fetchDatasets = createThunkAction(
             } = info || {};
             const { iso, applicationConfig } = defaultLayer || {};
             const { global, selectorConfig } = applicationConfig || {};
-
-            // build statement config
-            let statementConfig =
-              defaultLayer.legendConfig && defaultLayer.legendConfig.statement
-                ? { statement: defaultLayer.legendConfig.statement }
-                : null;
-            if (isLossLayer) {
-              statementConfig = {
-                type: 'lossLayer',
-              };
-            } else if (isLossDriverLayer) {
-              statementConfig = {
-                type: 'lossDriverLayer',
-              };
-            } else if (isKbaLayer) {
-              statementConfig = {
-                type: 'kbaLayer',
-              };
-            } else if (isMosaicLandscapes) {
-              statementConfig = {
-                type: 'mosaicLandscapes',
-              };
-            } else if (global && !!iso.length && iso[0]) {
-              statementConfig = {
-                type: 'isoLayer',
-                isos: iso,
-              };
-            }
             return {
               id: applicationConfig?.dataset_slug || applicationConfig.slug,
               dataset:
@@ -120,8 +92,6 @@ export const fetchDatasets = createThunkAction(
                   ...selectorConfig,
                 },
               }),
-              // disclaimer statement config
-              statementConfig,
               // layers config
               layers:
                 layer &&
@@ -178,6 +148,34 @@ export const fetchDatasets = createThunkAction(
                         decode_config && reduceParams(decode_config);
                       const sqlParams =
                         sql_config && reduceSqlParams(sql_config);
+
+                      // build statement config
+                      let statementConfig =
+                        legendConfig && legendConfig.statement
+                          ? { statement: legendConfig.statement }
+                          : null;
+                      if (isLossLayer) {
+                        statementConfig = {
+                          type: 'lossLayer',
+                        };
+                      } else if (isLossDriverLayer) {
+                        statementConfig = {
+                          type: 'lossDriverLayer',
+                        };
+                      } else if (isKbaLayer) {
+                        statementConfig = {
+                          type: 'kbaLayer',
+                        };
+                      } else if (isMosaicLandscapes) {
+                        statementConfig = {
+                          type: 'mosaicLandscapes',
+                        };
+                      } else if (global && !!iso.length && iso[0]) {
+                        statementConfig = {
+                          type: 'isoLayer',
+                          isos: iso,
+                        };
+                      }
 
                       return {
                         ...info,
@@ -280,6 +278,8 @@ export const fetchDatasets = createThunkAction(
                         ...(confirmedOnly && {
                           id: 'confirmedOnly',
                         }),
+                        // disclaimer statement config
+                        statementConfig,
                       };
                     }),
                   'position'

--- a/providers/datasets-provider/actions.js
+++ b/providers/datasets-provider/actions.js
@@ -20,7 +20,7 @@ const handleFeatureEnvLock = (env) => {
     return true;
   }
   if (currEnv === 'preproduction') {
-    return ['preproduction', 'production', 'staging'].includes(env);
+    return ['preproduction', 'production'].includes(env);
   }
   return env === currEnv;
 };

--- a/services/datasets.js
+++ b/services/datasets.js
@@ -15,7 +15,7 @@ const environmentString = () => {
 export const getDatasets = () =>
   rwRequest
     .get(
-      `/dataset?application=gfw&includes=metadata,vocabulary,layer&published=true&page[size]=9999&env=${environmentString()}${
+      `/dataset?application=gfw&includes=metadata,vocabulary,layer&published=true&page[size]=9999&env=production,preproduction,staging${
         environmentString() === 'staging'
           ? `&filterIncludesByEnv=true&refresh=${new Date()}`
           : ''

--- a/services/datasets.js
+++ b/services/datasets.js
@@ -15,7 +15,7 @@ const environmentString = () => {
 export const getDatasets = () =>
   rwRequest
     .get(
-      `/dataset?application=gfw&includes=metadata,vocabulary,layer&published=true&page[size]=9999&env=production,preproduction,staging${
+      `/dataset?application=gfw&includes=metadata,vocabulary,layer&published=true&page[size]=9999&env=${environmentString()}${
         environmentString() === 'staging'
           ? `&filterIncludesByEnv=true&refresh=${new Date()}`
           : ''

--- a/yarn.lock
+++ b/yarn.lock
@@ -8273,10 +8273,10 @@ gettext-parser@^1.3.1:
     encoding "^0.1.12"
     safe-buffer "^5.1.1"
 
-gfw-components@1.8.10:
-  version "1.8.10"
-  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.10.tgz#1c7fd9033557d8b47dd5eeaa075bcb0e37590f67"
-  integrity sha512-5+mPaqI3gJZN5899YyZZWGUP3noaSEwC7zrl6zd2nbP11pS5a+PVHECQ3haUf6F9hG74EoZ/pD7D4A52gxjWqg==
+gfw-components@1.8.11:
+  version "1.8.11"
+  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.11.tgz#db5b3882bb286b62f12df0e19d1ffc1e9e086625"
+  integrity sha512-OU+o5wpBUTg0pKE2N4aghNOIUDXYz4umQ8R5m1XRRwa/KG3dOg5nvUS+mDql8nSHCoxXLzpFuy6L2Z1YnihhLw==
   dependencies:
     "@artsy/fresnel" "^1.1.0"
     "@tippyjs/react" "^4.0.2"


### PR DESCRIPTION
## IMPORTANT

https://github.com/Vizzuality/gfw/pull/4517/commits/bf4bfb1139d777b4da34c2cf8aa4e7a627a4cf0a needs to be removed before this PR is merged. It is only included at the moment to facilitate testing for both FE and Science. 

## Overview

This PR adds the possibility of using a toggle/switch in the map legend, in order to switch dataset layers. 

**In this PR:**
- Added the possibility to use a toggle switch to switch between a dataset's layers
  - It is enabled when the `isToggleLayer` property is set on a dataset  
  - Added a new `light-alternate` theme to the existing `<Switch />` component  
  - The `<Switch />` component can now also be displayed in a smaller size  
- Updated `gfw-components` to the latest version  
- Fixed an error _"state mutation detected between dispatches' error when switching layers"_
  _only is shown in development, made it impossible to switch layers_  
- Fixed an issue with `statementConfig` (layer statement) where the statement was built based on a dataset's default layer  
  _the correct configuration is to show the statement on a per layer basis_  
- Fixed an issue with the `<LayerStatement />` component, in which the `className` was not being applied for simple statements  
- Minor auto-linting fixes

## Screenshot

<img width="302" alt="Screenshot 2023-03-03 at 15 28 13" src="https://user-images.githubusercontent.com/6273795/222760030-8684fd04-b776-48b8-b736-8c8c7bb01464.png">

## Test Environment

https://gfw-staging-pr-4517.herokuapp.com/

## Tracking

[FLAG-698](https://gfw.atlassian.net/browse/FLAG-698)

