### PR TITLE
Add the missing map attributions to the map (+ styling)

### DIFF
--- a/components/map/component.jsx
+++ b/components/map/component.jsx
@@ -426,11 +426,7 @@ class MapComponent extends Component {
                 {/* SCALE */}
                 <Scale className="map-scale" map={map} viewport={viewport} />
                 {/* ATTRIBUTIONS */}
-                <Attributions
-                  className="map-attributions"
-                  map={map}
-                  viewport={viewport}
-                />
+                <Attributions className="map-attributions" />
               </Fragment>
             )}
           </Map>

--- a/components/map/components/attributions/attributions-content/component.jsx
+++ b/components/map/components/attributions/attributions-content/component.jsx
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import { PropTypes } from 'prop-types';
 import { useMemo } from 'react';
 
 import Icon from 'components/ui/icon';
@@ -8,7 +8,7 @@ import geeLogo from 'assets/logos/gee.png';
 import cartoLogo from 'assets/logos/carto.png';
 import planetLogo from 'assets/logos/planet.png';
 
-const AttributionsContent = ({ narrow = false, isModal = false }) => {
+const AttributionsContent = ({ isDesktop = false, isModal = false }) => {
   const currentYear = useMemo(() => new Date().getFullYear());
 
   return (
@@ -49,46 +49,51 @@ const AttributionsContent = ({ narrow = false, isModal = false }) => {
           />
         </a>
       </div>
-      {!narrow && (
-        <div className="links">
-          <span>
-            Map data ©
-            {currentYear}
-            {' '}
-            Google
-          </span>
-          {isModal && (
-            <>
-              <a
-                href="http://www.openstreetmap.org/copyright"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                © OpenStreetMap
-              </a>
-              <a
-                href="https://www.mapbox.com/map-feedback/"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Improve this map
-              </a>
-            </>
-          )}
-          <a href="/terms" rel="noopener noreferrer" target="_blank">
-            Terms of use
-          </a>
-          <a href="/privacy-policy" rel="noopener noreferrer" target="_blank">
-            Privacy policy
-          </a>
-        </div>
-      )}
+      <div className="links">
+        <span>
+          Map data ©
+          {currentYear}
+          {' '}
+          Google
+        </span>
+        <a
+          href="https://www.mapbox.com/about/maps/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          © Mapbox
+        </a>
+        <a
+          href="http://www.openstreetmap.org/copyright"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          © OpenStreetMap
+        </a>
+        <a
+          href="https://www.mapbox.com/map-feedback/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Improve this map
+        </a>
+        {(isDesktop || isModal) && (
+          <>
+            <a href="/terms" rel="noopener noreferrer" target="_blank">
+              Terms of use
+            </a>
+            <a href="/privacy-policy" rel="noopener noreferrer" target="_blank">
+              Privacy policy
+            </a>
+          </>
+        )}
+      </div>
     </>
   );
 };
 
 AttributionsContent.propTypes = {
-  narrow: PropTypes.bool,
+  isDesktop: PropTypes.bool,
   isModal: PropTypes.bool,
 };
 

--- a/components/map/components/attributions/component.jsx
+++ b/components/map/components/attributions/component.jsx
@@ -1,8 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-import { Button } from 'gfw-components';
+import { Button, Mobile, Desktop } from 'gfw-components';
 
 import Icon from 'components/ui/icon';
 
@@ -12,33 +12,31 @@ import AttributionsModal from './attributions-modal';
 
 import './styles.scss';
 
-const MapAttributions = ({ className, viewport, map }) => {
-  const width = map._container.clientWidth;
+const MapAttributions = ({ className }) => {
   const [attributionsModalOpen, setAttributionsModalOpen] = useState(false);
-  const [narrowView, setNarrowView] = useState(width < 900);
-
-  useEffect(() => {
-    setNarrowView(width < 900);
-  }, [viewport]);
 
   return (
     <>
-      <div className={cx('c-map-attributions', className)}>
-        <AttributionsContent narrow={narrowView} />
-        {narrowView && (
-          <>
-            <Button
-              className="attribution-btn"
-              size="small"
-              round
-              dark
-              onClick={() => setAttributionsModalOpen(true)}
-            >
-              <Icon icon={infoIcon} />
-            </Button>
-          </>
-        )}
-      </div>
+      <Desktop>
+        <div className={cx('c-map-attributions', className)}>
+          <AttributionsContent isDesktop />
+        </div>
+      </Desktop>
+      <Mobile>
+        <div className={cx('c-map-attributions', className, '-mobile')}>
+          <AttributionsContent />
+          <Button
+            className="attribution-btn"
+            size="small"
+            round
+            dark
+            onClick={() => setAttributionsModalOpen(true)}
+          >
+            <Icon icon={infoIcon} />
+          </Button>
+        </div>
+      </Mobile>
+
       <AttributionsModal
         open={attributionsModalOpen}
         onRequestClose={() => setAttributionsModalOpen(false)}
@@ -49,8 +47,6 @@ const MapAttributions = ({ className, viewport, map }) => {
 
 MapAttributions.propTypes = {
   className: PropTypes.string,
-  map: PropTypes.object,
-  viewport: PropTypes.object,
 };
 
 export default MapAttributions;

--- a/components/map/components/attributions/styles.scss
+++ b/components/map/components/attributions/styles.scss
@@ -1,9 +1,25 @@
 @import '~styles/settings.scss';
 
 .c-map-attributions {
+  width: 100%;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: end;
+  flex-wrap: wrap;
+  gap: 12px;
+
+  &.-mobile {
+    gap: 8px;
+    padding-right: 24px;
+  }
+
+  .logos,
+  .links {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    height: 28px;
+  }
 
   a,
   span {
@@ -39,10 +55,10 @@
   }
 
   .attribution-btn {
+    position: absolute;
+    right: 24px;
+    bottom: 78px;
     opacity: 0.8;
-    margin-left: rem(10px);
-    width: 14px;
-    height: 14px;
     min-width: 14px;
     min-height: 14px;
 


### PR DESCRIPTION
## Overview

This PR adds the missing map attributions to the map. 

## Demo

<img width="1680" alt="Screenshot 2023-03-03 at 17 20 47" src="https://user-images.githubusercontent.com/6273795/222786143-854d86cd-6562-44e9-a949-0405fc0de2c0.png">
<img width="852" alt="Screenshot 2023-03-03 at 17 21 11" src="https://user-images.githubusercontent.com/6273795/222786173-19193cde-1d6d-4a40-a393-71648f871471.png">

## Tracking  

[FLAG-598](https://gfw.atlassian.net/browse/FLAG-598)

