### PR TITLE
Fix primaryForest widget not showing in saved AOI/Dashboards

### DIFF
--- a/components/widgets/land-cover/primary-forest/index.js
+++ b/components/widgets/land-cover/primary-forest/index.js
@@ -18,7 +18,7 @@ export default {
   widget: 'primaryForest',
   title: 'Primary forest in {location}',
   categories: ['land-cover'],
-  types: ['country', 'geostore'],
+  types: ['country', 'aoi'],
   admins: ['adm0', 'adm1', 'adm2'],
   settingsConfig: [
     {


### PR DESCRIPTION
## Overview

This PR fixes the `primaryForest` widget not showing in dashboards for saved AOI. 
It also adds the correct layer to the widget, so that it is shown in analysis when the "Primary Forests" layer is selected. 

## Tracking  

[FLAG-278](https://gfw.atlassian.net/browse/FLAG-278)

