### PR TITLE
Remove "netChange" widget from custom AOIs and WDPAs

### DIFF
--- a/components/widgets/forest-change/net-change/index.js
+++ b/components/widgets/forest-change/net-change/index.js
@@ -28,7 +28,7 @@ export default {
   },
   categories: ['summary', 'forest-change'],
   subcategories: ['net-change'],
-  types: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
+  types: ['global', 'country', 'geostore', 'use'],
   admins: ['global', 'adm0', 'adm1', 'adm2'],
   caution: {
     text:


### PR DESCRIPTION
## Overview

This PR makes it so that the `netChange` widget no longer appears for custom AOIs or WDPAs

## Tracking 

[FLAG-605](https://gfw.atlassian.net/browse/FLAG-605)

