### PR TITLE
[FLAG-713] Fix SatteliteBasemap settings info button not working + crashes

### DIFF
--- a/components/satellite-basemaps/component.jsx
+++ b/components/satellite-basemaps/component.jsx
@@ -168,20 +168,24 @@ const SatelliteBasemaps = ({
                       className="satellite-basemap--thumbnail"
                     />
                     <div className="satellite-basemap--content">
-                      <span className="satellite-basemap--title">
-                        {basemap.label}
-                        {basemap.infoModal && (
-                          <Button
-                            className="info-btn"
-                            theme="theme-button-tiny theme-button-grey-filled square"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setModalMetaSettings(basemap.infoModal);
-                            }}
-                          >
-                            <Icon icon={infoIcon} />
-                          </Button>
-                        )}
+                      <span className="satellite-basemap--title-info">
+                        <span className="satellite-basemap--title">
+                          {basemap.label}
+                        </span>
+                        <span className="satellite-basemap--info">
+                          {basemap.infoModal && (
+                            <Button
+                              className="info-btn"
+                              theme="theme-button-tiny theme-button-grey-filled square"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setModalMetaSettings(basemap.infoModal);
+                              }}
+                            >
+                              <Icon icon={infoIcon} />
+                            </Button>
+                          )}
+                        </span>
                       </span>
                       {basemap.description && (
                         <p className="satellite-basemap--description">

--- a/components/satellite-basemaps/component.jsx
+++ b/components/satellite-basemaps/component.jsx
@@ -20,9 +20,8 @@ import './styles.scss';
 function handleTitle(basemap) {
   return (
     <>
-      <span>
-        {basemap.label}
-        {' '}
+      <span className="label-caveat">
+        <span className="label">{basemap.label}</span>
         {basemap?.caveat && <span className="caveat">{basemap.caveat}</span>}
       </span>
       {basemap.value === 'planet' &&

--- a/components/satellite-basemaps/styles.scss
+++ b/components/satellite-basemaps/styles.scss
@@ -17,6 +17,11 @@
     height: 41px;
     background: $slate-dark;
 
+    .label-caveat {
+      display: flex;
+      gap: 3px;
+    }
+
     .active-basemap-title {
       display: flex;
       flex-flow: column;

--- a/components/satellite-basemaps/styles.scss
+++ b/components/satellite-basemaps/styles.scss
@@ -91,6 +91,12 @@
       margin: 0 10px 0 0;
     }
 
+    &--title-info {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
     &--title {
       display: flex;
       align-items: center;


### PR DESCRIPTION
## Overview

**In this PR:** 

- Fix the SatteliteBasemap settings info button not working after a user changes the language  
  _was triggering a change in the basemap instead_  
- Fix application error when switching between basemaps after the user changes the language

**Note:** 

More technical explanation in the corresponding JIRA task. 

## Tracking

[FLAG-713](https://gfw.atlassian.net/browse/FLAG-713)

## Test Environment  

https://gfw-staging-pr-4527.herokuapp.com/map/

## Testing

1. Visit the /map page
2. In the map legend, expand the basemap settings  
3. Verify that the info buttons work correctly and so does switching the basemaps  
4. Change the language of the page to a different one  
5. Verify that the info buttons work correctly and so does switching the basemaps  

## Demo

https://user-images.githubusercontent.com/6273795/227187035-5c45004b-f59d-4da0-bc0d-4dfdd012cf52.mp4


