### PR TITLE
[FLAG-687] Fix intermittent dashboard crash when switching admin areas

### DIFF
--- a/components/widgets/fires/fire-alerts-simple/index.js
+++ b/components/widgets/fires/fire-alerts-simple/index.js
@@ -1,5 +1,7 @@
 import tropicalIsos from 'data/tropical-isos.json';
 
+import { handleViirsMeta } from 'utils/gfw-meta';
+
 import {
   POLITICAL_BOUNDARIES_DATASET,
   FIRES_VIIRS_DATASET,
@@ -315,8 +317,8 @@ export default {
   settings: {
     dataset: 'viirs',
   },
-  getData: (params) => {
-    const { VIIRS } = params.GFW_META.datasets;
+  getData: async (params) => {
+    const VIIRS = await handleViirsMeta(params);
     const defaultStartDate = VIIRS?.defaultStartDate;
     const defaultEndDate = VIIRS?.defaultEndDate;
     const startDate = params?.startDate || defaultStartDate;

--- a/components/widgets/forest-change/integrated-deforestation-alerts/index.js
+++ b/components/widgets/forest-change/integrated-deforestation-alerts/index.js
@@ -13,7 +13,7 @@ import {
   INTEGRATED_ALERTS_GLAD,
 } from 'data/layers';
 
-import { handleIntegratedMeta } from 'utils/gfw-meta';
+import { handleIntegratedMeta, handleGladMeta } from 'utils/gfw-meta';
 
 import find from 'lodash/find';
 import sumBy from 'lodash/sumBy';
@@ -458,8 +458,8 @@ export default {
     entryKey: 'alert__count',
   },
   // Downloads
-  getDataURL: (params) => {
-    const { GLAD } = params.GFW_META.datasets;
+  getDataURL: async (params) => {
+    const GLAD = await handleGladMeta(params);
     const defaultStartDate = GLAD?.defaultStartDate;
     const defaultEndDate = GLAD?.defaultEndDate;
     const startDate = params?.startDate || defaultStartDate;

--- a/utils/gfw-meta.js
+++ b/utils/gfw-meta.js
@@ -54,6 +54,17 @@ export async function handleGladMeta(params) {
   return GLAD;
 }
 
+export async function handleViirsMeta(params) {
+  let VIIRS;
+  if (isEmpty(params?.GFW_META?.datasets)) {
+    const meta = await getGfwMeta();
+    VIIRS = meta?.datasets?.VIIRS;
+  } else {
+    VIIRS = params?.GFW_META?.datasets?.VIIRS;
+  }
+  return VIIRS;
+}
+
 export async function handleIntegratedMeta(params) {
   let INTEGRATED;
   if (isEmpty(params?.GFW_META?.datasets)) {


### PR DESCRIPTION
## Overview

This PR fixes an intermittent dashboard crash when switching admin areas.  

Occasionally, the fire-alerts-simple will attempt to access GFW_META before it has been fetched, and crashes while trying to access its properties. 

This is similar to what happened before in #4303, and finishes the fix. 

## Tracking

[FLAG-687](https://gfw.atlassian.net/browse/FLAG-687)

