### PR TITLE
Improve spacing between chart pie legend widgets legend and pie chart

### DIFF
--- a/components/charts/components/pie-chart-legend/component.jsx
+++ b/components/charts/components/pie-chart-legend/component.jsx
@@ -22,7 +22,7 @@ class PieChartLegend extends PureComponent {
         `${formatNumber({
           num: item[config.key],
           unit: item.unit ? item.unit : config.unit,
-        })}`?.length > 10
+        })}`?.length > 9
     );
 
     return (

--- a/components/charts/components/pie-chart-legend/component.jsx
+++ b/components/charts/components/pie-chart-legend/component.jsx
@@ -17,6 +17,14 @@ class PieChartLegend extends PureComponent {
       return '';
     })();
 
+    const shouldDisplaySmallerValues = data?.some(
+      (item) =>
+        `${formatNumber({
+          num: item[config.key],
+          unit: item.unit ? item.unit : config.unit,
+        })}`?.length > 10
+    );
+
     return (
       <div
         className={cx('c-pie-chart-legend', className)}
@@ -38,7 +46,13 @@ class PieChartLegend extends PureComponent {
                   </p>
                 </div>
                 {sizeClass !== 'x-small' && (
-                  <div className="legend-value" style={{ color: item.color }}>
+                  <div
+                    className={cx({
+                      'legend-value': true,
+                      'legend-value--small': shouldDisplaySmallerValues,
+                    })}
+                    style={{ color: item.color }}
+                  >
                     {value}
                   </div>
                 )}

--- a/components/charts/components/pie-chart-legend/styles.scss
+++ b/components/charts/components/pie-chart-legend/styles.scss
@@ -32,8 +32,8 @@
   }
 
   .legend-value {
-    padding: rem(5px) 0 0 rem(20px);
-    font-size: rem(28px);
+    padding: rem(5px) 0 0 rem(18px);
+    font-size: rem(27px);
     font-weight: 500;
     margin-bottom: rem(20px);
   }

--- a/components/charts/components/pie-chart-legend/styles.scss
+++ b/components/charts/components/pie-chart-legend/styles.scss
@@ -36,6 +36,10 @@
     font-size: rem(27px);
     font-weight: 500;
     margin-bottom: rem(20px);
+
+    &--small {
+      font-size: rem(20px);
+    }
   }
 
   .small {

--- a/components/widget/components/widget-pie-chart-legend/styles.scss
+++ b/components/widget/components/widget-pie-chart-legend/styles.scss
@@ -5,10 +5,11 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    gap: 4%;
+  }
 
-    .cover-legend {
-      min-width: 50%;
-    }
+  .cover-legend {
+    min-width: 50%;
   }
 
   .pie-contextual-settings-btn {

--- a/components/widgets/forest-change/integrated-deforestation-alerts/selectors.js
+++ b/components/widgets/forest-change/integrated-deforestation-alerts/selectors.js
@@ -123,7 +123,7 @@ export const parseConfig = createSelector(
               value: highestAlertCount,
               color: highestColour,
               percentage: highestAlertPercentage,
-              unit: 'counts',
+              unit: 'countsK',
             },
           ]
         : []),
@@ -133,7 +133,7 @@ export const parseConfig = createSelector(
         value: highAlertCount,
         color: highColour,
         percentage: highAlertPercentage,
-        unit: 'counts',
+        unit: 'countsK',
       },
       ...(!confidence
         ? [
@@ -142,7 +142,7 @@ export const parseConfig = createSelector(
               value: lowAlertCount,
               color: lowColour,
               percentage: lowAlertPercentage,
-              unit: 'counts',
+              unit: 'countsK',
             },
           ]
         : []),

--- a/components/widgets/forest-change/integrated-deforestation-alerts/selectors.js
+++ b/components/widgets/forest-change/integrated-deforestation-alerts/selectors.js
@@ -123,7 +123,7 @@ export const parseConfig = createSelector(
               value: highestAlertCount,
               color: highestColour,
               percentage: highestAlertPercentage,
-              unit: 'countsK',
+              unit: 'counts',
             },
           ]
         : []),
@@ -133,7 +133,7 @@ export const parseConfig = createSelector(
         value: highAlertCount,
         color: highColour,
         percentage: highAlertPercentage,
-        unit: 'countsK',
+        unit: 'counts',
       },
       ...(!confidence
         ? [
@@ -142,7 +142,7 @@ export const parseConfig = createSelector(
               value: lowAlertCount,
               color: lowColour,
               percentage: lowAlertPercentage,
-              unit: 'countsK',
+              unit: 'counts',
             },
           ]
         : []),


### PR DESCRIPTION
## Overview

This PR improves the spacing between chart pie legend widgets legend and pie chart. 
In some browsers, due to the sidebars, the pie chart and legend get smooched together with no separation. 

In order to mitigate this, this PR adds a gap, slightly decreases the font size and overall improves the spacing to account for this (while allowing the chart to correctly resize itself). 

## Demo
![one](https://user-images.githubusercontent.com/6273795/227584608-422d8a71-ff55-4f86-b14e-e8e5c993e0f7.png)
![two](https://user-images.githubusercontent.com/6273795/227584644-2316bd2f-4046-42c9-b3d1-1818efa6305e.png)
![three](https://user-images.githubusercontent.com/6273795/227584666-d0bbdfa4-38d7-4060-97ab-2981454312fd.png)

Fallback: 
![four](https://user-images.githubusercontent.com/6273795/227584722-2e8b48c5-f418-4102-9aee-c5cc76c30fc0.png)



## Tracking

[FLAG-582](https://gfw.atlassian.net/browse/FLAG-582)

