### PR TITLE
[FLAG-757]: move Forestry outside incorrect group

### DIFF
--- a/components/widgets/forest-change/tree-loss-drivers/selectors.js
+++ b/components/widgets/forest-change/tree-loss-drivers/selectors.js
@@ -165,6 +165,7 @@ export const parseConfig = createSelector(
         })
         .reverse()
     );
+
     const insertIndex = findIndex(tooltip, { key: 'class_Urbanization' });
     if (insertIndex > -1) {
       tooltip.splice(insertIndex, 0, {
@@ -172,6 +173,22 @@ export const parseConfig = createSelector(
         label: 'Drivers of permanent deforestation:',
       });
     }
+
+    const forestryIndex = tooltip.findIndex(
+      (element) => element.key === 'class_Forestry'
+    );
+    const agricultureIndex = tooltip.findIndex(
+      (element) => element.key === 'class_Shifting agriculture'
+    );
+
+    const rearrengedTooltips = [...tooltip];
+
+    delete rearrengedTooltips[forestryIndex];
+    delete rearrengedTooltips[agricultureIndex];
+
+    rearrengedTooltips.splice(2, 0, tooltip[forestryIndex]);
+    rearrengedTooltips.splice(3, 0, tooltip[agricultureIndex]);
+
     return {
       height: 250,
       xKey: 'year',
@@ -182,7 +199,7 @@ export const parseConfig = createSelector(
         tickFormatter: yearTicksFormatter,
       },
       unit: 'ha',
-      tooltip,
+      tooltip: rearrengedTooltips,
     };
   }
 );


### PR DESCRIPTION
## Overview

The Tree Cover Loss by Drivers widget has a tooltip that appears upon hovering. It lists “Forestry” under “Drivers of permanent deforestation”, which is incorrect. 

the tooltip array was rearranged to display the Forestry entry correct.

## Demo

<img width="769" alt="Screenshot 2023-04-06 at 1 15 23 p m" src="https://user-images.githubusercontent.com/127868788/230473954-3d14fd39-2fc2-4433-a972-d4dbd2553864.png">


## Testing

- [ ] go to `/dashboards/country/CAN/?category=summary&location=WyJjb3VudHJ5IiwiQ0FOIl0%3D&map=eyJjZW50ZXIiOnsibGF0Ijo3MS4yMTYwNzk4MjA0NjcxMiwibG5nIjotOTYuODMwODIzOTAxMTY2MDF9LCJiYXNlbWFwIjp7InZhbHVlIjoicGxhbmV0IiwiY29sb3IiOiIiLCJuYW1lIjoicGxhbmV0X21lZHJlc192aXN1YWxfMjAyMy0wMl9tb3NhaWMiLCJpbWFnZVR5cGUiOiJ2aXN1YWwifSwiY2FuQm91bmQiOmZhbHNlLCJkYXRhc2V0cyI6W3siZGF0YXNldCI6InBvbGl0aWNhbC1ib3VuZGFyaWVzIiwibGF5ZXJzIjpbImRpc3B1dGVkLXBvbGl0aWNhbC1ib3VuZGFyaWVzIiwicG9saXRpY2FsLWJvdW5kYXJpZXMiXSwiYm91bmRhcnkiOnRydWUsIm9wYWNpdHkiOjEsInZpc2liaWxpdHkiOnRydWV9LHsiZGF0YXNldCI6Ik5ldC1DaGFuZ2UtU1RBR0lORyIsImxheWVycyI6WyJmb3Jlc3QtbmV0LWNoYW5nZSJdLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlLCJwYXJhbXMiOnsidmlzaWJpbGl0eSI6dHJ1ZSwiYWRtX2xldmVsIjoiYWRtMCJ9fV19&showMap=true&treeLoss=eyJmb3Jlc3RUeXBlIjoiIiwiZXh0ZW50WWVhciI6MjAwMH0%3D&treeLossTsc=eyJoaWdobGlnaHRlZCI6ZmFsc2V9`
- [ ] or the embedded version `/embed/widget/treeLossTsc/country/CAN/?location=WyJjb3VudHJ5IiwiQ0FOIl0%3D&treeLossTsc=eyJoaWdobGlnaHRlZCI6ZmFsc2V9&widget=treeLossTsc`

- [ ] you should see the tooltip in the "ANNUAL TREE COVER LOSS BY DOMINANT DRIVER IN CANADA" in the correct order described in the ticket.

