### PR TITLE
[FLAG-721] Fix the integrated deforestation alerts widget in AOI view

### DIFF
--- a/components/widgets/forest-change/integrated-deforestation-alerts/index.js
+++ b/components/widgets/forest-change/integrated-deforestation-alerts/index.js
@@ -224,7 +224,10 @@ export default {
       });
     }
 
-    const { id: geostoreId } = params?.geostore;
+    const {
+      geostore: { id, hash },
+    } = params;
+    const geostoreId = hash || id;
 
     // Stop if geostoreId undefined
     if (geostoreId.length <= 0) return null;
@@ -465,7 +468,6 @@ export default {
     const startDate = params?.startDate || defaultStartDate;
     const endDate = params?.endDate || defaultEndDate;
     const alertSystem = handleAlertSystem(params, 'deforestationAlertsDataset');
-    const isWDPA = params?.locationType === 'wdpa';
 
     let table = 'gfw_integrated_alerts';
     if (alertSystem === 'glad_l') {
@@ -478,10 +480,10 @@ export default {
       table = 'wur_radd_alerts';
     }
 
-    let geostoreId = params?.geostore?.hash;
-    if (isWDPA) {
-      geostoreId = params?.geostore?.id;
-    }
+    const {
+      geostore: { id, hash },
+    } = params;
+    const geostoreId = hash || id;
 
     return [
       fetchIntegratedAlerts({

--- a/components/widgets/forest-change/integrated-deforestation-alerts/index.js
+++ b/components/widgets/forest-change/integrated-deforestation-alerts/index.js
@@ -224,7 +224,7 @@ export default {
       });
     }
 
-    const geostoreId = params?.geostore?.hash;
+    const { id: geostoreId } = params?.geostore;
 
     // Stop if geostoreId undefined
     if (geostoreId.length <= 0) return null;


### PR DESCRIPTION
## Overview

The integrated deforestation alerts widget isn’t showing for this AOI on the map or dashboard: [Subri River Deforestation Rates & Statistics | GFW](https://gfw.global/3LCh7pW). Here is the link to the widget: [Subri River Deforestation Rates & Statistics | GFW](https://gfw.global/42CTlR0).

## Demo

![image-20230320-215653](https://user-images.githubusercontent.com/23243868/230673919-4cd7f6d5-405d-45cc-bbf6-2f95be1239ec.png)


## Notes

According to https://resource-watch.github.io/doc-api/reference.html\#what-are-geostore-objects hash and id are the same type and value

## Testing

- Open the [AOI link](https://gfw-staging-pr-4537.herokuapp.com/dashboards/aoi/6418c42f188ab7001bca0e5e/?category=summary&location=WyJhb2kiLCI2NDE4YzQyZjE4OGFiNzAwMWJjYTBlNWUiXQ%3D%3D&map=eyJjZW50ZXIiOnsibGF0Ijo1LjMxMzE4MDY2OTY2NzI1NiwibG5nIjotMS43MzkzNDU3NDg5NzkwNTAzfSwiem9vbSI6MTAuMDcwMTk2MTYxNTM5MDk2LCJiYXNlbWFwIjp7InZhbHVlIjoicGxhbmV0IiwiY29sb3IiOiIiLCJuYW1lIjoicGxhbmV0X21lZHJlc192aXN1YWxfMjAyMy0wMl9tb3NhaWMifSwiY2FuQm91bmQiOmZhbHNlLCJkYXRhc2V0cyI6W3siZGF0YXNldCI6InBvbGl0aWNhbC1ib3VuZGFyaWVzIiwibGF5ZXJzIjpbImRpc3B1dGVkLXBvbGl0aWNhbC1ib3VuZGFyaWVzIiwicG9saXRpY2FsLWJvdW5kYXJpZXMiXSwiYm91bmRhcnkiOnRydWUsIm9wYWNpdHkiOjEsInZpc2liaWxpdHkiOnRydWV9LHsiZGF0YXNldCI6InRyZWUtY292ZXItbG9zcyIsImxheWVycyI6WyJ0cmVlLWNvdmVyLWxvc3MiXSwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZSwicGFyYW1zIjp7InRocmVzaG9sZCI6MzAsInZpc2liaWxpdHkiOnRydWUsImFkbV9sZXZlbCI6ImFkbTAifX1dfQ%3D%3D&showMap=true) and try to see the widget data

