### PR TITLE
[FLAG-723] Fix the fire alerts widget in AOI view  

### DIFF
--- a/components/widgets/fires/fire-alerts-simple/index.js
+++ b/components/widgets/fires/fire-alerts-simple/index.js
@@ -323,6 +323,11 @@ export default {
     const defaultEndDate = VIIRS?.defaultEndDate;
     const startDate = params?.startDate || defaultStartDate;
     const endDate = params?.endDate || defaultEndDate;
+    const {
+      geostore: { id, hash },
+    } = params;
+    const geostoreId = hash || id;
+
     if (shouldQueryPrecomputedTables(params)) {
       return fetchVIIRSAlertsSum({
         ...params,
@@ -347,7 +352,7 @@ export default {
         return data;
       });
     }
-    const geostoreId = params?.geostore?.hash;
+
     return fetchVIIRSAlertsSumOTF({
       ...params,
       startDate,
@@ -389,7 +394,11 @@ export default {
         }),
       ];
     }
-    const geostoreId = params?.geostore?.hash;
+    const {
+      geostore: { id, hash },
+    } = params;
+    const geostoreId = hash || id;
+
     return [
       fetchVIIRSAlertsSumOTF({
         ...params,


### PR DESCRIPTION
## Overview

The fire alerts widget isn’t showing for this AOI on the map or dashboard: [Subri River Deforestation Rates & Statistics | GFW](https://gfw.global/3LCh7pW). Here is the link to the widget: [Subri River Deforestation Rates & Statistics | GFW](https://gfw.global/42oID0i)

## Demo

![image-20230320-220817](https://user-images.githubusercontent.com/23243868/230676301-4c2f76c3-3708-44ab-9b38-e64eda82e564.png)


## Notes

According to https://resource-watch.github.io/doc-api/reference.html\#what-are-geostore-objects hash and id are the same type and value

## Testing

- Open the [AOI link](https://gfw-staging-pr-4538.herokuapp.com/dashboards/aoi/6418c42f188ab7001bca0e5e/?category=summary&location=WyJhb2kiLCI2NDE4YzQyZjE4OGFiNzAwMWJjYTBlNWUiXQ%3D%3D&map=eyJjZW50ZXIiOnsibGF0Ijo1LjMxMzE4MDY2OTY2NzIzLCJsbmciOi0xLjczOTM0NTc0ODk3OTA3NTh9LCJ6b29tIjoxMC4wNzAxOTYxNjE1MzkwOTYsImJhc2VtYXAiOnsidmFsdWUiOiJwbGFuZXQiLCJjb2xvciI6IiIsIm5hbWUiOiJwbGFuZXRfbWVkcmVzX3Zpc3VhbF8yMDIzLTAzX21vc2FpYyJ9LCJjYW5Cb3VuZCI6ZmFsc2UsImRhdGFzZXRzIjpbeyJkYXRhc2V0IjoicG9saXRpY2FsLWJvdW5kYXJpZXMiLCJsYXllcnMiOlsiZGlzcHV0ZWQtcG9saXRpY2FsLWJvdW5kYXJpZXMiLCJwb2xpdGljYWwtYm91bmRhcmllcyJdLCJib3VuZGFyeSI6dHJ1ZSwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZX0seyJkYXRhc2V0IjoidHJlZS1jb3Zlci1sb3NzIiwibGF5ZXJzIjpbInRyZWUtY292ZXItbG9zcyJdLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlLCJwYXJhbXMiOnsidGhyZXNob2xkIjozMCwidmlzaWJpbGl0eSI6dHJ1ZSwiYWRtX2xldmVsIjoiYWRtMCJ9fV19&showMap=true) and try to see the widget data

