### PR TITLE
[FLAG-748]: display "Global Primary Forest Loss" widget in AOI 

### DIFF
--- a/components/widgets/forest-change/tree-loss-primary/index.js
+++ b/components/widgets/forest-change/tree-loss-primary/index.js
@@ -104,10 +104,6 @@ export default {
     noLossWithIndicator:
       'From {startYear} to {endYear}, <b>{location} lost {loss} of humid primary forest</b> in {indicator}.',
   },
-  whitelists: {
-    indicators: ['primary_forest'],
-    checkStatus: true,
-  },
   settings: {
     threshold: 30,
     extentYear: 2000,


### PR DESCRIPTION
## Overview

this widget [https://gfw.global/3ZWKE2a](https://gfw.global/3ZWKE2a)
 isn't showing for the AOI, it is displaying for the global and country dashboards.

it seems that the `whitelists` object in the widget config was misconfigured.


## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

- [ ] go to `/dashboards/aoi/6414a3ba0605c0001bad6517/?category=forest-change&lang=en&location=WyJhb2kiLCI2NDE0YTNiYTA2MDVjMDAwMWJhZDY1MTciXQ%3D%3D&map=eyJjZW50ZXIiOnsibGF0IjoxNS40ODg3MTkwMjMzNTU2OCwibG5nIjotODQuODkwNDExMDUwNDkxODJ9LCJ6b29tIjo4LjY0OTg1MzU0NDU4ODU2MSwiYmFzZW1hcCI6eyJ2YWx1ZSI6InBsYW5ldCIsImNvbG9yIjoiIiwibmFtZSI6InBsYW5ldF9tZWRyZXNfdmlzdWFsXzIwMjMtMDNfbW9zYWljIn0sImNhbkJvdW5kIjpmYWxzZSwiZGF0YXNldHMiOlt7Im9wYWNpdHkiOjAuNywidmlzaWJpbGl0eSI6dHJ1ZSwiZGF0YXNldCI6ImludGFjdC1mb3Jlc3QtbGFuZHNjYXBlcyIsImxheWVycyI6WyJpbnRhY3QtZm9yZXN0LWxhbmRzY2FwZXMiXX0seyJkYXRhc2V0IjoicG9saXRpY2FsLWJvdW5kYXJpZXMiLCJsYXllcnMiOlsiZGlzcHV0ZWQtcG9saXRpY2FsLWJvdW5kYXJpZXMiLCJwb2xpdGljYWwtYm91bmRhcmllcyJdLCJib3VuZGFyeSI6dHJ1ZSwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZX0seyJkYXRhc2V0IjoidHJlZS1jb3Zlci1sb3NzIiwibGF5ZXJzIjpbInRyZWUtY292ZXItbG9zcyJdLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlLCJwYXJhbXMiOnsidGhyZXNob2xkIjozMCwidmlzaWJpbGl0eSI6dHJ1ZSwiYWRtX2xldmVsIjoiYWRtMCJ9fV19&scrollTo=forest-loss&showMap=true&treeLoss=eyJmb3Jlc3RUeXBlIjoiaWZsIiwiZXh0ZW50WWVhciI6MjAwMH0%3D`

you should see the "Global Primary Forest Loss" widget correctly displayed in the page
