### PR TITLE
[FLAG-669] Fix the explore fire alerts button

### DIFF
--- a/layouts/topics/components/topics-header/topics-intro/component.jsx
+++ b/layouts/topics/components/topics-header/topics-intro/component.jsx
@@ -12,6 +12,10 @@ import './styles.scss';
 const TopicsIntro = ({ intro = {}, className, handleSkipToTools }) => {
   const { img1x, img2x, title, text, citation, button } = intro;
 
+  const redirectTo = (link) => {
+    window.location = link;
+  };
+
   return (
     <div className={cx('c-topics-intro', className)}>
       <Row className="title-row">
@@ -43,8 +47,8 @@ const TopicsIntro = ({ intro = {}, className, handleSkipToTools }) => {
                 trackEvent({
                   category: 'Topics pages',
                   action: 'Open citation info button',
-                  label: title
-                })
+                  label: title,
+                });
               }}
             >
               <Icon className="citation-icon" icon={infoIcon} />
@@ -58,7 +62,10 @@ const TopicsIntro = ({ intro = {}, className, handleSkipToTools }) => {
           <p className="intro-text">{text}</p>
           <div className="intro-buttons">
             {button && (
-              <Button className="intro-btn" link={button.link}>
+              <Button
+                className="intro-btn"
+                onClick={() => redirectTo(button.link)}
+              >
                 {button.text}
               </Button>
             )}


### PR DESCRIPTION
## Overview

The explore fire alerts on the map button at the top of the [fire topics page](https://www.globalforestwatch.org/topics/fires/#intro) does not work. Clicking it does nothing but should open the map with [the fire alerts layer](https://www.globalforestwatch.org/map/?analysis=eyJzaG93RHJhdyI6dHJ1ZX0%3D&map=eyJjZW50ZXIiOnsibGF0Ijo5LjkxMDE2Mjc1MTc4ODAyNywibG5nIjotMTIuMTQ5OTA1MDAwMDIxNDg5fSwiem9vbSI6OS41NzgzMjYyMTg4MzMxMDksImRhdGFzZXRzIjpbeyJkYXRhc2V0IjoiZmlyZS1hbGVydHMtdmlpcnMiLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlLCJsYXllcnMiOlsiZmlyZS1hbGVydHMtdmlpcnMiXX0seyJkYXRhc2V0IjoicG9saXRpY2FsLWJvdW5kYXJpZXMiLCJsYXllcnMiOlsiZGlzcHV0ZWQtcG9saXRpY2FsLWJvdW5kYXJpZXMiLCJwb2xpdGljYWwtYm91bmRhcmllcyJdLCJvcGFjaXR5IjoxLCJ2aXNpYmlsaXR5Ijp0cnVlfV19&mapMenu=eyJtZW51U2VjdGlvbiI6ImRhdGFzZXRzIiwiZGF0YXNldENhdGVnb3J5IjoiZm9yZXN0Q2hhbmdlIn0%3D) visualized.

## Demo

![image-20230130-201607](https://user-images.githubusercontent.com/23243868/232827243-a7175442-40e9-40ab-a5d7-bc18d80df6f0.png)


## Testing

- Open the [page](https://gfw-staging-pr-4541.herokuapp.com/topics/fires/#intro)
- Try to click on "explore fire alerts"
- Check if it redirects to map

