### PR TITLE
[FLAG-625] Fix browse our apps button link

### DIFF
--- a/layouts/home/config.js
+++ b/layouts/home/config.js
@@ -85,7 +85,7 @@ export default {
       buttons: [
         {
           text: 'BROWSE OUR APPS',
-          extLink: 'https://developers.globalforestwatch.org',
+          extLink: 'https://www.globalforestwatch.org/help',
         },
       ],
       image: card5,

--- a/layouts/home/config.js
+++ b/layouts/home/config.js
@@ -65,19 +65,6 @@ export default {
       image: card3,
       webPImage: card3Webp,
     },
-    // {
-    //   title: 'Forest insights',
-    //   summary:
-    //     'Read the latest stories and findings about forests from our team of researchers on the GFW blog.',
-    //   buttons: [
-    //     {
-    //       text: 'START LEARNING',
-    //       extLink: 'https://blog.globalforestwatch.org/',
-    //     },
-    //   ],
-    //   image: card4,
-    //   webPImage: card4Webp,
-    // },
     {
       title: 'A suite of tools',
       summary:


### PR DESCRIPTION
## Overview

The 'browse our apps' Link on homepage links to https://developers.globalforestwatch.org/
Change this to link to the Help Center here: https://www.globalforestwatch.org/help/

## Demo

<img width="1021" alt="Screen Shot 2023-01-09 at 3 41 35 PM-20230109-204140" src="https://user-images.githubusercontent.com/23243868/232831794-c292ebed-06af-4f8e-bc15-707852db5736.png">

## Testing

- Open the [page](https://gfw-staging-pr-4542.herokuapp.com/)
- Try to click on "browse our apps"
- Check if it redirects to help page

