### PR TITLE
FLAG-719: update filter label from 2016 to 2000

### DIFF
--- a/components/widgets/utils/config.js
+++ b/components/widgets/utils/config.js
@@ -27,7 +27,7 @@ export const getForestTypes = ({
     .map((f) => ({
       ...f,
       label: f.label.includes('{iflYear}')
-        ? f.label.replace('{iflYear}', settings.ifl || 2016)
+        ? f.label.replace('{iflYear}', settings.ifl || 2000)
         : f.label,
       metaKey:
         f.metaKey === 'primary_forest'


### PR DESCRIPTION
## Overview

Updating filter label from "Intact Forest Landscapes (2016)" to "Intact Forest Landscapes (2000)"

![Screenshot 2023-04-26 at 9 59 39 p m](https://user-images.githubusercontent.com/127868788/234756143-b8b6dd7d-a380-4558-b80c-eca44415d5c8.png)


## Demo

If applicable: screenshots, gifs, etc.

## Notes

If applicable: ancilary topics, caveats, alternative strategies that didn't work out, etc.

## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

