### PR TITLE
FLAG-751: insert new GTM script

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -5,11 +5,61 @@ import sprite from 'svg-sprite-loader/runtime/sprite.build';
 
 import { mediaStyles } from 'gfw-components';
 
-const isProduction = process.env.NODE_ENV === 'production';
+const isProduction = process.env.NEXT_PUBLIC_FEATURE_ENV === 'production';
 
 export default class MyDocument extends Document {
   render() {
     const spriteContent = sprite.stringify();
+    const googleTagManagerScripts = {};
+
+    if (isProduction) {
+      googleTagManagerScripts.head = (
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer','GTM-NXXKNZL');
+          `,
+          }}
+        />
+      );
+      googleTagManagerScripts.body = (
+        <noscript
+          dangerouslySetInnerHTML={{
+            __html: `
+              <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NXXKNZL" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+            `,
+          }}
+        />
+      );
+    } else {
+      // staging scripts
+      googleTagManagerScripts.head = (
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+              new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+              'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=RMMtBOJR3X5oL-iJf1UvnQ&gtm_preview=env-7&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+              })(window,document,'script','dataLayer','GTM-NXXKNZL');
+            `,
+          }}
+        />
+      );
+      googleTagManagerScripts.body = (
+        <noscript
+          dangerouslySetInnerHTML={{
+            __html: `
+            <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NXXKNZL&gtm_auth=RMMtBOJR3X5oL-iJf1UvnQ&gtm_preview=env-7&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+            `,
+          }}
+        />
+      );
+    }
 
     return (
       <Html lang="en">
@@ -62,28 +112,14 @@ export default class MyDocument extends Document {
             src="//cdn.transifex.com/live.js"
             rel="preconnect"
           />
-
-          {isProduction && (
-            <script
-              async
-              src="https://www.googletagmanager.com/gtag/js?id=G-JVWWXY8NP3"
-            />
-          )}
-
-          {isProduction && (
-            <script
-              dangerouslySetInnerHTML={{
-                __html: `
-                  window.dataLayer = window.dataLayer || [];
-                  function gtag(){dataLayer.push(arguments);}
-                  gtag('js', new Date());
-                  gtag('config', 'G-JVWWXY8NP3');
-                `,
-              }}
-            />
-          )}
+          {/* Google Tag Manager */}
+          {googleTagManagerScripts.head}
+          {/* End Google Tag Manager */}
         </Head>
         <body>
+          {/* Google Tag Manager (noscript) */}
+          {googleTagManagerScripts.body}
+          {/* End Google Tag Manager (noscript) */}
           <div dangerouslySetInnerHTML={{ __html: spriteContent }} />
           <main id="maincontent">
             <Main />


### PR DESCRIPTION
## Overview

Adding new GTM script alongside existing one

## Demo

To test this we need to have installed the Tag Assistant Companion
[https://chrome.google.com/webstore/detail/tag-assistant-companion/jmekfmbnaedfebfnmakmokmlfpblbfdm?hl=en](https://chrome.google.com/webstore/detail/tag-assistant-companion/jmekfmbnaedfebfnmakmokmlfpblbfdm?hl=en)

## Notes


## Testing

- Include any steps to verify the features this PR introduces.
- If this fixes a bug, include bug reproduction steps.

