### PR TITLE
[FLAG-746] Add warning label to weekly-fire-alerts

### DIFF
--- a/components/widgets/fires/fires-alerts/index.js
+++ b/components/widgets/fires/fires-alerts/index.js
@@ -23,6 +23,14 @@ const defaultConfig = {
   title: 'Weekly Fire Alerts in {location}',
   large: true,
   categories: ['summary', 'fires'],
+  alerts: [
+    {
+      id: 'weekly-fire-alerts-1',
+      text: `To include all detected fire alerts, go to the widget settings icon and readjust the confidence level to all.`,
+      icon: 'warning',
+      visible: ['global', 'country', 'geostore', 'aoi', 'wdpa', 'use'],
+    },
+  ],
   settingsConfig: [
     {
       key: 'forestType',


### PR DESCRIPTION
## Overview

We want to add a warning label message to the [weekly fire alerts widget](https://gfw.global/3nbPdXU). The widget displays only high-confidence alerts, so users may mistakenly think it includes all alerts.

The warning message: 
“To include all detected fire alerts, go to the widget settings icon and readjust the confidence level to all.”

We will use the default settings for the warning label that we just created; this will only apply to widgets, as this widget doesn’t appear on the map analysis.

## Demo

![Screenshot 2023-05-05 at 12 02 52](https://user-images.githubusercontent.com/23243868/236495378-72e38ea6-ba3f-454a-b92e-8acf50430637.png)


## Testing

- Open the Weekly fire alerts
- Check the warning message

