### PR TITLE
[FLAG-491]: Make changes to the Intact Forest widget

### DIFF
--- a/components/widgets/land-cover/intact-tree-cover/index.js
+++ b/components/widgets/land-cover/intact-tree-cover/index.js
@@ -70,19 +70,19 @@ export default {
   settings: {
     forestType: 'ifl',
     threshold: 30,
-    extentYear: 2010,
-    ifl: 2016,
+    extentYear: 2000,
+    ifl: 2000,
   },
   refetchKeys: ['landCategory', 'threshold', 'extentYear'],
   sentences: {
     initial:
-      'As of 2016, {percentage} of {location} tree cover was <b>intact forest</b>.',
+      'As of 2000, {percentage} of {location} tree cover was <b>intact forest</b>.',
     withIndicator:
-      'As of 2016, {percentage} of {location} tree cover in {indicator} was <b>intact forest</b>.',
+      'As of 2000, {percentage} of {location} tree cover in {indicator} was <b>intact forest</b>.',
     noIntact:
-      'As of 2016, <b>none</b> of {location} tree cover was <b>intact forest</b>.',
+      'As of 2000, <b>none</b> of {location} tree cover was <b>intact forest</b>.',
     noIntactwithIndicator:
-      'As of 2016, <b>none</b> of {location} tree cover in {indicator} was <b>intact forest</b>.',
+      'As of 2000, <b>none</b> of {location} tree cover in {indicator} was <b>intact forest</b>.',
   },
   whitelists: {
     checkStatus: true,


### PR DESCRIPTION
## Overview

We need to make some changes to the Intact Forest widget. The query the widget runs (an example from [Angola](https://gfw.global/3AIc5ma)) looks like this:

```https://data-api.globalforestwatch.org/dataset/gadm__tcl__iso_summary/v202204.2/query/json?sql=SELECT iso, SUM(umd_tree_cover_extent_2010__ha) AS umd_tree_cover_extent_2010__ha, SUM(area__ha) AS area__ha FROM data WHERE iso = 'AGO' AND is__ifl_intact_forest_landscapes_2000 = 'true' AND umd_tree_cover_density_2000__threshold = 30 GROUP BY iso ORDER BY iso```

And the widget says, "As of 2016, 0.53% of Angola's tree cover was intact forest." See the screenshot below.
![image-20220824-211525](https://github.com/Vizzuality/gfw/assets/23243868/e5089d5f-5972-4e44-851d-d457c28fa093)

This sentence does not accurately reflect the query. 

It looks like the query uses the 2010 extent with the 2000 IFL extent. Unfortunately, since we do not have an IFL layer that corresponds to 2010

We need to change this to use the 2000 extent with the 2000 IFL layer. 

## Demo
![Screenshot 2023-05-16 at 13 07 01](https://github.com/Vizzuality/gfw/assets/23243868/e15ce1f1-e78e-4fda-a05b-23bca09665e4)


![Screenshot 2023-05-16 at 13 07 10](https://github.com/Vizzuality/gfw/assets/23243868/10e19b35-e4d8-41ab-a187-7718bc92fa3e)


