### PR TITLE
[FLAG-761]: Location tree cover widget is missing the latest years

### DIFF
--- a/components/widgets/forest-change/tree-loss-located/index.js
+++ b/components/widgets/forest-change/tree-loss-located/index.js
@@ -148,7 +148,7 @@ export default {
         /* lossItemReference is for reference of startYear, endYear and range. 
           The perfect item should have all the years to set the variables */
         const lossItemReference = lossMappedData.findIndex(({ loss }) =>
-          loss.find(({ umd_tree_cover_loss__year: year }) => year >= 2021)
+          loss.find(({ umd_tree_cover_loss__year: year }) => year >= MAX_YEAR)
         );
 
         const { startYear, endYear, range } = getYearsRangeFromData(

--- a/components/widgets/forest-change/tree-loss-located/index.js
+++ b/components/widgets/forest-change/tree-loss-located/index.js
@@ -16,7 +16,7 @@ import {
 
 import getWidgetProps from './selectors';
 
-const MAX_YEAR = 2020;
+const MAX_YEAR = 2021;
 const MIN_YEAR = 2001;
 
 export default {
@@ -116,36 +116,44 @@ export default {
   getData: (params) =>
     all([getExtentGrouped(params), getLossGrouped(params)]).then(
       spread((extentGrouped, lossGrouped) => {
+        const extentData = extentGrouped.data.data || [];
+        const lossData = lossGrouped.data.data || [];
+        const { adm0, adm1 } = params;
+
         let groupKey = 'iso';
-        if (params.adm0) groupKey = 'adm1';
-        if (params.adm1) groupKey = 'adm2';
 
-        const extentData = extentGrouped.data.data;
-        let extentMappedData = {};
-        if (extentData && extentData.length) {
-          extentMappedData = extentData.map((d) => ({
-            id: groupKey === 'iso' ? d[groupKey] : parseInt(d[groupKey], 10),
-            extent: d.extent || 0,
-            percentage: d.extent ? (d.extent / d.total) * 100 : 0,
-          }));
-        }
-        const lossData = lossGrouped.data.data;
-        let lossMappedData = [];
-        if (lossData && lossData.length) {
-          const lossByRegion = groupBy(lossData, groupKey);
-          lossMappedData = Object.keys(lossByRegion).map((d) => {
-            const regionLoss = lossByRegion[d];
-            return {
-              id: groupKey === 'iso' ? d : parseInt(d, 10),
-              loss: regionLoss,
-            };
-          });
-        }
+        if (adm0) groupKey = 'adm1';
+        if (adm1) groupKey = 'adm2';
 
-        const { startYear, endYear, range } =
-          (lossMappedData[0] &&
-            getYearsRangeFromData(lossMappedData[0].loss)) ||
-          {};
+        const extentMappedData = extentData.map((extentItem) => {
+          const { extent = 0, total = 0 } = extentItem;
+          const extentGroupKey = extentItem[groupKey];
+
+          return {
+            id:
+              groupKey === 'iso'
+                ? extentGroupKey
+                : parseInt(extentGroupKey, 10),
+            extent,
+            percentage: (extent / total) * 100,
+          };
+        });
+
+        const lossByRegion = groupBy(lossData, groupKey);
+        const lossMappedData = Object.keys(lossByRegion).map((regionIndex) => ({
+          id: groupKey === 'iso' ? regionIndex : parseInt(regionIndex, 10),
+          loss: lossByRegion[regionIndex],
+        }));
+
+        /* lossItemReference is for reference of startYear, endYear and range. 
+          The perfect item should have all the years to set the variables */
+        const lossItemReference = lossMappedData.findIndex(({ loss }) =>
+          loss.find(({ umd_tree_cover_loss__year: year }) => year >= 2021)
+        );
+
+        const { startYear, endYear, range } = getYearsRangeFromData(
+          lossMappedData[lossItemReference].loss
+        );
 
         return {
           lossByRegion: lossMappedData,


### PR DESCRIPTION
## Overview

The location of tree cover loss in [country] widget needs years added. For example, the [LOCATION OF TREE COVER LOSS IN MEXICO](https://gfw.global/3odKntI) widget includes the data from 2001 - 2017. In the settings menu, I can only filter and customize the data from 2001-2017. We need this widget to include the latest data (e.g., 2001-2021) for all the available countries.

## Demo
![image-20230414-212748](https://github.com/Vizzuality/gfw/assets/23243868/e16f70f7-d429-471e-a04e-9ecfb3a66c35)

![Screenshot 2023-05-17 at 16 13 40](https://github.com/Vizzuality/gfw/assets/23243868/6238859b-509b-428a-8b73-914711f65363)



## Testing

- Open the env test link
- Find the widget
- Try to change the data range and/or check the sentence.

