### PR TITLE
[FLAG-1050] Update TCL downloadable file

### DIFF
--- a/components/analysis/components/show-analysis/selectors.js
+++ b/components/analysis/components/show-analysis/selectors.js
@@ -15,7 +15,7 @@ import { FOREST_GAIN, FOREST_LOSS } from 'data/layers';
 
 const gainID = FOREST_GAIN;
 const lossID = FOREST_LOSS;
-const DOWNLOAD_VERSION = '2022';
+const DOWNLOAD_VERSION = '2023';
 
 const selectLocation = (state) => state.location && state.location.payload;
 const selectData = (state) => state.analysis && state.analysis.data;

--- a/layouts/dashboards/components/header/selectors.js
+++ b/layouts/dashboards/components/header/selectors.js
@@ -12,7 +12,7 @@ import {
 } from 'providers/areas-provider/selectors';
 
 const isServer = typeof window === 'undefined';
-const DOWNLOAD_VERSION = '2022';
+const DOWNLOAD_VERSION = '2023';
 
 // get list data
 export const selectLocation = (state) =>


### PR DESCRIPTION
## Overview

Much like we did in FLAG-724: Update TCL downloadable spreadsheet on map and dashboards
RELEASED
 , we will need to update the dashboards' download link (see image below) with new data once this is provided by the engineering and research teams. This will depend on our plan for the MVP (which may not include this). We may release this after the MVP. 


## Demo
![Screenshot 2024-03-29 at 11 16 58](https://github.com/wri/gfw/assets/23243868/44b94811-3778-4509-bdc8-21ab2113074f)
