### PR TITLE
[FLAG-1346] Remove "Custom Area Handling" method

### DIFF
--- a/components/forms/area-of-interest/actions.js
+++ b/components/forms/area-of-interest/actions.js
@@ -10,8 +10,6 @@ import {
   clearArea,
 } from 'providers/areas-provider/actions';
 
-import { getWidgetsData } from 'components/widgets/actions';
-
 export const saveAreaOfInterest = createThunkAction(
   'saveAreaOfInterest',
   ({
@@ -99,12 +97,6 @@ export const saveAreaOfInterest = createThunkAction(
           dispatch(setArea({ ...area, userArea: true }));
           if (viewAfterSave) {
             dispatch(viewArea({ areaId: area.id }));
-          }
-          if (
-            location.payload.type === 'geostore' ||
-            location.payload.type === 'aoi'
-          ) {
-            dispatch(getWidgetsData());
           }
         })
         .catch((error) => {

--- a/components/widgets/actions.js
+++ b/components/widgets/actions.js
@@ -1,7 +1,6 @@
 import { createAction, createThunkAction } from 'redux/actions';
 import { trackEvent } from 'utils/analytics';
 
-import { getNonGlobalDatasets } from 'services/analysis-cached';
 import { setDashboardPromptsSettings } from 'components/prompts/dashboard-prompts/actions';
 
 // widgets
@@ -17,47 +16,29 @@ export const setActiveWidget = createAction('setActiveWidget');
 export const setShowMap = createAction('setShowMap');
 export const setWidgetsLoading = createAction('setWidgetsLoading');
 
-export const getWidgetsData = createThunkAction(
-  'getWidgetsData',
-  () => (dispatch) => {
-    dispatch(setWidgetsLoading({ loading: true, error: false }));
-    getNonGlobalDatasets()
-      .then((response) => {
-        const { rows } = response.data;
-        dispatch(
-          setWidgetsData({
-            nonGlobalDatasets: rows && rows[0],
-          })
-        );
-      })
-      .catch(() => {
-        dispatch(setWidgetsLoading({ error: true, loading: false }));
-      });
-  }
-);
-
 export const setWidgetSettings = createThunkAction(
   'setWidgetSettings',
-  ({ change, widget }) => (dispatch) => {
-    dispatch(
-      setWidgetSettingsByKey({
-        key: widget,
-        change,
-      })
-    );
-    if (!change.interaction) {
-      trackEvent({
-        category: 'Widget Settings',
-        action: 'User changes the widget settings',
-        label: widget,
-      });
+  ({ change, widget }) =>
+    (dispatch) => {
       dispatch(
-        setDashboardPromptsSettings({
-          open: true,
-          stepIndex: 0,
-          stepsKey: 'shareWidget',
+        setWidgetSettingsByKey({
+          key: widget,
+          change,
         })
       );
+      if (!change.interaction) {
+        trackEvent({
+          category: 'Widget Settings',
+          action: 'User changes the widget settings',
+          label: widget,
+        });
+        dispatch(
+          setDashboardPromptsSettings({
+            open: true,
+            stepIndex: 0,
+            stepsKey: 'shareWidget',
+          })
+        );
+      }
     }
-  }
 );

--- a/components/widgets/index.js
+++ b/components/widgets/index.js
@@ -58,8 +58,6 @@ const makeMapStateToProps = () => {
 
 class WidgetsContainer extends PureComponent {
   static propTypes = {
-    getWidgetsData: PropTypes.func,
-    location: PropTypes.object,
     category: PropTypes.string,
     activeWidget: PropTypes.object,
     setMapSettings: PropTypes.func,
@@ -70,11 +68,7 @@ class WidgetsContainer extends PureComponent {
   };
 
   componentDidMount() {
-    const { getWidgetsData, location, activeWidget, embed } = this.props;
-    if (location.type === 'global') {
-      getWidgetsData();
-    }
-
+    const { activeWidget, embed } = this.props;
     if (!embed && activeWidget && activeWidget.datasets) {
       this.syncWidgetWithMap();
     }
@@ -82,11 +76,9 @@ class WidgetsContainer extends PureComponent {
 
   componentDidUpdate(prevProps) {
     const {
-      getWidgetsData,
       setWidgetsCategory,
       activeWidget,
       embed,
-      location,
       category,
       setActiveWidget,
     } = this.props;
@@ -94,10 +86,6 @@ class WidgetsContainer extends PureComponent {
     if (!isEqual(category, prevProps.category)) {
       setActiveWidget(null);
       setWidgetsCategory(category);
-    }
-
-    if (location.type === 'global' && prevProps.location?.type !== 'global') {
-      getWidgetsData();
     }
 
     // if widget is active and layers or params change push to map

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -1,5 +1,5 @@
 import qs from 'qs';
-import { cartoRequest, dataMartRequest, dataRequest } from 'utils/request';
+import { dataMartRequest, dataRequest } from 'utils/request';
 import { PROXIES } from 'utils/proxies';
 
 import forestTypes from 'data/forest-types';
@@ -63,8 +63,6 @@ const SQL_QUERIES = {
     'SELECT {select_location}, alert__week, alert__year, SUM(alert__count) AS alert__count, confidence__cat FROM data {WHERE} AND alert__year >= {alert__year} AND alert__week >= 1 GROUP BY alert__year, alert__week ORDER BY alert__week DESC, alert__year DESC',
   firesDailySum: `SELECT {select_location}, confidence__cat, SUM(alert__count) AS alert__count FROM data {WHERE} AND alert__date >= '{startDate}' AND alert__date <= '{endDate}' GROUP BY {location}, confidence__cat`,
   firesDailySumOTF: `SELECT SUM(alert__count) AS alert__count, confidence__cat FROM data WHERE alert__date >= '{startDate}' AND alert__date <= '{endDate}' GROUP BY confidence__cat&geostore_id={geostoreId}&geostore_origin=rw`,
-  nonGlobalDatasets:
-    'SELECT {polynames} FROM polyname_whitelist WHERE iso is null AND adm1 is null AND adm2 is null',
   getLocationPolynameWhitelist:
     'SELECT {select_location}, {polynames} FROM data {WHERE}',
   alertsWeekly:
@@ -2856,15 +2854,6 @@ const buildPolynameSelects = (nonTable, dataset) => {
     );
   });
   return polyString;
-};
-
-// get counts of countries that each forest type and land category intersects with
-export const getNonGlobalDatasets = () => {
-  const url = `/sql?q=${SQL_QUERIES.nonGlobalDatasets}`.replace(
-    '{polynames}',
-    buildPolynameSelects(true, 'annual')
-  );
-  return cartoRequest.get(url);
 };
 
 // get a boolean list of forest types and land categories inside a given shape


### PR DESCRIPTION
## Overview

From Will’s work on [FLAG-1336](https://gfw.atlassian.net/browse/FLAG-1336) , we know that when a custom area is saved, the method getNonGlobalDatasets is called.

However, this call does not appear to work in production, so it may be deprecated or unnecessary.

```
https://wri-01.carto.com/api/v2/sql?q=
SELECT 
  plantations, plantations AS plantations, 
  ifl, ifl AS ifl, 
  primary_forest, primary_forest AS primary_forest, 
  mangroves_2020, mangroves_2020 AS mangroves_2020, 
  mining, mining AS mining,
  wdpa, wdpa AS wdpa, 
  kba, kba AS kba, 
  aze, aze AS aze, 
  landmark, landmark AS landmark, 
  idn_forest_moratorium, idn_forest_moratorium AS idn_forest_moratorium, 
  oil_palm, oil_palm AS oil_palm, 
  wood_fiber, wood_fiber AS wood_fiber, 
  managed_forests, managed_forests AS managed_forests 
 FROM polyname_whitelist 
 WHERE iso is null AND adm1 is null AND adm2 is null
```

We can go ahead and remove this, and we’ll verify that we have tests in place to ensure saved areas are working.

### Acceptance criteria: 

- Code above has been removed
- Custom areas are still saved correctly



[FLAG-1336]: https://gfw.atlassian.net/browse/FLAG-1336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ