### PR TITLE
[FLAG-1459] Add hover message for the global integrated disturbance alerts data download button

### DIFF
--- a/components/widget/components/widget-header/components/widget-download-button/component.jsx
+++ b/components/widget/components/widget-header/components/widget-download-button/component.jsx
@@ -16,6 +16,7 @@ import downloadIcon from 'assets/icons/download.svg?sprite';
 import { GFW_API } from 'utils/apis';
 
 const GLAD_ALERTS_WIDGET = 'gladAlerts';
+const DEFORESTATION_ALERTS_WIDGET = 'integratedDeforestationAlerts';
 
 const isServer = typeof window === 'undefined';
 
@@ -234,6 +235,11 @@ class WidgetDownloadButton extends PureComponent {
     return widget === GLAD_ALERTS_WIDGET;
   };
 
+  isDeforestationAlertsWidget = () => {
+    const { widget } = this.props;
+    return widget === DEFORESTATION_ALERTS_WIDGET;
+  };
+
   isCustomShape = () => {
     const { location, status } = this.props;
     return location && location.type === 'geostore' && status !== 'saved';
@@ -268,10 +274,17 @@ class WidgetDownloadButton extends PureComponent {
     const { areaTooLarge, disabled, disabledMessage, widget } = this.props;
     const { disabled: localDisabled } = this.state;
 
-    let tooltipText =
-      this.isGladAlertsWidget() && this.isCustomShape()
-        ? 'Download data. Please add .csv to the filename if extension is missing.'
-        : 'Download data.';
+    let tooltipText = 'Download data.';
+
+    if (this.isGladAlertsWidget() && this.isCustomShape()) {
+      tooltipText =
+        'Download data. Please add .csv to the filename if extension is missing.';
+    }
+
+    if (this.isDeforestationAlertsWidget()) {
+      tooltipText =
+        'Download may fail due to system limits. If this happens, please try after a minute.';
+    }
 
     if (areaTooLarge) {
       tooltipText =


### PR DESCRIPTION
## Overview

Downloads for the [global integrated disturbance alerts ](https://gfw.global/JFqQwu)may fail due to backend system limits (e.g., request timeout or payload size limits). Currently, the download button appears enabled even when the download cannot be completed.

Add a front-end message to inform users that downloads may be temporarily unavailable and suggest a workaround.

### Acceptance Criteria

After users have narrowed the total alerts to fewer than 100,000, display the following hover message above all integrated disturbance alerts download buttons:

"Download may fail due to system limits. If this happens, please try after a minute."
