### PR TITLE
[FLAG-1465] New accounts see My GFW Profile window instead of Save AOI when saving areas of interest

### DIFF
--- a/utils/user.js
+++ b/utils/user.js
@@ -3,14 +3,4 @@ export const checkUserProfileFilled = ({
   fullName,
   lastName,
   sector,
-  subsector,
-} = {}) =>
-  !!email &&
-  (!!fullName || !!lastName) &&
-  !!sector &&
-  subsector &&
-  (subsector.includes('Other')
-    ? // if 'Other: <input>', we make sure that the value is not empty
-      !!subsector.split('Other:')[1].trim()
-    : // otherwise we just check the subsector
-      !!subsector);
+} = {}) => !!email && (!!fullName || !!lastName) && !!sector;


### PR DESCRIPTION
## Overview

When people 1) select an area of interest and 2) click on the Save in My GFW button. Instead of the Save AOI window, they see their My GFW Profile window and are asked to complete their profile, even though they are already logged in. This prevents them from saving the selected area of interest. From what users described, it seems to only happen with new accounts. So it doesn’t appear to be an issue with AOI itself, but with the accounts and My GFW Profile forms. 
