### PR TITLE
Pin gain version so we don't need to add it back to geotrellis

### DIFF
--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -14,7 +14,7 @@ import { getWHEREQuery } from './get-where-query';
 
 const VIIRS_START_YEAR = 2012;
 
-const PINNED_GAIN_VERSION = 'v20251209'
+const PINNED_GAIN_VERSION = 'v20251209';
 
 const SQL_QUERIES = {
   // This Query is used by the treeLossTsc (pie chart version) widget (_tree-loss-drivers), which had its rollout paused.
@@ -958,7 +958,7 @@ export const getTreeCoverGainByPlantationType = (params) => {
     ...params,
     dataset: 'annual',
     datasetType: 'summary',
-    version: 'v20251209',
+    version: PINNED_GAIN_VERSION,
   });
 
   if (!requestUrl) return new Promise(() => {});

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -14,6 +14,8 @@ import { getWHEREQuery } from './get-where-query';
 
 const VIIRS_START_YEAR = 2012;
 
+const PINNED_GAIN_VERSION = 'v20251209'
+
 const SQL_QUERIES = {
   // This Query is used by the treeLossTsc (pie chart version) widget (_tree-loss-drivers), which had its rollout paused.
   treeCoverLossByDriver:
@@ -956,6 +958,7 @@ export const getTreeCoverGainByPlantationType = (params) => {
     ...params,
     dataset: 'annual',
     datasetType: 'summary',
+    version: 'v20251209',
   });
 
   if (!requestUrl) return new Promise(() => {});
@@ -1377,6 +1380,7 @@ export const getGain = (params) => {
     ...params,
     dataset: 'annual',
     datasetType: 'summary',
+    version: PINNED_GAIN_VERSION,
   });
 
   if (!requestUrl) {
@@ -1440,6 +1444,7 @@ export const getGainGrouped = (params) => {
     dataset: 'annual',
     datasetType: 'summary',
     grouped: true,
+    version: PINNED_GAIN_VERSION,
   });
 
   if (!requestUrl) {


### PR DESCRIPTION
Gain doesn't change in annual updates, so I had removed it from geotrellis to slim it down for this last year of running it. But it is required generally for the dashboard. Pinning the version here similar to tropical tree cover if that's ok, so we can just re-use the table that already has it.