### PR TITLE
PZB-905: fix Multiple Protected Area Analytics Issues on Flagship Map

### DIFF
--- a/components/widgets/forest-change/tree-loss-drivers/index.js
+++ b/components/widgets/forest-change/tree-loss-drivers/index.js
@@ -75,6 +75,8 @@ export default {
       '<b>Globally</b> from {startYear} to {endYear}, {lossPercentage} of tree cover loss occurred in areas where the dominant drivers of loss resulted in deforestation.',
     initial:
       'In {location} from {startYear} to {endYear}, {lossPercentage} of tree cover loss occurred in areas where the dominant drivers of loss resulted in deforestation.',
+    noLoss:
+      'In {location} from {startYear} to {endYear}, <b>no</b> tree cover loss occurred in areas where the dominant drivers of loss resulted in deforestation.',
   },
   whitelists: {
     checkStatus: true,

--- a/components/widgets/forest-change/tree-loss-drivers/selectors.js
+++ b/components/widgets/forest-change/tree-loss-drivers/selectors.js
@@ -33,7 +33,6 @@ export const getPermanentCategories = createSelector(
 export const getFilteredData = createSelector(
   [getData, getSortedCategories],
   (data, sortedCategories) => {
-    console.log('tree-loss-drivers', data);
     return data && data.length
       ? sortedCategories
           .map(({ value }) => data.find((item) => item.driver_type === value))
@@ -88,9 +87,8 @@ export const parseSentence = createSelector(
   [getFilteredData, getSentences, getSettings, getLocationLabel],
   (filteredData, sentences, settings, location) => {
     if (!filteredData) return null;
-    const { globalInitial, initial } = sentences;
+    const { globalInitial, initial, noLoss } = sentences;
     const { startYear, endYear } = settings;
-    const sentence = location === 'global' ? globalInitial : initial;
 
     const totalLoss = filteredData.reduce(
       (acc, { loss_area_ha, driver_type }) => {
@@ -114,12 +112,17 @@ export const parseSentence = createSelector(
       0
     );
 
+    let sentence = location === 'global' ? globalInitial : initial;
+    if (totalLoss === 0 && noLoss) {
+      sentence = noLoss;
+    }
+
     const params = {
       location,
       startYear,
       endYear,
       lossPercentage: formatNumber({
-        num: (permanentLoss * 100) / totalLoss,
+        num: totalLoss > 0 ? (permanentLoss * 100) / totalLoss : 0,
         unit: '%',
       }),
     };

--- a/components/widgets/selectors.js
+++ b/components/widgets/selectors.js
@@ -3,6 +3,7 @@ import sortBy from 'lodash/sortBy';
 import intersection from 'lodash/intersection';
 import compact from 'lodash/compact';
 import isEmpty from 'lodash/isEmpty';
+import omit from 'lodash/omit';
 import lowerCase from 'lodash/lowerCase';
 import flatMap from 'lodash/flatMap';
 import moment from 'moment';
@@ -493,16 +494,28 @@ export const getWidgets = createSelector(
       const widgetQuerySettings = widgetSettings && widgetSettings[widget];
       const widgetInteraction = interactions && interactions[widget];
 
-      const layerSettings = {
-        ...layerParams,
-        ...decodeParams,
-        ...(startYear && {
-          startYear,
-        }),
-        ...(endYear && {
-          endYear,
-        }),
-      };
+      // Widgets that define their own startYear/endYear defaults manage their
+      // own year range via a settings control; the active map layer's
+      // timeline shouldn't silently override that (see TCL graphs starting
+      // in 2002 instead of 2001 when the loss layer's timeline was trimmed).
+      // Note: layerParams/decodeParams may already carry their own computed
+      // startYear/endYear (see getActiveLayersWithDates), so those need to
+      // be stripped too, not just the locally recomputed startYear/endYear.
+      const widgetHasOwnYearRange = defaultSettings?.startYear !== undefined;
+
+      const layerSettings = omit(
+        {
+          ...layerParams,
+          ...decodeParams,
+          ...(startYear && {
+            startYear,
+          }),
+          ...(endYear && {
+            endYear,
+          }),
+        },
+        widgetHasOwnYearRange ? ['startYear', 'endYear'] : []
+      );
 
       const mergedSettings = {
         ...defaultSettings,

--- a/services/analysis-cached.js
+++ b/services/analysis-cached.js
@@ -791,18 +791,31 @@ export const getTreeCoverOTF = async (params) => {
 };
 
 export const getTreeCoverGainOTF = async (params) => {
-  const { adm0, geostore } = params || {};
+  const { adm0, geostore, threshold } = params || {};
   const geostoreId = geostore.id || adm0;
-  const urlBase = '/dataset/umd_tree_cover_gain/latest/query';
-  const sql = `?sql=${SQL_QUERIES.treeCoverGainSimpleOTF}`;
 
-  const url = encodeURI(`${urlBase + sql}`.replace('{geostoreId}', geostoreId));
+  const urlBaseGain = '/dataset/umd_tree_cover_gain/latest/query';
+  const urlBaseExtent = '/dataset/umd_tree_cover_density_2000/latest/query';
+  const sqlGain = `?sql=${SQL_QUERIES.treeCoverGainSimpleOTF}`;
+  const sqlExtent = `?sql=${SQL_QUERIES.treeCoverOTF}`;
 
-  const response = await dataRequest.get(url);
+  const urlGain = encodeURI(
+    `${urlBaseGain + sqlGain}`.replace('{geostoreId}', geostoreId)
+  );
+  const urlExtent = encodeURI(
+    `${urlBaseExtent + sqlExtent}`
+      .replace('{threshold}', threshold)
+      .replace('{geostoreId}', geostoreId)
+  );
+
+  const [gainResponse, extentResponse] = await Promise.all([
+    dataRequest.get(urlGain),
+    dataRequest.get(urlExtent),
+  ]);
 
   return {
-    gain: response.data[0]?.area__ha,
-    extent: params?.geostore?.areaHa || 0,
+    gain: gainResponse.data[0]?.area__ha || 0,
+    extent: extentResponse.data[0]?.area__ha || 0,
   };
 };
 


### PR DESCRIPTION
## Overview

3 fixes for map:
1- TCL Graph Starting in 2002 Instead of 2001 TCL graphs for PA analytics start in 2002 rather than 2001.
2- Tree Cover Gain Showing 0.0% TC gain appears incorrect for PA analytics, even if TC in the 20-year dataset was 100%, the gain should still show more than 0.0% when looking at the other stats.
3- TCL by Dominant Driver Not Working TCL by dominant driver does not appear to be working for PA analytics.

## Demo

<img width="279" height="460" alt="Screenshot 2026-07-10 at 20 14 13" src="https://github.com/user-attachments/assets/f14ed1a3-c449-4d70-8cb4-55d4298eb32e" />

__________


<img width="268" height="450" alt="Screenshot 2026-07-10 at 20 15 15" src="https://github.com/user-attachments/assets/479349a0-a112-4cf8-85b6-e2cac2c3a5a1" />


__________


<img width="268" height="202" alt="Screenshot 2026-07-10 at 20 16 08" src="https://github.com/user-attachments/assets/c5f95d49-d7dd-4cfe-bc6f-09a4646b0fbb" />
