### PR TITLE
PZB-1113: Use browser origin for register and reset instead of hardcoded origin

### DIFF
--- a/services/__tests__/user.spec.js
+++ b/services/__tests__/user.spec.js
@@ -1,0 +1,47 @@
+import { register, resetPassword } from 'services/user';
+import { apiRequest } from 'utils/request';
+
+jest.mock('utils/request', () => ({
+  apiRequest: {
+    post: jest.fn(() => Promise.resolve({ status: 200, data: {} })),
+  },
+  apiAuthRequest: { defaults: { headers: {} } },
+}));
+
+describe('user service', () => {
+  const originalLocation = window.location;
+
+  const setHost = (origin) => {
+    delete window.location;
+    window.location = { origin, host: origin.replace(/^https?:\/\//, '') };
+  };
+
+  afterEach(() => {
+    window.location = originalLocation;
+    jest.clearAllMocks();
+  });
+
+  describe('register user', () => {
+    it('uses the current browser origin for callbackUrl', () => {
+      setHost('https://www.globalnaturewatch.org');
+      register({ email: 'user@example.com' });
+
+      const url = apiRequest.post.mock.calls[0][0];
+      expect(url).toContain(
+        'callbackUrl=https://www.globalnaturewatch.org/my-gfw/'
+      );
+    });
+  });
+
+  describe('reset user password', () => {
+    it('uses the current browser origin for callbackUrl', () => {
+      setHost('https://staging.globalforestwatch.org');
+      resetPassword({ email: 'user@example.com' });
+
+      const url = apiRequest.post.mock.calls[0][0];
+      expect(url).toContain(
+        'callbackUrl=https://staging.globalforestwatch.org/my-gfw/'
+      );
+    });
+  });
+});

--- a/services/__tests__/user.spec.js
+++ b/services/__tests__/user.spec.js
@@ -28,7 +28,21 @@ describe('user service', () => {
 
       const url = apiRequest.post.mock.calls[0][0];
       expect(url).toContain(
-        'callbackUrl=https://www.globalnaturewatch.org/my-gfw/'
+        `callbackUrl=${encodeURIComponent(
+          'https://www.globalnaturewatch.org/my-gfw/'
+        )}`
+      );
+    });
+
+    it('URL-encodes the callbackUrl so IPv6 loopback origins survive the query string', () => {
+      setHost('http://[::1]:3000');
+      register({ email: 'user@example.com' });
+
+      const url = apiRequest.post.mock.calls[0][0];
+
+      expect(url).not.toMatch(/[[\]]/);
+      expect(url).toContain(
+        `callbackUrl=${encodeURIComponent('http://[::1]:3000/my-gfw/')}`
       );
     });
   });
@@ -40,7 +54,9 @@ describe('user service', () => {
 
       const url = apiRequest.post.mock.calls[0][0];
       expect(url).toContain(
-        'callbackUrl=https://staging.globalforestwatch.org/my-gfw/'
+        `callbackUrl=${encodeURIComponent(
+          'https://staging.globalforestwatch.org/my-gfw/'
+        )}`
       );
     });
   });

--- a/services/user.js
+++ b/services/user.js
@@ -2,7 +2,8 @@ import { apiRequest, apiAuthRequest } from 'utils/request';
 
 const isServer = typeof window === 'undefined';
 
-const getCallbackUrl = () => `${window.location.origin}/my-gfw/`;
+const getCallbackUrl = () =>
+  encodeURIComponent(`${window.location.origin}/my-gfw/`);
 
 export function setServerCookie(token) {
   fetch('/api/set-cookie', { method: 'POST', body: JSON.stringify({ token }) });

--- a/services/user.js
+++ b/services/user.js
@@ -2,7 +2,7 @@ import { apiRequest, apiAuthRequest } from 'utils/request';
 
 const isServer = typeof window === 'undefined';
 
-const CALLBACK_URL = 'https://www.globalforestwatch.org/my-gfw/';
+const getCallbackUrl = () => `${window.location.origin}/my-gfw/`;
 
 export function setServerCookie(token) {
   fetch('/api/set-cookie', { method: 'POST', body: JSON.stringify({ token }) });
@@ -48,13 +48,16 @@ export const login = (formData) =>
   });
 
 export const register = (formData) =>
-  apiRequest.post(`/auth/sign-up?callbackUrl=${CALLBACK_URL}`, {
+  apiRequest.post(`/auth/sign-up?callbackUrl=${getCallbackUrl()}`, {
     ...formData,
     apps: ['gfw'],
   });
 
 export const resetPassword = (formData) =>
-  apiRequest.post(`/auth/reset-password?callbackUrl=${CALLBACK_URL}`, formData);
+  apiRequest.post(
+    `/auth/reset-password?callbackUrl=${getCallbackUrl()}`,
+    formData
+  );
 
 export const createProfile = (id, data) =>
   apiAuthRequest({


### PR DESCRIPTION
## Summary

Replaces the hardcoded `CALLBACK_URL` in `services/user.js` with a value derived from `window.location.origin` at call time. The `callbackUrl` we send to the authorization microservice on sign-up and password-reset is now whichever host the user's browser is actually on.

## Why

We're cutting over from `globalforestwatch.org` to `globalnaturewatch.org` next week. The old constant —

```js
const CALLBACK_URL = 'https://www.globalforestwatch.org/my-gfw/';
```

— pinned the value we hand to the auth service on every request. Since that value is **persisted onto the Okta user's profile as the `origin` attribute** (see below), every new account created and every password reset issued would keep steering users back to the legacy domain regardless of where they actually signed up.

**With this change, we can deploy to production *today* and the DNS cutover becomes a no-op for auth flows.** No coordinated release, no follow-up hotfix, no window where new accounts silently break. When DNS flips, `window.location.origin` flips with it, the value stored on the Okta user profile flips with it, and the post-email redirect resolves to whichever host the user started from — production, staging, preview builds, and the new `globalnaturewatch.org` domain alike.

## What changed

- `services/user.js`: `CALLBACK_URL` constant → `getCallbackUrl()` helper returning `` `${window.location.origin}/my-gfw/` ``.
- Applied in both `register` and `resetPassword`.
- `services/__tests__/user.spec.js`: new spec verifying both endpoints emit a `callbackUrl` matching the current browser origin.

## How the callback actually flows

Verified against [`resource-watch/authorization`](https://github.com/resource-watch/authorization/blob/9b25f3786bbe2f4f1c6a6dcb88256fa83274fe74/src/providers/okta.provider.ts) — specifically `setCallbackUrl` middleware (`auth.router.ts`), and `signUp` / `sendResetMail` in `okta.provider.ts`.

The `callbackUrl` we send is **not** embedded directly into the confirmation/reset email. Instead the auth service stores it as the `origin` custom attribute on the Okta user profile, and later reads it back to redirect the browser after the user clicks the email link.

```mermaid
sequenceDiagram
    autonumber
    actor U as User
    participant B as Browser<br/>(GFW client JS)
    participant GFW as GFW Server<br/>(Next.js /api/gfw proxy)
    participant AUTH as authorization svc<br/>(api.resourcewatch.org)
    participant Okta as Okta
    participant Mail as Email inbox

    U->>B: Submits register / reset form on https://HOST
    Note over B: getCallbackUrl() runs here — window.location.origin<br/>is a browser API, only defined in the browser
    B->>GFW: POST /api/gfw/auth/sign-up?callbackUrl=https://HOST/my-gfw/
    Note over GFW: pages/api/gfw/[...params].js<br/>next-http-proxy-middleware forwards to GFW_API
    GFW->>AUTH: POST /auth/sign-up?callbackUrl=https://HOST/my-gfw/
    Note over AUTH: setCallbackUrl middleware<br/>stashes value in ctx.session.callbackUrl
    AUTH->>Okta: createUser / updateUserProtectedFields<br/>{ origin: "https://HOST/my-gfw/" }
    Okta->>Mail: Send Okta-templated activation / recovery email<br/>(link points at Okta → auth svc, NOT at HOST directly)
    U->>Mail: Opens email, clicks link
    Mail->>AUTH: GET /auth/sign-up-redirect?email=…<br/>(or Okta recovery landing)
    AUTH->>Okta: getOktaUserByEmail(email)
    Okta-->>AUTH: user.profile.origin = "https://HOST/my-gfw/"
    AUTH-->>B: 302 redirect → https://HOST/my-gfw/?token=…
    B-->>U: Lands on /my-gfw/ on the same HOST they started from, signed in
```

Two consequences worth noting:

- **`sendResetMail` refreshes the stored `origin`** every time a reset is requested (`okta.provider.ts` line 849). So even users who registered on the legacy domain will get their `origin` updated the next time they hit "forgot password" from the new domain.
- **Accounts registered but not yet confirmed at cutover** still carry the pre-cutover `origin`. If we want zero fallout there we can trigger a resend from the new host, or leave a temporary redirect on the legacy hostname for `/my-gfw/*`.

## Safety

- `register` / `resetPassword` are only invoked from the `LoginForm` submit handler (`components/forms/login/actions.js`), which runs client-side after mount — `window` is always defined at call time.
- `login` itself does not use `callbackUrl` and is untouched.

## Test plan

### Automated

- ✅ `jest services/__tests__/user.spec.js` — 2/2 passing (register + resetPassword each assert callbackUrl matches `window.location.origin`).
- ✅ `eslint services/user.js services/__tests__/user.spec.js` — clean.

### Manual — sign-up (per environment: localhost, then the Heroku review app for this PR)

1. Open an **incognito / private** window (no cached session, no autofill, no lingering `ctx.session.callbackUrl`).
2. Navigate to the host under test — start with `http://localhost:3000`, then repeat against this PR's Heroku review app URL (e.g. `https://gfw-pr-<N>.herokuapp.com`).
3. Open DevTools → **Network** tab, filter for `sign-up`.
4. Register with a fresh **yopmail** address, e.g. `gfw-pr-verify-<timestamp>@yopmail.com`.
5. In the captured `POST` to `/api/gfw/auth/sign-up` (our Next.js proxy at `pages/api/gfw/[...params].js`, which forwards to `api.resourcewatch.org/auth/sign-up`), confirm the query string contains the host you're on — e.g. `callbackUrl=http://localhost:3000/my-gfw/` on localhost and `callbackUrl=https://gfw-pr-<N>.herokuapp.com/my-gfw/` on the review app — i.e. the host matches the URL bar, **not** a hardcoded value.
6. Open `https://yopmail.com/`, enter the inbox name, open the activation email.
7. Click the link. (Do **not** rely on hovering — the visible href points at Okta/the auth service and does the origin lookup server-side; only the final landing URL reveals the stored `origin`.)
8. Confirm the browser ends up on `/my-gfw/` on the **same host** you registered from and the account is activated.

### Manual — password reset

1. New incognito window, same host as above.
2. Trigger "Forgot password" for the yopmail address created above.
3. Repeat steps 5–8 with `reset-password` instead of `sign-up`.

### Cross-host verification (proves the dynamic behavior)

Register once from `http://localhost:3000` with one yopmail address, then register again from this PR's Heroku review app (`https://gfw-pr-<N>.herokuapp.com`) with a *different* yopmail address. Confirm both:

- the outgoing `callbackUrl` query param reflects the host of that run (localhost vs. the review app), and
- the final post-email landing URL is on that same host,

with **no code change** between the two runs.

### Okta admin console — verify the `origin` attribute plumbing

Because the callback is persisted on the Okta user profile, the piece to verify in Okta is the custom profile attribute and the resulting stored value — not a redirect allow-list.

1. Log in to the Okta admin console for the WRI tenant.
2. **Directory → Profile Editor → User (default)** → confirm a custom string attribute named `origin` exists and is writable by the API. This is what `OktaService.createUserWithoutPassword` / `updateUserProtectedFields` targets.
3. **Directory → People** → search for the yopmail account you just registered → **Profile** tab → confirm `origin` is set to the exact `https://HOST/my-gfw/` you registered from (scheme + host + path, no extra slashes).
4. Trigger the reset flow from a *different* host for the same user and re-check the profile — `origin` should now reflect the new host, proving `sendResetMail`'s update path.
5. **Customizations → Brands → World Resources Institute → Emails → User Activation** (and the corresponding Password Reset template) → confirm the templates route back through the authorization service's sign-up-redirect / recovery endpoints (not hard-coded to a specific frontend host) — this is what allows the stored `origin` to drive the final destination.
