### PR TITLE
Switch domain from globalforestwatch.org to globalnaturewatch.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@next/bundle-analyzer": "^10.0.1",
     "@reduxjs/toolkit": "^1.4.0",
     "@wordpress/api-fetch": "^3.19.1",
-    "@worldresources/gfw-components": "3.5.20",
+    "@worldresources/gfw-components": "^3.5.22",
     "aws-sdk": "^2.291.0",
     "axios": "1.6.7",
     "chroma-js": "^2.1.0",

--- a/utils/domain.js
+++ b/utils/domain.js
@@ -2,6 +2,6 @@
 // Node script during `postbuild` (Node 18, no webpack/babel), so it can't
 // load an ES module. Once globalnaturewatch.org is serving the app, this is
 // the only line that needs to change.
-const GFW_DOMAIN = 'https://www.globalforestwatch.org';
+const GFW_DOMAIN = 'https://www.globalnaturewatch.org';
 
 module.exports = { GFW_DOMAIN };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4173,10 +4173,10 @@
     lodash "^4.17.19"
     react-native-url-polyfill "^1.1.2"
 
-"@worldresources/gfw-components@3.5.20":
-  version "3.5.20"
-  resolved "https://registry.yarnpkg.com/@worldresources/gfw-components/-/gfw-components-3.5.20.tgz#2a8adb802a94e0d1c6267dde810010dee28f656f"
-  integrity sha512-UmtKuY+B6hijHNEexS59dbrxTA18c25ULNW3ohGokf5oO5TSQylxDb37FJ7Vj/MzQiz+pgEfqFDGFzJxdOOTmw==
+"@worldresources/gfw-components@^3.5.22":
+  version "3.5.22"
+  resolved "https://registry.yarnpkg.com/@worldresources/gfw-components/-/gfw-components-3.5.22.tgz#efbe1f9643cf69b952016144f085207374fe38b0"
+  integrity sha512-2Tx8OUaBmhlAbbQEyhpavtGuKXOGAo/Qxf9qhI1rd7DJxwMeuTMH+Srd0QADgnaIK9uXqwUSzpGm0Lk6dMfavw==
   dependencies:
     "@artsy/fresnel" "^1.1.0"
     "@tippyjs/react" "^4.0.2"


### PR DESCRIPTION
globalforestwatch.org -> globalnaturewatch.org for root domain
upgrade wri/gfw-components to 3.5.22

Expected to break staging until the redirect is in place