### PR TITLE
[PZB-1179] Replace Flagship "Contact Us" Form with Zendesk Form Link

### DIFF
--- a/layouts/about/contact/component.jsx
+++ b/layouts/about/contact/component.jsx
@@ -1,13 +1,20 @@
-import { Row, Column, ContactUsForm } from '@worldresources/gfw-components';
+import { Row, Column } from '@worldresources/gfw-components';
 
 const AboutContactSection = () => (
   <div className="l-section-contact">
     <Row>
-      <Column width={[1, 1 / 2]} className="desc">
+      <Column width={[1, 3 / 4]} className="desc">
         <h3>Contact us</h3>
         <p className="intro">
           Question, comment, request, feedback? We want to hear from you! Get in
-          touch by completing the form on the right.
+          touch by completing the form at&nbsp;
+          <a
+            href="https://globalnaturewatch.zendesk.com/hc/en-us/requests/new"
+            target="_blank"
+            rel="noreferrer"
+          >
+            https://globalnaturewatch.zendesk.com/hc/en-us/requests/new
+          </a>
         </p>
         <p>Global Nature Watch, 10 G Street NE Suite 800</p>
         <p>Washington, DC 20002, USA</p>
@@ -26,9 +33,6 @@ const AboutContactSection = () => (
         >
           Explore jobs
         </a>
-      </Column>
-      <Column width={[1, 1 / 2]}>
-        <ContactUsForm />
       </Column>
     </Row>
   </div>

--- a/layouts/about/join/component.jsx
+++ b/layouts/about/join/component.jsx
@@ -1,5 +1,3 @@
-import { Link as AnchorLink } from 'react-scroll';
-
 import { Row, Column, Button } from '@worldresources/gfw-components';
 
 const AboutJoinSection = () => (
@@ -9,11 +7,15 @@ const AboutJoinSection = () => (
         <h4>
           <i>We welcome others to join the growing GNW partnership.</i>
         </h4>
-        <AnchorLink to="contact" spy smooth duration={500}>
+        <a
+          href="https://globalnaturewatch.zendesk.com/hc/en-us/requests/new"
+          target="_blank"
+          rel="noreferrer"
+        >
           <Button light className="anchor">
             EMAIL US
           </Button>
-        </AnchorLink>
+        </a>
       </Column>
     </Row>
   </section>


### PR DESCRIPTION
## Overview

The current Contact Us form on Flagship should be removed and replaced with a direct link to the new Zendesk form across all pages. This will allow non-developers (e.g. Jessica Immelman) to manage and edit the form directly without requiring front-end changes.

New form URL: https://globalnaturewatch.zendesk.com/hc/en-us/requests/new

Pages to update:

- https://www.globalforestwatch.org/ — footer
- https://www.globalforestwatch.org/dashboards/global/ — footer
- https://www.globalforestwatch.org/help/ — 2 places: footer and under the help tab
- https://www.globalforestwatch.org/about/ — 3 places: footer, "Email Us", and "Contact Us" below the About paragraph
- https://www.globalforestwatch.org/topics/biodiversity/#footer — footer
- https://www.globalforestwatch.org/blog/ — footer
- https://www.globalforestwatch.org/search/ — footer
- https://www.globalforestwatch.org/my-gfw/ — footer

### Acceptance Criteria

Remove the existing embedded Contact Us form from Flagship
Replace all Contact Us instances across the pages listed above with a link to the new Zendesk form



